### PR TITLE
add codeowners file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,5 @@
+# This file implements GitHub's [codeowners](https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners) features
+
+* @mwjohnson56
+* @Bharat-Ramadas
+* @elsevers


### PR DESCRIPTION
Add a `codeowners` file that declares Martin and Bharat as the "owners" of the develop branch. After this PR is merged, we will configure the repository so that to merge any PR into develop will require the approval of one of the "owners" listed in the `codeowners` file. 

We currently do this for both the eMach and the AMDC repos.
