### PR TITLE
Fix import issue with mach_eval module

### DIFF
--- a/mach_eval/mach_eval.py
+++ b/mach_eval/mach_eval.py
@@ -6,10 +6,17 @@ manner suitable for both machine optimization and evaluation.
 
 from typing import Protocol, runtime_checkable, Any, List
 from abc import abstractmethod, ABC
-import sys
-sys.path.append("..")
-import mach_opt as mo
 from copy import deepcopy
+import os
+import sys
+
+# change current working directory to file location
+os.chdir(os.path.dirname(__file__))
+# add the directory immediately above this file's directory to path for module import
+sys.path.append("../..")
+sys.path.append("..")
+
+import mach_opt as mo
 
 __all__ = [
     "MachineDesign",


### PR DESCRIPTION
This PR resolves #114 by changing the current working directory in the `mach_eval `module to the folder within which it resides to facilitate relative imports agnostic of the location of executing script. Scripts run from within `eMach `and from outside using private scripts should now be functional.