### PR TITLE
Add mock imports and specify python ver for RTD

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,8 @@
+# Required
+version: 2
+
+# Set the version of Python and other tools you might need
+build:
+  os: ubuntu-20.04
+  tools:
+    python: "3.8"

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -17,9 +17,6 @@ import sys
 
 sys.path.insert(0, os.path.abspath("..\.."))
 
-# import packages for which autodocs need to be created
-import mach_eval
-import mach_opt
 
 # -- Project information -----------------------------------------------------
 
@@ -43,6 +40,9 @@ release = "0.0.1"
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = ["sphinx.ext.autodoc", "sphinx.ext.githubpages", "sphinx.ext.intersphinx"]
+
+# Add mock packages for non-standard or C based python packages used in modules
+autodoc_mock_imports  = ["pygmo", "numpy", "pandas", "pickle"]
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]


### PR DESCRIPTION
The issue with Python doc autogen not working on ReadTheDocs seems to be caused due to 2 causes:

1. `ReadTheDocs` uses Python3.7 by default. This causes usage of `Protocol` in modules to result in build failure. The newly added .yaml file will address this issue
2.  Need to support other packages such as `pygmo`, `numpy` etc. that the modules depend on. If the modules have an underlying dependency on C code, this can be done only by creating `mock` modules. This is done with the `autodoc_mock_imports` entry within the `conf.py` file

With both these changes, autodoc feature should be functional on the `eMach` `RTD` platform.
