### PR TITLE
Change plane wall resistance to take in only one length value

### DIFF
--- a/docs/source/general_analyzers/Images/ExampleTempDist.svg
+++ b/docs/source/general_analyzers/Images/ExampleTempDist.svg
@@ -7,7 +7,7 @@
   <rdf:RDF xmlns:cc="http://creativecommons.org/ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
     <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-    <dc:date>2022-05-30T17:37:20.046354</dc:date>
+    <dc:date>2022-06-07T12:45:13.296413</dc:date>
     <dc:format>image/svg+xml</dc:format>
     <dc:creator>
      <cc:Agent>
@@ -50,29 +50,29 @@ C -6.326016 -3.673985 -7.071068 -1.875269 -7.071068 0
 C -7.071068 1.875269 -6.326016 3.673985 -5 5 
 C -3.673985 6.326016 -1.875269 7.071068 0 7.071068 
 z
-" id="C0_0_2493ecd527"/>
+" id="C0_0_6993ebf6db"/>
     </defs>
-    <g clip-path="url(#p0815875453)">
-     <use style="fill:#440154;stroke:#440154;" x="309.665455" xlink:href="#C0_0_2493ecd527" y="143.28"/>
+    <g clip-path="url(#p69b2ffbe32)">
+     <use style="fill:#440154;stroke:#440154;" x="309.665455" xlink:href="#C0_0_6993ebf6db" y="143.28"/>
     </g>
-    <g clip-path="url(#p0815875453)">
-     <use style="fill:#81d34d;stroke:#81d34d;" x="66.174545" xlink:href="#C0_0_2493ecd527" y="143.28"/>
+    <g clip-path="url(#p69b2ffbe32)">
+     <use style="fill:#fde725;stroke:#fde725;" x="66.174545" xlink:href="#C0_0_6993ebf6db" y="143.28"/>
     </g>
-    <g clip-path="url(#p0815875453)">
-     <use style="fill:#f4e61e;stroke:#f4e61e;" x="167.629091" xlink:href="#C0_0_2493ecd527" y="143.28"/>
+    <g clip-path="url(#p69b2ffbe32)">
+     <use style="fill:#bade28;stroke:#bade28;" x="167.629091" xlink:href="#C0_0_6993ebf6db" y="143.28"/>
     </g>
-    <g clip-path="url(#p0815875453)">
-     <use style="fill:#fde725;stroke:#fde725;" x="218.356364" xlink:href="#C0_0_2493ecd527" y="93.861818"/>
+    <g clip-path="url(#p69b2ffbe32)">
+     <use style="fill:#b5de2b;stroke:#b5de2b;" x="218.356364" xlink:href="#C0_0_6993ebf6db" y="93.861818"/>
     </g>
-    <g clip-path="url(#p0815875453)">
-     <use style="fill:#3d4d8a;stroke:#3d4d8a;" x="218.356364" xlink:href="#C0_0_2493ecd527" y="192.698182"/>
+    <g clip-path="url(#p69b2ffbe32)">
+     <use style="fill:#404688;stroke:#404688;" x="218.356364" xlink:href="#C0_0_6993ebf6db" y="192.698182"/>
     </g>
-    <g clip-path="url(#p0815875453)">
-     <use style="fill:#fde725;stroke:#fde725;" x="218.356364" xlink:href="#C0_0_2493ecd527" y="143.28"/>
+    <g clip-path="url(#p69b2ffbe32)">
+     <use style="fill:#b5de2b;stroke:#b5de2b;" x="218.356364" xlink:href="#C0_0_6993ebf6db" y="143.28"/>
     </g>
    </g>
    <g id="patch_3">
-    <path clip-path="url(#p0815875453)" d="M 66.174545 242.116364 
+    <path clip-path="url(#p69b2ffbe32)" d="M 66.174545 242.116364 
 L 269.083636 242.116364 
 L 269.083636 44.443636 
 L 66.174545 44.443636 
@@ -80,7 +80,7 @@ z
 " style="fill:none;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_4">
-    <path clip-path="url(#p0815875453)" d="M 167.629091 143.28 
+    <path clip-path="url(#p69b2ffbe32)" d="M 167.629091 143.28 
 L 269.083636 143.28 
 L 269.083636 44.443636 
 L 167.629091 44.443636 
@@ -88,7 +88,7 @@ z
 " style="fill:none;stroke:#000000;stroke-linejoin:miter;"/>
    </g>
    <g id="patch_5">
-    <path clip-path="url(#p0815875453)" d="M 167.629091 242.116364 
+    <path clip-path="url(#p69b2ffbe32)" d="M 167.629091 242.116364 
 L 269.083636 242.116364 
 L 269.083636 143.28 
 L 167.629091 143.28 
@@ -98,37 +98,37 @@ z
    <g id="matplotlib.axis_1"/>
    <g id="matplotlib.axis_2"/>
    <g id="line2d_1">
-    <path clip-path="url(#p0815875453)" d="M 66.174545 143.28 
+    <path clip-path="url(#p69b2ffbe32)" d="M 66.174545 143.28 
 L 167.629091 143.28 
 " style="fill:none;stroke:#ff0000;stroke-dasharray:5.55,2.4;stroke-dashoffset:0;stroke-width:1.5;"/>
    </g>
    <g id="line2d_2">
-    <path clip-path="url(#p0815875453)" d="M 167.629091 143.28 
+    <path clip-path="url(#p69b2ffbe32)" d="M 167.629091 143.28 
 L 218.356364 93.861818 
 " style="fill:none;stroke:#ff0000;stroke-dasharray:5.55,2.4;stroke-dashoffset:0;stroke-width:1.5;"/>
    </g>
    <g id="line2d_3">
-    <path clip-path="url(#p0815875453)" d="M 167.629091 143.28 
+    <path clip-path="url(#p69b2ffbe32)" d="M 167.629091 143.28 
 L 218.356364 192.698182 
 " style="fill:none;stroke:#ff0000;stroke-dasharray:5.55,2.4;stroke-dashoffset:0;stroke-width:1.5;"/>
    </g>
    <g id="line2d_4">
-    <path clip-path="url(#p0815875453)" d="M 218.356364 93.861818 
+    <path clip-path="url(#p69b2ffbe32)" d="M 218.356364 93.861818 
 L 218.356364 143.28 
 " style="fill:none;stroke:#ff0000;stroke-dasharray:5.55,2.4;stroke-dashoffset:0;stroke-width:1.5;"/>
    </g>
    <g id="line2d_5">
-    <path clip-path="url(#p0815875453)" d="M 218.356364 192.698182 
+    <path clip-path="url(#p69b2ffbe32)" d="M 218.356364 192.698182 
 L 218.356364 143.28 
 " style="fill:none;stroke:#ff0000;stroke-dasharray:5.55,2.4;stroke-dashoffset:0;stroke-width:1.5;"/>
    </g>
    <g id="line2d_6">
-    <path clip-path="url(#p0815875453)" d="M 218.356364 93.861818 
+    <path clip-path="url(#p69b2ffbe32)" d="M 218.356364 93.861818 
 L 309.665455 143.28 
 " style="fill:none;stroke:#ff0000;stroke-dasharray:5.55,2.4;stroke-dashoffset:0;stroke-width:1.5;"/>
    </g>
    <g id="line2d_7">
-    <path clip-path="url(#p0815875453)" d="M 218.356364 192.698182 
+    <path clip-path="url(#p69b2ffbe32)" d="M 218.356364 192.698182 
 L 309.665455 143.28 
 " style="fill:none;stroke:#ff0000;stroke-dasharray:5.55,2.4;stroke-dashoffset:0;stroke-width:1.5;"/>
    </g>
@@ -155,7 +155,7 @@ L 321.84 34.56
   </g>
   <g id="axes_2">
    <g id="patch_10">
-    <path clip-path="url(#p30d5836d5f)" d="M 338.58 252 
+    <path clip-path="url(#p81ec9fdf97)" d="M 338.58 252 
 L 338.58 251.150625 
 L 338.58 35.409375 
 L 338.58 34.56 
@@ -166,8 +166,8 @@ L 349.452 252
 z
 " style="fill:#ffffff;stroke:#ffffff;stroke-linejoin:miter;stroke-width:0.01;"/>
    </g>
-   <image height="217" id="imageba2d57212b" transform="scale(1 -1)translate(0 -217)" width="10" x="339" xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAAAoAAADZCAYAAAAZmKE8AAABUklEQVR4nO2ayQ0CUQxDs30qowb6LwQYWniRHEUjwdmyYzth92e8LgOP8nCCszIPBtQzWmJpyuh0xgFGCPRMtfSma8rIt0e+ZnrpPdcXnxHhJlxvzohzzL1mGK4jTXO8Bq6QSsuXAjPieBpdY0YKpM3wrvVrJneNGRuLixkhUG9m4K73mtEHrn8iHTjXAddy6T0znJHhRprZc/1fXA3wDjdzj3Nld3iPeNZcQ+FehXBGfeANoHpGvWv4lmLCjD5Hl884wEgrxNK4wsV4Ql4hdq2XDlrhgLStxZPxpdLqeBqu1dJFXevNcEa9mYEZ13Ks+DBgDlSodp2brvVmIOOhZnAzyZuBQNwMZjxOK9xrhudI4zn+ptJqM42u5RXKpfWngDecVyh/neGLK5d+8DVDuM6MjNAK/rhndeBngEr6pXRgRgrkjHTGMvgXhKS/sQf88uMHTLaBaOo9r8QAAAAASUVORK5CYII=" y="-35"/>
+   <image height="217.44" id="imageb0b2b6f175" transform="scale(1 -1)translate(0 -217.44)" width="10.8" x="338.64" xlink:href="data:image/png;base64,
+iVBORw0KGgoAAAANSUhEUgAAAC0AAAOKCAYAAAAP69lRAAAFVUlEQVR4nO3c243cQBAEQT7GNJkg/03Ryoa7j1gUkGFBYjHoHpI63X/uv59rzPPtgN+YjD7Xvde9V3wV7Zz7ub/d8GOTv/RkdCNPKVpp5CmT0Y08pWjlXI08YzL6XHfHgyhaOfez171XfI1GN/KUopVzNfKMyehGnlK00oOtUrRy7l5AGpPRjTylaKWrqTIZ3fFQilZ6WaNMRjfylKKVzrQyGd3xUIpWelmjTEY38pSilf79tDIZ3UZUilZa40rRSmdamYzueChFK11NlcnoRp5StHI+nWljMvosZg8mF+20xpXJ6I6HUrTSmVYmo3sIUIpWenJRJqPbiErRSmdaKVrpaqpMRnfLU4pWWuPKZHQbUSlaOdfekd78pSej24hK0cr5DGYPJo9GN/KUopXz2TvSm7/0ZHQjTyla6cFWmYzuXZ5StNInOaVopTmtTEZ3y1OKVnpZo0xG97JGKVpp5CmT0d3ylKKV/scrZTK6jagUrbTGlcnoRp5StNLLGmUyupGnFK10y1OKVprTymR0tzylaKWRp0xGd8tTilb6w2BlMrqRpxStdMtTJqN7sFWKVhp5ymR0tzylaKWRp0xGN/KUopVGnlK00pxWJqMbeUrRSiNPmYzufwdSilYaecpkdLc8pWilkadMRnc8lKKV1rgyGd3IU4pWGnnKZHQjTylaaeQpRSvNaWUyuuOhFK20xpXJ6EaeUrRyPt8u+IXJX3oyupGnFK10ppXJ6B4ClKKVRp4yGd3IU4pWGnnKZHTHQylaaY0rRSvNaWUyuuOhFK20xpXJ6EaeUrTSyFMmoxt5StFKZ1qZjG4jKkUrjTylaKVoZTK6Na5MRrcRlaKVzrRStNIaVyajG3lK0UojT5mMbuQpRSvnuvf+N4TJX3oyuo2oFK20xpXJ6I6HUrTSGlcmoxt5StFKZ1opWulljTIZ3S1PKVopWpmM7panFK20xpXJ6B4ClKKV1rgyGd3xUIpWOtPKZHS3PKVopZGnTEb33kMpWmmNK0UrrXFlMvrcHQ+jaKU1rkxGtxGVopXOtDIZfa6rjUgUrTTylMnoc/cQYBStNPKUyehGnlK00shTJqP7fKEUrfT5Qila6WqqTEa3xpWilUaeMhndg61StNLIUyajz+DE2/yli1YaecpkdMdDKVrpZY0yGX2eRp5RtNIaVyajOx5K0Uq3PKVopaupMhndGleKVs7TX34ak9Hd8pSilW55ymR0tzylaKWRp0xGN/KUopVGnjIZ3XsPpWilNa5MRrcRlaKVzrRStNKZViajOx5K0UpP48pkdCNPKVrpTCuT0R0PpWilM61MRvcQoBStNPKUyejz3P++3fBjk7900UojT5mM7panFK008pSila6mymT0eRt5RtFKV1NlMrqNqBSt9OSiTEaft41oFK20xpXJ6DaiUrTSyxplMvo8VxuRKFppjSuT0edt5BlFK408pWjlvL2sMSaj+2KrFK008pTJ6D5fKEUrfWZWJqMbeUrRSiNPmYxu5ClFK31zUSaj+3yhFK008pTJ6F71KkUrfZJTilaa08pkdP9+Wila6U9GlMnoHmyVopW+uSiT0Y08pWilW54yGd2DrVK00rs8ZTK6W55StNInOWUyuo2oFK30z+uVopWexpXJ6Na4UrTSGlcmo/uTEaVopReQymR0G1EpWmmNK5PRjTylaKUzrUxGn+f+dsLPTf7SRSuNPGUy+ixWLzYXzZy3NW4UrZz32jvUk7/0ZHRrXClaOe/dyCMmo8/TRjSKVrrlKZPRjTylaKVbnjIZfZ7B7r3iq2inNa5MRp/33uveK76KdlrjStHKf1YdkhYbx4BxAAAAAElFTkSuQmCC" y="-34.56"/>
    <g id="matplotlib.axis_3"/>
    <g id="matplotlib.axis_4">
     <g id="ytick_1">
@@ -175,33 +175,40 @@ iVBORw0KGgoAAAANSUhEUgAAAAoAAADZCAYAAAAZmKE8AAABUklEQVR4nO2ayQ0CUQxDs30qowb6LwQY
       <defs>
        <path d="M 0 0 
 L 3.5 0 
-" id="mc73af22799" style="stroke:#000000;stroke-width:0.8;"/>
+" id="md7daf0d535" style="stroke:#000000;stroke-width:0.8;"/>
       </defs>
       <g>
-       <use style="stroke:#000000;stroke-width:0.8;" x="349.452" xlink:href="#mc73af22799" y="216.827198"/>
+       <use style="stroke:#000000;stroke-width:0.8;" x="349.452" xlink:href="#md7daf0d535" y="237.12221"/>
       </g>
      </g>
      <g id="text_1">
-      <!-- 40 -->
-      <g transform="translate(356.452 220.626417)scale(0.1 -0.1)">
+      <!-- 50 -->
+      <g transform="translate(356.452 240.921429)scale(0.1 -0.1)">
        <defs>
-        <path d="M 37.796875 64.3125 
-L 12.890625 25.390625 
-L 37.796875 25.390625 
+        <path d="M 10.796875 72.90625 
+L 49.515625 72.90625 
+L 49.515625 64.59375 
+L 19.828125 64.59375 
+L 19.828125 46.734375 
+Q 21.96875 47.46875 24.109375 47.828125 
+Q 26.265625 48.1875 28.421875 48.1875 
+Q 40.625 48.1875 47.75 41.5 
+Q 54.890625 34.8125 54.890625 23.390625 
+Q 54.890625 11.625 47.5625 5.09375 
+Q 40.234375 -1.421875 26.90625 -1.421875 
+Q 22.3125 -1.421875 17.546875 -0.640625 
+Q 12.796875 0.140625 7.71875 1.703125 
+L 7.71875 11.625 
+Q 12.109375 9.234375 16.796875 8.0625 
+Q 21.484375 6.890625 26.703125 6.890625 
+Q 35.15625 6.890625 40.078125 11.328125 
+Q 45.015625 15.765625 45.015625 23.390625 
+Q 45.015625 31 40.078125 35.4375 
+Q 35.15625 39.890625 26.703125 39.890625 
+Q 22.75 39.890625 18.8125 39.015625 
+Q 14.890625 38.140625 10.796875 36.28125 
 z
-M 35.203125 72.90625 
-L 47.609375 72.90625 
-L 47.609375 25.390625 
-L 58.015625 25.390625 
-L 58.015625 17.1875 
-L 47.609375 17.1875 
-L 47.609375 0 
-L 37.796875 0 
-L 37.796875 17.1875 
-L 4.890625 17.1875 
-L 4.890625 26.703125 
-z
-" id="DejaVuSans-52"/>
+" id="DejaVuSans-53"/>
         <path d="M 31.78125 66.40625 
 Q 24.171875 66.40625 20.328125 58.90625 
 Q 16.5 51.421875 16.5 36.375 
@@ -224,7 +231,7 @@ Q 19.53125 74.21875 31.78125 74.21875
 z
 " id="DejaVuSans-48"/>
        </defs>
-       <use xlink:href="#DejaVuSans-52"/>
+       <use xlink:href="#DejaVuSans-53"/>
        <use x="63.623047" xlink:href="#DejaVuSans-48"/>
       </g>
      </g>
@@ -232,113 +239,12 @@ z
     <g id="ytick_2">
      <g id="line2d_9">
       <g>
-       <use style="stroke:#000000;stroke-width:0.8;" x="349.452" xlink:href="#mc73af22799" y="169.930128"/>
+       <use style="stroke:#000000;stroke-width:0.8;" x="349.452" xlink:href="#md7daf0d535" y="207.366631"/>
       </g>
      </g>
      <g id="text_2">
-      <!-- 60 -->
-      <g transform="translate(356.452 173.729347)scale(0.1 -0.1)">
-       <defs>
-        <path d="M 33.015625 40.375 
-Q 26.375 40.375 22.484375 35.828125 
-Q 18.609375 31.296875 18.609375 23.390625 
-Q 18.609375 15.53125 22.484375 10.953125 
-Q 26.375 6.390625 33.015625 6.390625 
-Q 39.65625 6.390625 43.53125 10.953125 
-Q 47.40625 15.53125 47.40625 23.390625 
-Q 47.40625 31.296875 43.53125 35.828125 
-Q 39.65625 40.375 33.015625 40.375 
-z
-M 52.59375 71.296875 
-L 52.59375 62.3125 
-Q 48.875 64.0625 45.09375 64.984375 
-Q 41.3125 65.921875 37.59375 65.921875 
-Q 27.828125 65.921875 22.671875 59.328125 
-Q 17.53125 52.734375 16.796875 39.40625 
-Q 19.671875 43.65625 24.015625 45.921875 
-Q 28.375 48.1875 33.59375 48.1875 
-Q 44.578125 48.1875 50.953125 41.515625 
-Q 57.328125 34.859375 57.328125 23.390625 
-Q 57.328125 12.15625 50.6875 5.359375 
-Q 44.046875 -1.421875 33.015625 -1.421875 
-Q 20.359375 -1.421875 13.671875 8.265625 
-Q 6.984375 17.96875 6.984375 36.375 
-Q 6.984375 53.65625 15.1875 63.9375 
-Q 23.390625 74.21875 37.203125 74.21875 
-Q 40.921875 74.21875 44.703125 73.484375 
-Q 48.484375 72.75 52.59375 71.296875 
-z
-" id="DejaVuSans-54"/>
-       </defs>
-       <use xlink:href="#DejaVuSans-54"/>
-       <use x="63.623047" xlink:href="#DejaVuSans-48"/>
-      </g>
-     </g>
-    </g>
-    <g id="ytick_3">
-     <g id="line2d_10">
-      <g>
-       <use style="stroke:#000000;stroke-width:0.8;" x="349.452" xlink:href="#mc73af22799" y="123.033059"/>
-      </g>
-     </g>
-     <g id="text_3">
-      <!-- 80 -->
-      <g transform="translate(356.452 126.832278)scale(0.1 -0.1)">
-       <defs>
-        <path d="M 31.78125 34.625 
-Q 24.75 34.625 20.71875 30.859375 
-Q 16.703125 27.09375 16.703125 20.515625 
-Q 16.703125 13.921875 20.71875 10.15625 
-Q 24.75 6.390625 31.78125 6.390625 
-Q 38.8125 6.390625 42.859375 10.171875 
-Q 46.921875 13.96875 46.921875 20.515625 
-Q 46.921875 27.09375 42.890625 30.859375 
-Q 38.875 34.625 31.78125 34.625 
-z
-M 21.921875 38.8125 
-Q 15.578125 40.375 12.03125 44.71875 
-Q 8.5 49.078125 8.5 55.328125 
-Q 8.5 64.0625 14.71875 69.140625 
-Q 20.953125 74.21875 31.78125 74.21875 
-Q 42.671875 74.21875 48.875 69.140625 
-Q 55.078125 64.0625 55.078125 55.328125 
-Q 55.078125 49.078125 51.53125 44.71875 
-Q 48 40.375 41.703125 38.8125 
-Q 48.828125 37.15625 52.796875 32.3125 
-Q 56.78125 27.484375 56.78125 20.515625 
-Q 56.78125 9.90625 50.3125 4.234375 
-Q 43.84375 -1.421875 31.78125 -1.421875 
-Q 19.734375 -1.421875 13.25 4.234375 
-Q 6.78125 9.90625 6.78125 20.515625 
-Q 6.78125 27.484375 10.78125 32.3125 
-Q 14.796875 37.15625 21.921875 38.8125 
-z
-M 18.3125 54.390625 
-Q 18.3125 48.734375 21.84375 45.5625 
-Q 25.390625 42.390625 31.78125 42.390625 
-Q 38.140625 42.390625 41.71875 45.5625 
-Q 45.3125 48.734375 45.3125 54.390625 
-Q 45.3125 60.0625 41.71875 63.234375 
-Q 38.140625 66.40625 31.78125 66.40625 
-Q 25.390625 66.40625 21.84375 63.234375 
-Q 18.3125 60.0625 18.3125 54.390625 
-z
-" id="DejaVuSans-56"/>
-       </defs>
-       <use xlink:href="#DejaVuSans-56"/>
-       <use x="63.623047" xlink:href="#DejaVuSans-48"/>
-      </g>
-     </g>
-    </g>
-    <g id="ytick_4">
-     <g id="line2d_11">
-      <g>
-       <use style="stroke:#000000;stroke-width:0.8;" x="349.452" xlink:href="#mc73af22799" y="76.135989"/>
-      </g>
-     </g>
-     <g id="text_4">
       <!-- 100 -->
-      <g transform="translate(356.452 79.935208)scale(0.1 -0.1)">
+      <g transform="translate(356.452 211.16585)scale(0.1 -0.1)">
        <defs>
         <path d="M 12.40625 8.296875 
 L 28.515625 8.296875 
@@ -360,7 +266,142 @@ z
       </g>
      </g>
     </g>
-    <g id="text_5">
+    <g id="ytick_3">
+     <g id="line2d_10">
+      <g>
+       <use style="stroke:#000000;stroke-width:0.8;" x="349.452" xlink:href="#md7daf0d535" y="177.611052"/>
+      </g>
+     </g>
+     <g id="text_3">
+      <!-- 150 -->
+      <g transform="translate(356.452 181.410271)scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-49"/>
+       <use x="63.623047" xlink:href="#DejaVuSans-53"/>
+       <use x="127.246094" xlink:href="#DejaVuSans-48"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_4">
+     <g id="line2d_11">
+      <g>
+       <use style="stroke:#000000;stroke-width:0.8;" x="349.452" xlink:href="#md7daf0d535" y="147.855473"/>
+      </g>
+     </g>
+     <g id="text_4">
+      <!-- 200 -->
+      <g transform="translate(356.452 151.654692)scale(0.1 -0.1)">
+       <defs>
+        <path d="M 19.1875 8.296875 
+L 53.609375 8.296875 
+L 53.609375 0 
+L 7.328125 0 
+L 7.328125 8.296875 
+Q 12.9375 14.109375 22.625 23.890625 
+Q 32.328125 33.6875 34.8125 36.53125 
+Q 39.546875 41.84375 41.421875 45.53125 
+Q 43.3125 49.21875 43.3125 52.78125 
+Q 43.3125 58.59375 39.234375 62.25 
+Q 35.15625 65.921875 28.609375 65.921875 
+Q 23.96875 65.921875 18.8125 64.3125 
+Q 13.671875 62.703125 7.8125 59.421875 
+L 7.8125 69.390625 
+Q 13.765625 71.78125 18.9375 73 
+Q 24.125 74.21875 28.421875 74.21875 
+Q 39.75 74.21875 46.484375 68.546875 
+Q 53.21875 62.890625 53.21875 53.421875 
+Q 53.21875 48.921875 51.53125 44.890625 
+Q 49.859375 40.875 45.40625 35.40625 
+Q 44.1875 33.984375 37.640625 27.21875 
+Q 31.109375 20.453125 19.1875 8.296875 
+z
+" id="DejaVuSans-50"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-50"/>
+       <use x="63.623047" xlink:href="#DejaVuSans-48"/>
+       <use x="127.246094" xlink:href="#DejaVuSans-48"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_5">
+     <g id="line2d_12">
+      <g>
+       <use style="stroke:#000000;stroke-width:0.8;" x="349.452" xlink:href="#md7daf0d535" y="118.099894"/>
+      </g>
+     </g>
+     <g id="text_5">
+      <!-- 250 -->
+      <g transform="translate(356.452 121.899113)scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-50"/>
+       <use x="63.623047" xlink:href="#DejaVuSans-53"/>
+       <use x="127.246094" xlink:href="#DejaVuSans-48"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_6">
+     <g id="line2d_13">
+      <g>
+       <use style="stroke:#000000;stroke-width:0.8;" x="349.452" xlink:href="#md7daf0d535" y="88.344315"/>
+      </g>
+     </g>
+     <g id="text_6">
+      <!-- 300 -->
+      <g transform="translate(356.452 92.143533)scale(0.1 -0.1)">
+       <defs>
+        <path d="M 40.578125 39.3125 
+Q 47.65625 37.796875 51.625 33 
+Q 55.609375 28.21875 55.609375 21.1875 
+Q 55.609375 10.40625 48.1875 4.484375 
+Q 40.765625 -1.421875 27.09375 -1.421875 
+Q 22.515625 -1.421875 17.65625 -0.515625 
+Q 12.796875 0.390625 7.625 2.203125 
+L 7.625 11.71875 
+Q 11.71875 9.328125 16.59375 8.109375 
+Q 21.484375 6.890625 26.8125 6.890625 
+Q 36.078125 6.890625 40.9375 10.546875 
+Q 45.796875 14.203125 45.796875 21.1875 
+Q 45.796875 27.640625 41.28125 31.265625 
+Q 36.765625 34.90625 28.71875 34.90625 
+L 20.21875 34.90625 
+L 20.21875 43.015625 
+L 29.109375 43.015625 
+Q 36.375 43.015625 40.234375 45.921875 
+Q 44.09375 48.828125 44.09375 54.296875 
+Q 44.09375 59.90625 40.109375 62.90625 
+Q 36.140625 65.921875 28.71875 65.921875 
+Q 24.65625 65.921875 20.015625 65.03125 
+Q 15.375 64.15625 9.8125 62.3125 
+L 9.8125 71.09375 
+Q 15.4375 72.65625 20.34375 73.4375 
+Q 25.25 74.21875 29.59375 74.21875 
+Q 40.828125 74.21875 47.359375 69.109375 
+Q 53.90625 64.015625 53.90625 55.328125 
+Q 53.90625 49.265625 50.4375 45.09375 
+Q 46.96875 40.921875 40.578125 39.3125 
+z
+" id="DejaVuSans-51"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-51"/>
+       <use x="63.623047" xlink:href="#DejaVuSans-48"/>
+       <use x="127.246094" xlink:href="#DejaVuSans-48"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_7">
+     <g id="line2d_14">
+      <g>
+       <use style="stroke:#000000;stroke-width:0.8;" x="349.452" xlink:href="#md7daf0d535" y="58.588735"/>
+      </g>
+     </g>
+     <g id="text_7">
+      <!-- 350 -->
+      <g transform="translate(356.452 62.387954)scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-51"/>
+       <use x="63.623047" xlink:href="#DejaVuSans-53"/>
+       <use x="127.246094" xlink:href="#DejaVuSans-48"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_8">
      <!-- Temperature -->
      <g transform="translate(387.137938 174.949531)rotate(-90)scale(0.1 -0.1)">
       <defs>
@@ -573,10 +614,10 @@ z
   </g>
  </g>
  <defs>
-  <clipPath id="p0815875453">
+  <clipPath id="p69b2ffbe32">
    <rect height="217.44" width="267.84" x="54" y="34.56"/>
   </clipPath>
-  <clipPath id="p30d5836d5f">
+  <clipPath id="p81ec9fdf97">
    <rect height="217.44" width="10.872" x="338.58" y="34.56"/>
   </clipPath>
  </defs>

--- a/docs/source/general_analyzers/Images/PlaneWall.svg
+++ b/docs/source/general_analyzers/Images/PlaneWall.svg
@@ -8,41 +8,26 @@
    xmlns="http://www.w3.org/2000/svg"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   sodipodi:docname="PlaneWall.svg"
-   inkscape:version="1.0 (4035a4fb49, 2020-05-01)"
-   id="svg1291"
-   version="1.1"
-   viewBox="0 0 72 86"
+   width="72mm"
    height="86mm"
-   width="72mm">
+   viewBox="0 0 72 86"
+   version="1.1"
+   id="svg1291"
+   inkscape:version="1.0 (4035a4fb49, 2020-05-01)"
+   sodipodi:docname="PlaneWall.svg">
   <defs
      id="defs1285">
     <marker
-       inkscape:collect="always"
-       inkscape:isstock="true"
-       style="overflow:visible"
-       id="Arrow1Mend"
-       refX="0"
-       refY="0"
-       orient="auto"
-       inkscape:stockid="Arrow1Mend">
-      <path
-         transform="matrix(-0.4,0,0,-0.4,-4,0)"
-         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
-         d="M 0,0 5,-5 -12.5,0 5,5 Z"
-         id="path868" />
-    </marker>
-    <marker
-       inkscape:collect="always"
        inkscape:stockid="Arrow1Mend"
        orient="auto"
        refY="0"
        refX="0"
-       id="marker1599"
+       id="Arrow1Mend"
        style="overflow:visible"
-       inkscape:isstock="true">
+       inkscape:isstock="true"
+       inkscape:collect="always">
       <path
-         id="path1597"
+         id="path868"
          d="M 0,0 5,-5 -12.5,0 5,5 Z"
          style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
          transform="matrix(-0.4,0,0,-0.4,-4,0)" />
@@ -50,212 +35,227 @@
     <marker
        inkscape:isstock="true"
        style="overflow:visible"
-       id="marker1599-5"
+       id="marker1599"
        refX="0"
        refY="0"
        orient="auto"
-       inkscape:stockid="Arrow1Mend">
+       inkscape:stockid="Arrow1Mend"
+       inkscape:collect="always">
       <path
          transform="matrix(-0.4,0,0,-0.4,-4,0)"
          style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
          d="M 0,0 5,-5 -12.5,0 5,5 Z"
-         id="path1597-1" />
+         id="path1597" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker1599-5"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path1597-1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)" />
     </marker>
     <g
        id="id-c1edebfc-79d9-4c93-8db4-467657ab5a03">
       <symbol
-         id="id-3c537e05-5454-4503-a687-a47806632f33"
-         overflow="visible">
+         overflow="visible"
+         id="id-3c537e05-5454-4503-a687-a47806632f33">
         <path
-           id="id-73a813e6-a2f0-4288-8b8b-2e691f911c7a"
+           style="stroke:none;stroke-width:0"
            d=""
-           style="stroke:none;stroke-width:0" />
+           id="id-73a813e6-a2f0-4288-8b8b-2e691f911c7a" />
       </symbol>
       <symbol
-         id="id-b575722d-aae0-466e-9353-f80b755ecbcf"
-         overflow="visible">
+         overflow="visible"
+         id="id-b575722d-aae0-466e-9353-f80b755ecbcf">
         <path
-           id="id-3736a232-33f6-4ee9-a05d-e48c24d9a1a4"
+           style="stroke:none;stroke-width:0"
            d="M 1.78125,-1.140625 C 1.390625,-0.484375 1,-0.34375 0.5625,-0.3125 0.4375,-0.296875 0.34375,-0.296875 0.34375,-0.109375 0.34375,-0.046875 0.40625,0 0.484375,0 0.75,0 1.0625,-0.03125 1.328125,-0.03125 c 0.34375,0 0.6875,0.03125 1,0.03125 0.0625,0 0.1875,0 0.1875,-0.1875 0,-0.109375 -0.078125,-0.125 -0.15625,-0.125 -0.21875,-0.015625 -0.46875,-0.09375 -0.46875,-0.34375 0,-0.125 0.0625,-0.234375 0.140625,-0.375 l 0.765625,-1.265625 h 2.5 c 0.015625,0.203125 0.15625,1.5625 0.15625,1.65625 0,0.296875 -0.515625,0.328125 -0.71875,0.328125 C 4.59375,-0.3125 4.5,-0.3125 4.5,-0.109375 4.5,0 4.609375,0 4.640625,0 5.046875,0 5.46875,-0.03125 5.875,-0.03125 6.125,-0.03125 6.765625,0 7.015625,0 7.0625,0 7.1875,0 7.1875,-0.203125 7.1875,-0.3125 7.09375,-0.3125 6.953125,-0.3125 6.34375,-0.3125 6.34375,-0.375 6.3125,-0.671875 l -0.609375,-6.21875 c -0.015625,-0.203125 -0.015625,-0.25 -0.1875,-0.25 -0.15625,0 -0.203125,0.078125 -0.265625,0.171875 z M 2.984375,-2.609375 4.9375,-5.90625 5.265625,-2.609375 Z m 0,0"
-           style="stroke:none;stroke-width:0" />
+           id="id-3736a232-33f6-4ee9-a05d-e48c24d9a1a4" />
       </symbol>
     </g>
     <g
        id="id-ffcb1021-d92e-4f3e-b0f0-cb316c970d74">
       <symbol
-         id="id-55d2ddea-fc50-4211-b0f1-c7af3f70595a"
-         overflow="visible">
+         overflow="visible"
+         id="id-55d2ddea-fc50-4211-b0f1-c7af3f70595a">
         <path
-           id="id-964aba9e-90d7-4c4e-a005-18626c20b72a"
+           style="stroke:none;stroke-width:0"
            d=""
-           style="stroke:none;stroke-width:0" />
+           id="id-964aba9e-90d7-4c4e-a005-18626c20b72a" />
       </symbol>
       <symbol
-         id="id-6d67fe2e-499f-454f-881a-ea29b8027e9f"
-         overflow="visible">
+         overflow="visible"
+         id="id-6d67fe2e-499f-454f-881a-ea29b8027e9f">
         <path
-           id="id-8304a96c-a200-4377-8dd2-cd6edc6519ba"
+           style="stroke:none;stroke-width:0"
            d="M 3.734375,-6.03125 C 3.8125,-6.390625 3.84375,-6.5 4.78125,-6.5 c 0.296875,0 0.375,0 0.375,-0.1875 0,-0.125 -0.109375,-0.125 -0.15625,-0.125 -0.328125,0 -1.140625,0.03125 -1.46875,0.03125 -0.296875,0 -1.03125,-0.03125 -1.328125,-0.03125 -0.0625,0 -0.1875,0 -0.1875,0.203125 0,0.109375 0.09375,0.109375 0.28125,0.109375 0.015625,0 0.203125,0 0.375,0.015625 0.171875,0.03125 0.265625,0.03125 0.265625,0.171875 0,0.03125 0,0.0625 -0.03125,0.1875 L 1.5625,-0.78125 c -0.09375,0.390625 -0.109375,0.46875 -0.90625,0.46875 -0.171875,0 -0.265625,0 -0.265625,0.203125 C 0.390625,0 0.484375,0 0.65625,0 h 4.625 C 5.515625,0 5.515625,0 5.578125,-0.171875 L 6.375,-2.328125 c 0.03125,-0.109375 0.03125,-0.125 0.03125,-0.140625 0,-0.03125 -0.03125,-0.109375 -0.109375,-0.109375 -0.09375,0 -0.109375,0.0625 -0.171875,0.21875 -0.34375,0.90625 -0.78125,2.046875 -2.5,2.046875 H 2.6875 c -0.140625,0 -0.171875,0 -0.21875,0 -0.109375,-0.015625 -0.140625,-0.03125 -0.140625,-0.109375 0,-0.03125 0,-0.046875 0.046875,-0.21875 z m 0,0"
-           style="stroke:none;stroke-width:0" />
+           id="id-8304a96c-a200-4377-8dd2-cd6edc6519ba" />
       </symbol>
     </g>
     <g
        id="id-75443a0c-0c74-450b-a8e1-21b76418a041">
       <symbol
-         id="id-457d0e0d-bafa-45c2-99c0-c67458c4370e"
-         overflow="visible">
+         overflow="visible"
+         id="id-457d0e0d-bafa-45c2-99c0-c67458c4370e">
         <path
-           id="id-f5594215-1e21-4104-a456-1d22b27f7211"
+           style="stroke:none;stroke-width:0"
            d=""
-           style="stroke:none;stroke-width:0" />
+           id="id-f5594215-1e21-4104-a456-1d22b27f7211" />
       </symbol>
       <symbol
-         id="id-04d03892-73d5-4eff-bdc8-21897025508a"
-         overflow="visible">
+         overflow="visible"
+         id="id-04d03892-73d5-4eff-bdc8-21897025508a">
         <path
-           id="id-b1ed703f-4f70-4f7a-9ed6-9ce44d41956e"
+           style="stroke:none;stroke-width:0"
            d="m 2.859375,-6.8125 c 0,0 0,-0.109375 -0.125,-0.109375 -0.234375,0 -0.953125,0.078125 -1.21875,0.109375 -0.078125,0 -0.1875,0.015625 -0.1875,0.1875 0,0.125 0.09375,0.125 0.234375,0.125 0.484375,0 0.5,0.0625 0.5,0.171875 L 2.03125,-6.125 0.59375,-0.390625 c -0.046875,0.140625 -0.046875,0.15625 -0.046875,0.21875 0,0.234375 0.203125,0.28125 0.296875,0.28125 0.125,0 0.265625,-0.09375 0.328125,-0.203125 0.046875,-0.09375 0.5,-1.9375 0.5625,-2.1875 0.34375,0.03125 1.15625,0.1875 1.15625,0.84375 0,0.078125 0,0.109375 -0.03125,0.21875 -0.015625,0.109375 -0.03125,0.234375 -0.03125,0.34375 0,0.578125 0.390625,0.984375 0.90625,0.984375 0.296875,0 0.578125,-0.15625 0.796875,-0.53125 0.25,-0.4375 0.359375,-0.984375 0.359375,-1 0,-0.109375 -0.09375,-0.109375 -0.125,-0.109375 -0.09375,0 -0.109375,0.046875 -0.140625,0.1875 -0.203125,0.71875 -0.421875,1.234375 -0.859375,1.234375 -0.203125,0 -0.328125,-0.109375 -0.328125,-0.46875 0,-0.171875 0.046875,-0.40625 0.078125,-0.5625 C 3.5625,-1.3125 3.5625,-1.34375 3.5625,-1.453125 3.5625,-2.09375 2.9375,-2.375 2.078125,-2.5 2.390625,-2.671875 2.71875,-2.984375 2.9375,-3.234375 3.421875,-3.765625 3.875,-4.1875 4.359375,-4.1875 c 0.0625,0 0.078125,0 0.09375,0.015625 0.125,0.015625 0.125,0.015625 0.21875,0.078125 0.015625,0 0.015625,0.015625 0.03125,0.03125 -0.46875,0.03125 -0.5625,0.421875 -0.5625,0.546875 0,0.15625 0.109375,0.34375 0.375,0.34375 0.265625,0 0.546875,-0.21875 0.546875,-0.609375 0,-0.296875 -0.234375,-0.625 -0.671875,-0.625 -0.28125,0 -0.734375,0.078125 -1.453125,0.875 -0.34375,0.375 -0.734375,0.78125 -1.109375,0.921875 z m 0,0"
-           style="stroke:none;stroke-width:0" />
+           id="id-b1ed703f-4f70-4f7a-9ed6-9ce44d41956e" />
       </symbol>
     </g>
     <g
        id="id-4985a6ba-047d-4c2b-a8e4-0190682371e0">
       <symbol
-         id="id-1b881995-30b9-4eb4-99f9-5dd4a28df067"
-         overflow="visible">
+         overflow="visible"
+         id="id-1b881995-30b9-4eb4-99f9-5dd4a28df067">
         <path
-           id="id-2c3ec2c0-d7f7-4e6c-8092-14a8e8f998c7"
+           style="stroke:none;stroke-width:0"
            d=""
-           style="stroke:none;stroke-width:0" />
+           id="id-2c3ec2c0-d7f7-4e6c-8092-14a8e8f998c7" />
       </symbol>
       <symbol
-         id="id-fcd2371a-4d0b-4ce6-81af-6c3990e7650d"
-         overflow="visible">
+         overflow="visible"
+         id="id-fcd2371a-4d0b-4ce6-81af-6c3990e7650d">
         <path
-           id="id-51006b25-dd64-4850-a346-661966cc6e78"
+           style="stroke:none;stroke-width:0"
            d="m 3.734375,-6.125 c 0.0625,-0.234375 0.09375,-0.328125 0.28125,-0.359375 C 4.109375,-6.5 4.421875,-6.5 4.625,-6.5 c 0.703125,0 1.8125,0 1.8125,0.984375 0,0.34375 -0.15625,1.03125 -0.546875,1.421875 -0.265625,0.25 -0.78125,0.578125 -1.6875,0.578125 H 3.09375 Z m 1.4375,2.734375 c 1.015625,-0.21875 2.1875,-0.921875 2.1875,-1.921875 0,-0.859375 -0.890625,-1.5 -2.203125,-1.5 H 2.328125 c -0.203125,0 -0.296875,0 -0.296875,0.203125 C 2.03125,-6.5 2.125,-6.5 2.3125,-6.5 c 0.015625,0 0.203125,0 0.375,0.015625 0.1875,0.03125 0.265625,0.03125 0.265625,0.171875 0,0.03125 0,0.0625 -0.03125,0.1875 l -1.34375,5.34375 C 1.484375,-0.390625 1.46875,-0.3125 0.671875,-0.3125 0.5,-0.3125 0.40625,-0.3125 0.40625,-0.109375 0.40625,0 0.53125,0 0.546875,0 c 0.28125,0 0.984375,-0.03125 1.25,-0.03125 0.28125,0 1,0.03125 1.28125,0.03125 0.078125,0 0.1875,0 0.1875,-0.203125 0,-0.109375 -0.078125,-0.109375 -0.28125,-0.109375 -0.359375,0 -0.640625,0 -0.640625,-0.171875 0,-0.0625 0.015625,-0.109375 0.03125,-0.171875 l 0.65625,-2.640625 h 1.1875 c 0.90625,0 1.078125,0.5625 1.078125,0.90625 0,0.140625 -0.078125,0.453125 -0.140625,0.6875 C 5.09375,-1.421875 5,-1.0625 5,-0.859375 5,0.21875 6.203125,0.21875 6.328125,0.21875 c 0.84375,0 1.203125,-1 1.203125,-1.140625 0,-0.125 -0.109375,-0.125 -0.125,-0.125 -0.09375,0 -0.109375,0.0625 -0.125,0.140625 C 7.03125,-0.171875 6.59375,0 6.375,0 6.046875,0 5.96875,-0.21875 5.96875,-0.609375 c 0,-0.3125 0.0625,-0.8125 0.109375,-1.140625 0.015625,-0.140625 0.03125,-0.328125 0.03125,-0.46875 0,-0.765625 -0.671875,-1.078125 -0.9375,-1.171875 z m 0,0"
-           style="stroke:none;stroke-width:0" />
+           id="id-51006b25-dd64-4850-a346-661966cc6e78" />
       </symbol>
       <symbol
-         id="id-776225a2-7451-4ce7-9e9c-fcc640961313"
-         overflow="visible">
+         overflow="visible"
+         id="id-776225a2-7451-4ce7-9e9c-fcc640961313">
         <path
-           id="id-0b1f6f22-9a13-43b3-9d64-0250baad34e1"
+           style="stroke:none;stroke-width:0"
            d=""
-           style="stroke:none;stroke-width:0" />
+           id="id-0b1f6f22-9a13-43b3-9d64-0250baad34e1" />
       </symbol>
       <symbol
-         id="id-361625e8-1c45-4d45-a853-595ebf14c9a1"
-         overflow="visible">
+         overflow="visible"
+         id="id-361625e8-1c45-4d45-a853-595ebf14c9a1">
         <path
-           id="id-8c01811f-03e5-4be5-90df-6a2079272eff"
+           style="stroke:none;stroke-width:0"
            d="m 1.9375,1.09375 c -0.453125,0 -0.515625,0 -0.515625,-0.296875 v -1.125 C 1.453125,-0.296875 1.78125,0.0625 2.359375,0.0625 3.28125,0.0625 4.0625,-0.625 4.0625,-1.5 c 0,-0.859375 -0.703125,-1.578125 -1.59375,-1.578125 -0.390625,0 -0.796875,0.15625 -1.078125,0.4375 v -0.4375 L 0.34375,-3 v 0.25 c 0.484375,0 0.515625,0.046875 0.515625,0.328125 v 3.21875 c 0,0.296875 -0.0625,0.296875 -0.515625,0.296875 v 0.265625 c 0.015625,0 0.5,-0.03125 0.796875,-0.03125 0.25,0 0.734375,0.015625 0.796875,0.03125 z M 1.421875,-2.328125 C 1.625,-2.671875 2.03125,-2.84375 2.390625,-2.84375 c 0.59375,0 1.046875,0.609375 1.046875,1.34375 0,0.796875 -0.53125,1.375 -1.109375,1.375 -0.625,0 -0.890625,-0.53125 -0.90625,-0.578125 z m 0,0"
-           style="stroke:none;stroke-width:0" />
+           id="id-8c01811f-03e5-4be5-90df-6a2079272eff" />
       </symbol>
       <symbol
-         id="id-2832e8d0-37dc-450c-8fae-0876b713e489"
-         overflow="visible">
+         overflow="visible"
+         id="id-2832e8d0-37dc-450c-8fae-0876b713e489">
         <path
-           id="id-d4ef918b-9c89-4c4e-b016-77adf9728ed9"
+           style="stroke:none;stroke-width:0"
            d=""
-           style="stroke:none;stroke-width:0" />
+           id="id-d4ef918b-9c89-4c4e-b016-77adf9728ed9" />
       </symbol>
       <symbol
-         id="id-bab1c8ab-c19f-4343-a5dc-f523ff4de876"
-         overflow="visible">
+         overflow="visible"
+         id="id-bab1c8ab-c19f-4343-a5dc-f523ff4de876">
         <path
-           id="id-b86ad2f5-4e56-4005-9e59-93b8948b72ea"
+           style="stroke:none;stroke-width:0"
            d="m 6.84375,-3.265625 c 0.15625,0 0.34375,0 0.34375,-0.1875 C 7.1875,-3.65625 7,-3.65625 6.859375,-3.65625 h -5.96875 c -0.140625,0 -0.328125,0 -0.328125,0.203125 0,0.1875 0.1875,0.1875 0.328125,0.1875 z m 0.015625,1.9375 c 0.140625,0 0.328125,0 0.328125,-0.203125 0,-0.1875 -0.1875,-0.1875 -0.34375,-0.1875 H 0.890625 c -0.140625,0 -0.328125,0 -0.328125,0.1875 0,0.203125 0.1875,0.203125 0.328125,0.203125 z m 0,0"
-           style="stroke:none;stroke-width:0" />
+           id="id-b86ad2f5-4e56-4005-9e59-93b8948b72ea" />
       </symbol>
       <symbol
-         id="id-a6d5695e-1fe2-42ae-8978-90afa871ae8a"
-         overflow="visible">
+         overflow="visible"
+         id="id-a6d5695e-1fe2-42ae-8978-90afa871ae8a">
         <path
-           id="id-95daa3d5-8ede-45fe-9662-5da3f0bfbe63"
+           style="stroke:none;stroke-width:0"
            d=""
-           style="stroke:none;stroke-width:0" />
+           id="id-95daa3d5-8ede-45fe-9662-5da3f0bfbe63" />
       </symbol>
       <symbol
-         id="id-5eac10cc-72f7-4f81-91c4-f3eb8b22ee24"
-         overflow="visible">
+         overflow="visible"
+         id="id-5eac10cc-72f7-4f81-91c4-f3eb8b22ee24">
         <path
-           id="id-19564a34-67f6-4e4c-90a0-7e463cb5bfc4"
+           style="stroke:none;stroke-width:0"
            d="m 2.875,-4.1875 c 0.0625,-0.25 0.078125,-0.328125 0.71875,-0.328125 0.21875,0 0.28125,0 0.28125,-0.140625 0,-0.015625 0,-0.109375 -0.109375,-0.109375 -0.15625,0 -0.34375,0.015625 -0.515625,0.03125 -0.171875,0 -0.390625,0 -0.5625,0 -0.140625,0 -0.328125,0 -0.484375,0 -0.140625,0 -0.3125,-0.03125 -0.453125,-0.03125 -0.03125,0 -0.140625,0 -0.140625,0.15625 0,0.09375 0.078125,0.09375 0.21875,0.09375 0.015625,0 0.140625,0 0.265625,0.015625 0.15625,0.015625 0.171875,0.03125 0.171875,0.109375 0,0 0,0.046875 -0.03125,0.140625 l -0.9375,3.703125 C 1.234375,-0.3125 1.21875,-0.25 0.6875,-0.25 c -0.109375,0 -0.203125,0 -0.203125,0.140625 C 0.484375,0 0.5625,0 0.6875,0 h 3.5 c 0.1875,0 0.1875,0 0.25,-0.140625 0.0625,-0.1875 0.59375,-1.53125 0.59375,-1.59375 0,-0.015625 -0.015625,-0.09375 -0.125,-0.09375 -0.078125,0 -0.09375,0.03125 -0.140625,0.140625 C 4.5,-1.03125 4.1875,-0.25 2.921875,-0.25 H 2.125 c -0.203125,0 -0.21875,-0.015625 -0.21875,-0.078125 0,0 0,-0.03125 0.03125,-0.140625 z m 0,0"
-           style="stroke:none;stroke-width:0" />
+           id="id-19564a34-67f6-4e4c-90a0-7e463cb5bfc4" />
       </symbol>
       <symbol
-         id="id-b912fe46-fba0-4145-8a2a-0ad5998eb4ba"
-         overflow="visible">
+         overflow="visible"
+         id="id-b912fe46-fba0-4145-8a2a-0ad5998eb4ba">
         <path
-           id="id-5541aae6-e79f-408a-a688-31b78877a4e3"
+           style="stroke:none;stroke-width:0"
            d="m 2.1875,-4.625 c 0,-0.015625 0.015625,-0.109375 0.015625,-0.109375 0,-0.046875 -0.015625,-0.109375 -0.109375,-0.109375 -0.140625,0 -0.71875,0.0625 -0.890625,0.078125 -0.046875,0 -0.15625,0.015625 -0.15625,0.15625 0,0.09375 0.109375,0.09375 0.1875,0.09375 0.328125,0 0.328125,0.0625 0.328125,0.109375 0,0.046875 -0.015625,0.09375 -0.015625,0.15625 L 0.5625,-0.3125 c -0.046875,0.125 -0.046875,0.140625 -0.046875,0.15625 0,0.109375 0.09375,0.21875 0.25,0.21875 0.1875,0 0.265625,-0.125 0.3125,-0.28125 0.015625,-0.03125 0.3125,-1.265625 0.34375,-1.359375 0.5,0.046875 0.890625,0.21875 0.890625,0.578125 0,0.03125 0,0.0625 -0.015625,0.140625 -0.03125,0.09375 -0.03125,0.140625 -0.03125,0.21875 0,0.484375 0.40625,0.703125 0.75,0.703125 0.671875,0 0.875,-1.046875 0.875,-1.0625 0,-0.09375 -0.078125,-0.09375 -0.109375,-0.09375 -0.09375,0 -0.109375,0.046875 -0.140625,0.171875 C 3.5625,-0.625 3.375,-0.125 3.03125,-0.125 c -0.1875,0 -0.25,-0.171875 -0.25,-0.359375 0,-0.125 0,-0.140625 0.046875,-0.3125 0.015625,-0.03125 0.03125,-0.140625 0.03125,-0.21875 0,-0.625 -0.828125,-0.71875 -1.125,-0.734375 C 1.9375,-1.875 2.1875,-2.109375 2.3125,-2.21875 2.671875,-2.546875 3.015625,-2.875 3.40625,-2.875 c 0.078125,0 0.171875,0.015625 0.234375,0.09375 C 3.34375,-2.734375 3.28125,-2.5 3.28125,-2.390625 c 0,0.140625 0.109375,0.25 0.265625,0.25 0.203125,0 0.40625,-0.15625 0.40625,-0.4375 0,-0.234375 -0.171875,-0.5 -0.53125,-0.5 -0.40625,0 -0.765625,0.296875 -1.125,0.625 C 2,-2.1875 1.78125,-1.96875 1.484375,-1.84375 Z m 0,0"
-           style="stroke:none;stroke-width:0" />
+           id="id-5541aae6-e79f-408a-a688-31b78877a4e3" />
       </symbol>
       <symbol
-         id="id-0faa2b47-4dbb-43c8-ae8e-56120f3b9ec6"
-         overflow="visible">
+         overflow="visible"
+         id="id-0faa2b47-4dbb-43c8-ae8e-56120f3b9ec6">
         <path
-           id="id-ebd8507d-6ec7-44c2-bae1-900f8501ba57"
+           style="stroke:none;stroke-width:0"
            d="m 1.4375,-0.84375 c -0.25,0.390625 -0.46875,0.5625 -0.875,0.59375 -0.078125,0 -0.171875,0 -0.171875,0.140625 C 0.390625,-0.03125 0.453125,0 0.5,0 0.671875,0 0.90625,-0.03125 1.09375,-0.03125 1.3125,-0.03125 1.609375,0 1.8125,0 1.84375,0 1.953125,0 1.953125,-0.15625 1.953125,-0.25 1.859375,-0.25 1.828125,-0.25 1.78125,-0.265625 1.53125,-0.265625 1.53125,-0.453125 c 0,-0.09375 0.0625,-0.203125 0.09375,-0.265625 l 0.5625,-0.875 h 2 L 4.34375,-0.4375 C 4.328125,-0.359375 4.28125,-0.25 3.875,-0.25 c -0.09375,0 -0.1875,0 -0.1875,0.15625 C 3.6875,-0.0625 3.703125,0 3.796875,0 4,0 4.5,-0.03125 4.703125,-0.03125 c 0.125,0 0.28125,0.015625 0.40625,0.015625 C 5.234375,-0.015625 5.375,0 5.5,0 5.59375,0 5.640625,-0.0625 5.640625,-0.140625 5.640625,-0.25 5.5625,-0.25 5.453125,-0.25 c -0.40625,0 -0.421875,-0.0625 -0.4375,-0.21875 l -0.625,-4.3125 C 4.375,-4.921875 4.359375,-4.96875 4.234375,-4.96875 4.09375,-4.96875 4.0625,-4.90625 4,-4.8125 Z m 0.921875,-1 L 3.8125,-4.125 4.140625,-1.84375 Z m 0,0"
-           style="stroke:none;stroke-width:0" />
+           id="id-ebd8507d-6ec7-44c2-bae1-900f8501ba57" />
       </symbol>
     </g>
     <g
        id="id-09854d53-9bcd-4282-b63f-b538f2d1feee-5">
       <symbol
-         overflow="visible"
-         id="id-4f3ca652-6c58-4137-bc28-d0cbc568f46f-4">
+         id="id-4f3ca652-6c58-4137-bc28-d0cbc568f46f-4"
+         overflow="visible">
         <path
-           style="stroke:none;stroke-width:0"
+           id="id-8bfe8654-0934-451a-b4ae-454482a32930-1"
            d=""
-           id="id-8bfe8654-0934-451a-b4ae-454482a32930-1" />
+           style="stroke:none;stroke-width:0" />
       </symbol>
       <symbol
-         overflow="visible"
-         id="id-38597e5d-c100-4999-b031-8236bd39207e-7">
+         id="id-38597e5d-c100-4999-b031-8236bd39207e-7"
+         overflow="visible">
         <path
-           style="stroke:none;stroke-width:0"
+           id="id-62872e79-6c93-445a-8b47-d365e7c05ef2-4"
            d="M 3.734375,-6.03125 C 3.8125,-6.390625 3.84375,-6.5 4.78125,-6.5 c 0.296875,0 0.375,0 0.375,-0.1875 0,-0.125 -0.109375,-0.125 -0.15625,-0.125 -0.328125,0 -1.140625,0.03125 -1.46875,0.03125 -0.296875,0 -1.03125,-0.03125 -1.328125,-0.03125 -0.0625,0 -0.1875,0 -0.1875,0.203125 0,0.109375 0.09375,0.109375 0.28125,0.109375 0.015625,0 0.203125,0 0.375,0.015625 0.171875,0.03125 0.265625,0.03125 0.265625,0.171875 0,0.03125 0,0.0625 -0.03125,0.1875 L 1.5625,-0.78125 c -0.09375,0.390625 -0.109375,0.46875 -0.90625,0.46875 -0.171875,0 -0.265625,0 -0.265625,0.203125 C 0.390625,0 0.484375,0 0.65625,0 h 4.625 C 5.515625,0 5.515625,0 5.578125,-0.171875 L 6.375,-2.328125 c 0.03125,-0.109375 0.03125,-0.125 0.03125,-0.140625 0,-0.03125 -0.03125,-0.109375 -0.109375,-0.109375 -0.09375,0 -0.109375,0.0625 -0.171875,0.21875 -0.34375,0.90625 -0.78125,2.046875 -2.5,2.046875 H 2.6875 c -0.140625,0 -0.171875,0 -0.21875,0 -0.109375,-0.015625 -0.140625,-0.03125 -0.140625,-0.109375 0,-0.03125 0,-0.046875 0.046875,-0.21875 z m 0,0"
-           id="id-62872e79-6c93-445a-8b47-d365e7c05ef2-4" />
+           style="stroke:none;stroke-width:0" />
       </symbol>
       <symbol
-         overflow="visible"
-         id="id-13b81b6b-d6f8-40db-b902-49ff0f45c9f1-8">
+         id="id-13b81b6b-d6f8-40db-b902-49ff0f45c9f1-8"
+         overflow="visible">
         <path
-           style="stroke:none;stroke-width:0"
+           id="id-67ce64d1-5e28-4578-9b60-714fc3464c37-4"
            d=""
-           id="id-67ce64d1-5e28-4578-9b60-714fc3464c37-4" />
+           style="stroke:none;stroke-width:0" />
       </symbol>
       <symbol
-         overflow="visible"
-         id="id-1b0ffc1c-7de8-4164-bf7a-1a75f7a580a3-1">
+         id="id-1b0ffc1c-7de8-4164-bf7a-1a75f7a580a3-1"
+         overflow="visible">
         <path
-           style="stroke:none;stroke-width:0"
+           id="id-704a71ff-0a36-4541-b203-45ab579188e1-4"
            d="m 2.328125,-4.4375 c 0,-0.1875 0,-0.1875 -0.203125,-0.1875 -0.453125,0.4375 -1.078125,0.4375 -1.359375,0.4375 v 0.25 c 0.15625,0 0.625,0 1,-0.1875 v 3.546875 c 0,0.234375 0,0.328125 -0.6875,0.328125 H 0.8125 V 0 c 0.125,0 0.984375,-0.03125 1.234375,-0.03125 0.21875,0 1.09375,0.03125 1.25,0.03125 V -0.25 H 3.03125 c -0.703125,0 -0.703125,-0.09375 -0.703125,-0.328125 z m 0,0"
-           id="id-704a71ff-0a36-4541-b203-45ab579188e1-4" />
+           style="stroke:none;stroke-width:0" />
       </symbol>
     </g>
   </defs>
   <sodipodi:namedview
-     inkscape:window-maximized="1"
-     inkscape:window-y="-8"
-     inkscape:window-x="-8"
-     inkscape:window-height="705"
-     inkscape:window-width="1366"
-     showgrid="false"
-     inkscape:document-rotation="0"
-     inkscape:current-layer="layer1"
-     inkscape:document-units="mm"
-     inkscape:cy="148.15455"
-     inkscape:cx="46.337475"
-     inkscape:zoom="1.4"
-     inkscape:pageshadow="2"
-     inkscape:pageopacity="0.0"
-     borderopacity="1.0"
-     bordercolor="#666666"
+     id="base"
      pagecolor="#ffffff"
-     id="base" />
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="1.4"
+     inkscape:cx="46.337475"
+     inkscape:cy="148.15455"
+     inkscape:document-units="mm"
+     inkscape:current-layer="layer1"
+     inkscape:document-rotation="0"
+     showgrid="false"
+     inkscape:window-width="1920"
+     inkscape:window-height="1017"
+     inkscape:window-x="1272"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1" />
   <metadata
      id="metadata1288">
     <rdf:RDF>
@@ -264,562 +264,404 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
+        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
   <g
-     id="layer1"
+     inkscape:label="Layer 1"
      inkscape:groupmode="layer"
-     inkscape:label="Layer 1">
+     id="layer1">
     <path
-       id="path851"
+       style="fill:#cccccc;stroke:#000000;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
        d="M 19.36117,76.623705 H 39.986139 V 36.623702 l -20.624969,2e-6 z"
-       style="fill:#cccccc;stroke:#000000;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+       id="path851" />
     <path
-       id="path853"
+       style="fill:#f2f2f2;stroke:#000000;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
        d="m 19.36117,36.623704 11.270535,-19.999998 20.624967,-10e-7 -11.270533,19.999999 z"
-       style="fill:#f2f2f2;stroke:#000000;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+       id="path853" />
     <path
-       id="path855"
+       style="fill:#b3b3b3;stroke:#000000;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
        d="M 51.256672,16.623706 V 56.623702 L 39.986139,76.623705 V 36.623704 Z"
-       style="fill:#b3b3b3;stroke:#000000;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+       id="path855" />
     <path
-       sodipodi:nodetypes="cscc"
-       id="path857"
+       style="fill:none;stroke:#000000;stroke-width:0.264999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#Arrow1Mend)"
        d="m 57.992998,22.90551 c 0,0 -2.494565,-0.140833 -4.040211,2.801808 -1.118029,2.128532 0.934977,4.123198 -2.502249,6.00267 l -3.317989,0.209044"
-       style="fill:none;stroke:#000000;stroke-width:0.264999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#Arrow1Mend)" />
+       id="path857"
+       sodipodi:nodetypes="cscc" />
     <g
-       transform="matrix(0.455388,0,0,0.455388,58.17228,23.754967)"
-       ns1:version="1.7.1"
-       ns1:texconverter="pdflatex"
-       ns1:pdfconverter="inkscape"
-       ns1:text="$A$"
-       ns1:preamble="C:\Users\Martin Johnson\AppData\Roaming\inkscape\extensions\textext\default_packages.tex"
-       ns1:scale="1.290863076901474"
-       ns1:alignment="middle center"
-       ns1:stroke-to-path="0"
+       id="g1198"
        ns1:jacobian_sqrt="0.455388"
-       id="g1198">
+       ns1:stroke-to-path="0"
+       ns1:alignment="middle center"
+       ns1:scale="1.290863076901474"
+       ns1:preamble="C:\Users\Martin Johnson\AppData\Roaming\inkscape\extensions\textext\default_packages.tex"
+       ns1:text="$A$"
+       ns1:pdfconverter="inkscape"
+       ns1:texconverter="pdflatex"
+       ns1:version="1.7.1"
+       transform="matrix(0.455388,0,0,0.455388,58.17228,23.754967)">
       <defs
          id="id-7d94964a-9e98-43ed-a760-649e85202a82">
         <g
            id="g2126">
           <symbol
-             id="symbol2120"
-             overflow="visible">
+             overflow="visible"
+             id="symbol2120">
             <path
-               id="path2118"
+               style="stroke:none;stroke-width:0"
                d=""
-               style="stroke:none;stroke-width:0" />
+               id="path2118" />
           </symbol>
           <symbol
-             id="symbol2124"
-             overflow="visible">
+             overflow="visible"
+             id="symbol2124">
             <path
-               id="path2122"
+               style="stroke:none;stroke-width:0"
                d="M 1.78125,-1.140625 C 1.390625,-0.484375 1,-0.34375 0.5625,-0.3125 0.4375,-0.296875 0.34375,-0.296875 0.34375,-0.109375 0.34375,-0.046875 0.40625,0 0.484375,0 0.75,0 1.0625,-0.03125 1.328125,-0.03125 c 0.34375,0 0.6875,0.03125 1,0.03125 0.0625,0 0.1875,0 0.1875,-0.1875 0,-0.109375 -0.078125,-0.125 -0.15625,-0.125 -0.21875,-0.015625 -0.46875,-0.09375 -0.46875,-0.34375 0,-0.125 0.0625,-0.234375 0.140625,-0.375 l 0.765625,-1.265625 h 2.5 c 0.015625,0.203125 0.15625,1.5625 0.15625,1.65625 0,0.296875 -0.515625,0.328125 -0.71875,0.328125 C 4.59375,-0.3125 4.5,-0.3125 4.5,-0.109375 4.5,0 4.609375,0 4.640625,0 5.046875,0 5.46875,-0.03125 5.875,-0.03125 6.125,-0.03125 6.765625,0 7.015625,0 7.0625,0 7.1875,0 7.1875,-0.203125 7.1875,-0.3125 7.09375,-0.3125 6.953125,-0.3125 6.34375,-0.3125 6.34375,-0.375 6.3125,-0.671875 l -0.609375,-6.21875 c -0.015625,-0.203125 -0.015625,-0.25 -0.1875,-0.25 -0.15625,0 -0.203125,0.078125 -0.265625,0.171875 z M 2.984375,-2.609375 4.9375,-5.90625 5.265625,-2.609375 Z m 0,0"
-               style="stroke:none;stroke-width:0" />
+               id="path2122" />
           </symbol>
         </g>
       </defs>
       <g
-         transform="translate(-149.056,-127.624)"
-         id="id-a13a9b98-881c-4871-b0c6-f75bedffde80">
+         id="id-a13a9b98-881c-4871-b0c6-f75bedffde80"
+         transform="translate(-149.056,-127.624)">
         <g
-           id="id-61c673b5-10c3-4c9c-8ac3-30aa07130702"
-           style="fill:#000000;fill-opacity:1">
+           style="fill:#000000;fill-opacity:1"
+           id="id-61c673b5-10c3-4c9c-8ac3-30aa07130702">
           <g
-             transform="translate(148.712,134.765)"
-             id="g1194">
+             id="g1194"
+             transform="translate(148.712,134.765)">
             <path
-               id="id-54605547-751f-4a85-9fbc-4ead4cf4314d"
+               style="stroke:none;stroke-width:0"
                d="M 1.78125,-1.140625 C 1.390625,-0.484375 1,-0.34375 0.5625,-0.3125 0.4375,-0.296875 0.34375,-0.296875 0.34375,-0.109375 0.34375,-0.046875 0.40625,0 0.484375,0 0.75,0 1.0625,-0.03125 1.328125,-0.03125 c 0.34375,0 0.6875,0.03125 1,0.03125 0.0625,0 0.1875,0 0.1875,-0.1875 0,-0.109375 -0.078125,-0.125 -0.15625,-0.125 -0.21875,-0.015625 -0.46875,-0.09375 -0.46875,-0.34375 0,-0.125 0.0625,-0.234375 0.140625,-0.375 l 0.765625,-1.265625 h 2.5 c 0.015625,0.203125 0.15625,1.5625 0.15625,1.65625 0,0.296875 -0.515625,0.328125 -0.71875,0.328125 C 4.59375,-0.3125 4.5,-0.3125 4.5,-0.109375 4.5,0 4.609375,0 4.640625,0 5.046875,0 5.46875,-0.03125 5.875,-0.03125 6.125,-0.03125 6.765625,0 7.015625,0 7.0625,0 7.1875,0 7.1875,-0.203125 7.1875,-0.3125 7.09375,-0.3125 6.953125,-0.3125 6.34375,-0.3125 6.34375,-0.375 6.3125,-0.671875 l -0.609375,-6.21875 c -0.015625,-0.203125 -0.015625,-0.25 -0.1875,-0.25 -0.15625,0 -0.203125,0.078125 -0.265625,0.171875 z M 2.984375,-2.609375 4.9375,-5.90625 5.265625,-2.609375 Z m 0,0"
-               style="stroke:none;stroke-width:0" />
+               id="id-54605547-751f-4a85-9fbc-4ead4cf4314d" />
           </g>
         </g>
       </g>
     </g>
     <path
-       inkscape:transform-center-y="2.2558297"
-       inkscape:transform-center-x="1.2476916"
-       id="path1222"
+       style="fill:none;stroke:#000000;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
        d="m 15.588079,83.319206 2.594152,-4.597141"
-       style="fill:none;stroke:#000000;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+       id="path1222"
+       inkscape:transform-center-x="1.2476916"
+       inkscape:transform-center-y="2.2558297" />
     <g
-       transform="matrix(0.455388,0,0,0.455388,25.683621,79.94644)"
-       ns1:version="1.7.1"
-       ns1:texconverter="pdflatex"
-       ns1:pdfconverter="inkscape"
-       ns1:text="$L$"
-       ns1:preamble="C:\Users\Martin Johnson\AppData\Roaming\inkscape\extensions\textext\default_packages.tex"
-       ns1:scale="1.290863076901474"
-       ns1:alignment="middle center"
-       ns1:stroke-to-path="0"
+       id="g1286"
        ns1:jacobian_sqrt="0.455388"
-       id="g1286">
+       ns1:stroke-to-path="0"
+       ns1:alignment="middle center"
+       ns1:scale="1.290863076901474"
+       ns1:preamble="C:\Users\Martin Johnson\AppData\Roaming\inkscape\extensions\textext\default_packages.tex"
+       ns1:text="$L$"
+       ns1:pdfconverter="inkscape"
+       ns1:texconverter="pdflatex"
+       ns1:version="1.7.1"
+       transform="matrix(0.455388,0,0,0.455388,25.683621,79.94644)">
       <defs
          id="id-076584bf-fa76-4040-8ff7-55a2f1beeca0">
         <g
            id="g2143">
           <symbol
-             id="symbol2137"
-             overflow="visible">
+             overflow="visible"
+             id="symbol2137">
             <path
-               id="path2135"
+               style="stroke:none;stroke-width:0"
                d=""
-               style="stroke:none;stroke-width:0" />
+               id="path2135" />
           </symbol>
           <symbol
-             id="symbol2141"
-             overflow="visible">
+             overflow="visible"
+             id="symbol2141">
             <path
-               id="path2139"
+               style="stroke:none;stroke-width:0"
                d="M 3.734375,-6.03125 C 3.8125,-6.390625 3.84375,-6.5 4.78125,-6.5 c 0.296875,0 0.375,0 0.375,-0.1875 0,-0.125 -0.109375,-0.125 -0.15625,-0.125 -0.328125,0 -1.140625,0.03125 -1.46875,0.03125 -0.296875,0 -1.03125,-0.03125 -1.328125,-0.03125 -0.0625,0 -0.1875,0 -0.1875,0.203125 0,0.109375 0.09375,0.109375 0.28125,0.109375 0.015625,0 0.203125,0 0.375,0.015625 0.171875,0.03125 0.265625,0.03125 0.265625,0.171875 0,0.03125 0,0.0625 -0.03125,0.1875 L 1.5625,-0.78125 c -0.09375,0.390625 -0.109375,0.46875 -0.90625,0.46875 -0.171875,0 -0.265625,0 -0.265625,0.203125 C 0.390625,0 0.484375,0 0.65625,0 h 4.625 C 5.515625,0 5.515625,0 5.578125,-0.171875 L 6.375,-2.328125 c 0.03125,-0.109375 0.03125,-0.125 0.03125,-0.140625 0,-0.03125 -0.03125,-0.109375 -0.109375,-0.109375 -0.09375,0 -0.109375,0.0625 -0.171875,0.21875 -0.34375,0.90625 -0.78125,2.046875 -2.5,2.046875 H 2.6875 c -0.140625,0 -0.171875,0 -0.21875,0 -0.109375,-0.015625 -0.140625,-0.03125 -0.140625,-0.109375 0,-0.03125 0,-0.046875 0.046875,-0.21875 z m 0,0"
-               style="stroke:none;stroke-width:0" />
+               id="path2139" />
           </symbol>
         </g>
       </defs>
       <g
-         transform="translate(-149.103,-127.953)"
-         id="id-9d2976fa-8d47-483d-8f5e-0e31fdf3b8ac">
+         id="id-9d2976fa-8d47-483d-8f5e-0e31fdf3b8ac"
+         transform="translate(-149.103,-127.953)">
         <g
-           id="id-420bd919-1503-4b0b-a232-7b794739260e"
-           style="fill:#000000;fill-opacity:1">
+           style="fill:#000000;fill-opacity:1"
+           id="id-420bd919-1503-4b0b-a232-7b794739260e">
           <g
-             transform="translate(148.712,134.765)"
-             id="g1282">
+             id="g1282"
+             transform="translate(148.712,134.765)">
             <path
-               id="id-4ae106a8-a55e-481f-8e36-f5cbd23be3a9"
+               style="stroke:none;stroke-width:0"
                d="M 3.734375,-6.03125 C 3.8125,-6.390625 3.84375,-6.5 4.78125,-6.5 c 0.296875,0 0.375,0 0.375,-0.1875 0,-0.125 -0.109375,-0.125 -0.15625,-0.125 -0.328125,0 -1.140625,0.03125 -1.46875,0.03125 -0.296875,0 -1.03125,-0.03125 -1.328125,-0.03125 -0.0625,0 -0.1875,0 -0.1875,0.203125 0,0.109375 0.09375,0.109375 0.28125,0.109375 0.015625,0 0.203125,0 0.375,0.015625 0.171875,0.03125 0.265625,0.03125 0.265625,0.171875 0,0.03125 0,0.0625 -0.03125,0.1875 L 1.5625,-0.78125 c -0.09375,0.390625 -0.109375,0.46875 -0.90625,0.46875 -0.171875,0 -0.265625,0 -0.265625,0.203125 C 0.390625,0 0.484375,0 0.65625,0 h 4.625 C 5.515625,0 5.515625,0 5.578125,-0.171875 L 6.375,-2.328125 c 0.03125,-0.109375 0.03125,-0.125 0.03125,-0.140625 0,-0.03125 -0.03125,-0.109375 -0.109375,-0.109375 -0.09375,0 -0.109375,0.0625 -0.171875,0.21875 -0.34375,0.90625 -0.78125,2.046875 -2.5,2.046875 H 2.6875 c -0.140625,0 -0.171875,0 -0.21875,0 -0.109375,-0.015625 -0.140625,-0.03125 -0.140625,-0.109375 0,-0.03125 0,-0.046875 0.046875,-0.21875 z m 0,0"
-               style="stroke:none;stroke-width:0" />
+               id="id-4ae106a8-a55e-481f-8e36-f5cbd23be3a9" />
           </g>
         </g>
       </g>
     </g>
     <path
-       id="path1313"
+       style="fill:none;stroke:#000000;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
        d="M 16.636255,81.459174 H 25.10046"
+       id="path1313" />
+    <path
+       id="path1313-7"
+       d="m 28.797019,81.459177 h 8.464206"
        style="fill:none;stroke:#000000;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     <path
-       style="fill:none;stroke:#000000;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       d="m 28.797019,81.459177 h 8.464206"
-       id="path1313-7" />
-    <path
-       style="fill:none;stroke:#000000;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       d="m 36.210861,83.3168 2.594152,-4.59714"
-       id="path1222-9"
+       inkscape:transform-center-y="2.2558297"
        inkscape:transform-center-x="1.2476916"
-       inkscape:transform-center-y="2.2558297" />
+       id="path1222-9"
+       d="m 36.210861,83.3168 2.594152,-4.59714"
+       style="fill:none;stroke:#000000;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     <g
-       transform="matrix(0.455388,0,0,0.455388,28.31641,49.081048)"
-       ns1:version="1.7.1"
-       ns1:texconverter="pdflatex"
-       ns1:pdfconverter="inkscape"
-       ns1:text="$k$"
-       ns1:preamble="C:\Users\Martin Johnson\AppData\Roaming\inkscape\extensions\textext\default_packages.tex"
-       ns1:scale="1.290863076901474"
-       ns1:alignment="middle center"
-       ns1:stroke-to-path="0"
+       id="g1404"
        ns1:jacobian_sqrt="0.455388"
-       id="g1404">
+       ns1:stroke-to-path="0"
+       ns1:alignment="middle center"
+       ns1:scale="1.290863076901474"
+       ns1:preamble="C:\Users\Martin Johnson\AppData\Roaming\inkscape\extensions\textext\default_packages.tex"
+       ns1:text="$k$"
+       ns1:pdfconverter="inkscape"
+       ns1:texconverter="pdflatex"
+       ns1:version="1.7.1"
+       transform="matrix(0.455388,0,0,0.455388,28.31641,49.081048)">
       <defs
          id="id-ec3d1d84-5f6f-4c88-8059-e1335b4d77f1">
         <g
            id="g2162">
           <symbol
-             id="symbol2156"
-             overflow="visible">
+             overflow="visible"
+             id="symbol2156">
             <path
-               id="path2154"
+               style="stroke:none;stroke-width:0"
                d=""
-               style="stroke:none;stroke-width:0" />
+               id="path2154" />
           </symbol>
           <symbol
-             id="symbol2160"
-             overflow="visible">
+             overflow="visible"
+             id="symbol2160">
             <path
-               id="path2158"
+               style="stroke:none;stroke-width:0"
                d="m 2.859375,-6.8125 c 0,0 0,-0.109375 -0.125,-0.109375 -0.234375,0 -0.953125,0.078125 -1.21875,0.109375 -0.078125,0 -0.1875,0.015625 -0.1875,0.1875 0,0.125 0.09375,0.125 0.234375,0.125 0.484375,0 0.5,0.0625 0.5,0.171875 L 2.03125,-6.125 0.59375,-0.390625 c -0.046875,0.140625 -0.046875,0.15625 -0.046875,0.21875 0,0.234375 0.203125,0.28125 0.296875,0.28125 0.125,0 0.265625,-0.09375 0.328125,-0.203125 0.046875,-0.09375 0.5,-1.9375 0.5625,-2.1875 0.34375,0.03125 1.15625,0.1875 1.15625,0.84375 0,0.078125 0,0.109375 -0.03125,0.21875 -0.015625,0.109375 -0.03125,0.234375 -0.03125,0.34375 0,0.578125 0.390625,0.984375 0.90625,0.984375 0.296875,0 0.578125,-0.15625 0.796875,-0.53125 0.25,-0.4375 0.359375,-0.984375 0.359375,-1 0,-0.109375 -0.09375,-0.109375 -0.125,-0.109375 -0.09375,0 -0.109375,0.046875 -0.140625,0.1875 -0.203125,0.71875 -0.421875,1.234375 -0.859375,1.234375 -0.203125,0 -0.328125,-0.109375 -0.328125,-0.46875 0,-0.171875 0.046875,-0.40625 0.078125,-0.5625 C 3.5625,-1.3125 3.5625,-1.34375 3.5625,-1.453125 3.5625,-2.09375 2.9375,-2.375 2.078125,-2.5 2.390625,-2.671875 2.71875,-2.984375 2.9375,-3.234375 3.421875,-3.765625 3.875,-4.1875 4.359375,-4.1875 c 0.0625,0 0.078125,0 0.09375,0.015625 0.125,0.015625 0.125,0.015625 0.21875,0.078125 0.015625,0 0.015625,0.015625 0.03125,0.03125 -0.46875,0.03125 -0.5625,0.421875 -0.5625,0.546875 0,0.15625 0.109375,0.34375 0.375,0.34375 0.265625,0 0.546875,-0.21875 0.546875,-0.609375 0,-0.296875 -0.234375,-0.625 -0.671875,-0.625 -0.28125,0 -0.734375,0.078125 -1.453125,0.875 -0.34375,0.375 -0.734375,0.78125 -1.109375,0.921875 z m 0,0"
-               style="stroke:none;stroke-width:0" />
+               id="path2158" />
           </symbol>
         </g>
       </defs>
       <g
-         transform="translate(-149.259,-127.843)"
-         id="id-755ad5f4-668f-47e4-a0f4-98da2681f440">
+         id="id-755ad5f4-668f-47e4-a0f4-98da2681f440"
+         transform="translate(-149.259,-127.843)">
         <g
-           id="id-46dc9105-103d-424a-92e2-5b3a3a8cdf12"
-           style="fill:#000000;fill-opacity:1">
+           style="fill:#000000;fill-opacity:1"
+           id="id-46dc9105-103d-424a-92e2-5b3a3a8cdf12">
           <g
-             transform="translate(148.712,134.765)"
-             id="g1400">
+             id="g1400"
+             transform="translate(148.712,134.765)">
             <path
-               id="id-9cd05b4b-5d17-403e-9a5c-d83371a2d183"
+               style="stroke:none;stroke-width:0"
                d="m 2.859375,-6.8125 c 0,0 0,-0.109375 -0.125,-0.109375 -0.234375,0 -0.953125,0.078125 -1.21875,0.109375 -0.078125,0 -0.1875,0.015625 -0.1875,0.1875 0,0.125 0.09375,0.125 0.234375,0.125 0.484375,0 0.5,0.0625 0.5,0.171875 L 2.03125,-6.125 0.59375,-0.390625 c -0.046875,0.140625 -0.046875,0.15625 -0.046875,0.21875 0,0.234375 0.203125,0.28125 0.296875,0.28125 0.125,0 0.265625,-0.09375 0.328125,-0.203125 0.046875,-0.09375 0.5,-1.9375 0.5625,-2.1875 0.34375,0.03125 1.15625,0.1875 1.15625,0.84375 0,0.078125 0,0.109375 -0.03125,0.21875 -0.015625,0.109375 -0.03125,0.234375 -0.03125,0.34375 0,0.578125 0.390625,0.984375 0.90625,0.984375 0.296875,0 0.578125,-0.15625 0.796875,-0.53125 0.25,-0.4375 0.359375,-0.984375 0.359375,-1 0,-0.109375 -0.09375,-0.109375 -0.125,-0.109375 -0.09375,0 -0.109375,0.046875 -0.140625,0.1875 -0.203125,0.71875 -0.421875,1.234375 -0.859375,1.234375 -0.203125,0 -0.328125,-0.109375 -0.328125,-0.46875 0,-0.171875 0.046875,-0.40625 0.078125,-0.5625 C 3.5625,-1.3125 3.5625,-1.34375 3.5625,-1.453125 3.5625,-2.09375 2.9375,-2.375 2.078125,-2.5 2.390625,-2.671875 2.71875,-2.984375 2.9375,-3.234375 3.421875,-3.765625 3.875,-4.1875 4.359375,-4.1875 c 0.0625,0 0.078125,0 0.09375,0.015625 0.125,0.015625 0.125,0.015625 0.21875,0.078125 0.015625,0 0.015625,0.015625 0.03125,0.03125 -0.46875,0.03125 -0.5625,0.421875 -0.5625,0.546875 0,0.15625 0.109375,0.34375 0.375,0.34375 0.265625,0 0.546875,-0.21875 0.546875,-0.609375 0,-0.296875 -0.234375,-0.625 -0.671875,-0.625 -0.28125,0 -0.734375,0.078125 -1.453125,0.875 -0.34375,0.375 -0.734375,0.78125 -1.109375,0.921875 z m 0,0"
-               style="stroke:none;stroke-width:0" />
+               id="id-9cd05b4b-5d17-403e-9a5c-d83371a2d183" />
           </g>
         </g>
       </g>
     </g>
     <g
-       transform="matrix(0.455388,0,0,0.455388,29.337083,5.8179906)"
-       ns1:version="1.7.1"
-       ns1:texconverter="pdflatex"
-       ns1:pdfconverter="inkscape"
-       ns1:text="$R_\\mathrm{p} = \\frac{L}{kA}$"
-       ns1:preamble="C:\Users\Martin Johnson\AppData\Roaming\inkscape\extensions\textext\default_packages.tex"
-       ns1:scale="1.290863076901474"
-       ns1:alignment="middle center"
-       ns1:stroke-to-path="0"
+       id="g1537"
        ns1:jacobian_sqrt="0.455388"
-       id="g1537">
+       ns1:stroke-to-path="0"
+       ns1:alignment="middle center"
+       ns1:scale="1.290863076901474"
+       ns1:preamble="C:\Users\Martin Johnson\AppData\Roaming\inkscape\extensions\textext\default_packages.tex"
+       ns1:text="$R_\\mathrm{p} = \\frac{L}{kA}$"
+       ns1:pdfconverter="inkscape"
+       ns1:texconverter="pdflatex"
+       ns1:version="1.7.1"
+       transform="matrix(0.455388,0,0,0.455388,29.337083,5.8179906)">
       <defs
          id="id-60999a2d-bb44-4e89-9c30-438b8af01f89">
         <g
            id="g2210">
           <symbol
-             id="symbol2172"
-             overflow="visible">
+             overflow="visible"
+             id="symbol2172">
             <path
-               id="path2170"
+               style="stroke:none;stroke-width:0"
                d=""
-               style="stroke:none;stroke-width:0" />
+               id="path2170" />
           </symbol>
           <symbol
-             id="symbol2176"
-             overflow="visible">
+             overflow="visible"
+             id="symbol2176">
             <path
-               id="path2174"
+               style="stroke:none;stroke-width:0"
                d="m 3.734375,-6.125 c 0.0625,-0.234375 0.09375,-0.328125 0.28125,-0.359375 C 4.109375,-6.5 4.421875,-6.5 4.625,-6.5 c 0.703125,0 1.8125,0 1.8125,0.984375 0,0.34375 -0.15625,1.03125 -0.546875,1.421875 -0.265625,0.25 -0.78125,0.578125 -1.6875,0.578125 H 3.09375 Z m 1.4375,2.734375 c 1.015625,-0.21875 2.1875,-0.921875 2.1875,-1.921875 0,-0.859375 -0.890625,-1.5 -2.203125,-1.5 H 2.328125 c -0.203125,0 -0.296875,0 -0.296875,0.203125 C 2.03125,-6.5 2.125,-6.5 2.3125,-6.5 c 0.015625,0 0.203125,0 0.375,0.015625 0.1875,0.03125 0.265625,0.03125 0.265625,0.171875 0,0.03125 0,0.0625 -0.03125,0.1875 l -1.34375,5.34375 C 1.484375,-0.390625 1.46875,-0.3125 0.671875,-0.3125 0.5,-0.3125 0.40625,-0.3125 0.40625,-0.109375 0.40625,0 0.53125,0 0.546875,0 c 0.28125,0 0.984375,-0.03125 1.25,-0.03125 0.28125,0 1,0.03125 1.28125,0.03125 0.078125,0 0.1875,0 0.1875,-0.203125 0,-0.109375 -0.078125,-0.109375 -0.28125,-0.109375 -0.359375,0 -0.640625,0 -0.640625,-0.171875 0,-0.0625 0.015625,-0.109375 0.03125,-0.171875 l 0.65625,-2.640625 h 1.1875 c 0.90625,0 1.078125,0.5625 1.078125,0.90625 0,0.140625 -0.078125,0.453125 -0.140625,0.6875 C 5.09375,-1.421875 5,-1.0625 5,-0.859375 5,0.21875 6.203125,0.21875 6.328125,0.21875 c 0.84375,0 1.203125,-1 1.203125,-1.140625 0,-0.125 -0.109375,-0.125 -0.125,-0.125 -0.09375,0 -0.109375,0.0625 -0.125,0.140625 C 7.03125,-0.171875 6.59375,0 6.375,0 6.046875,0 5.96875,-0.21875 5.96875,-0.609375 c 0,-0.3125 0.0625,-0.8125 0.109375,-1.140625 0.015625,-0.140625 0.03125,-0.328125 0.03125,-0.46875 0,-0.765625 -0.671875,-1.078125 -0.9375,-1.171875 z m 0,0"
-               style="stroke:none;stroke-width:0" />
+               id="path2174" />
           </symbol>
           <symbol
-             id="symbol2180"
-             overflow="visible">
+             overflow="visible"
+             id="symbol2180">
             <path
-               id="path2178"
+               style="stroke:none;stroke-width:0"
                d=""
-               style="stroke:none;stroke-width:0" />
+               id="path2178" />
           </symbol>
           <symbol
-             id="symbol2184"
-             overflow="visible">
+             overflow="visible"
+             id="symbol2184">
             <path
-               id="path2182"
+               style="stroke:none;stroke-width:0"
                d="m 1.9375,1.09375 c -0.453125,0 -0.515625,0 -0.515625,-0.296875 v -1.125 C 1.453125,-0.296875 1.78125,0.0625 2.359375,0.0625 3.28125,0.0625 4.0625,-0.625 4.0625,-1.5 c 0,-0.859375 -0.703125,-1.578125 -1.59375,-1.578125 -0.390625,0 -0.796875,0.15625 -1.078125,0.4375 v -0.4375 L 0.34375,-3 v 0.25 c 0.484375,0 0.515625,0.046875 0.515625,0.328125 v 3.21875 c 0,0.296875 -0.0625,0.296875 -0.515625,0.296875 v 0.265625 c 0.015625,0 0.5,-0.03125 0.796875,-0.03125 0.25,0 0.734375,0.015625 0.796875,0.03125 z M 1.421875,-2.328125 C 1.625,-2.671875 2.03125,-2.84375 2.390625,-2.84375 c 0.59375,0 1.046875,0.609375 1.046875,1.34375 0,0.796875 -0.53125,1.375 -1.109375,1.375 -0.625,0 -0.890625,-0.53125 -0.90625,-0.578125 z m 0,0"
-               style="stroke:none;stroke-width:0" />
+               id="path2182" />
           </symbol>
           <symbol
-             id="symbol2188"
-             overflow="visible">
+             overflow="visible"
+             id="symbol2188">
             <path
-               id="path2186"
+               style="stroke:none;stroke-width:0"
                d=""
-               style="stroke:none;stroke-width:0" />
+               id="path2186" />
           </symbol>
           <symbol
-             id="symbol2192"
-             overflow="visible">
+             overflow="visible"
+             id="symbol2192">
             <path
-               id="path2190"
+               style="stroke:none;stroke-width:0"
                d="m 6.84375,-3.265625 c 0.15625,0 0.34375,0 0.34375,-0.1875 C 7.1875,-3.65625 7,-3.65625 6.859375,-3.65625 h -5.96875 c -0.140625,0 -0.328125,0 -0.328125,0.203125 0,0.1875 0.1875,0.1875 0.328125,0.1875 z m 0.015625,1.9375 c 0.140625,0 0.328125,0 0.328125,-0.203125 0,-0.1875 -0.1875,-0.1875 -0.34375,-0.1875 H 0.890625 c -0.140625,0 -0.328125,0 -0.328125,0.1875 0,0.203125 0.1875,0.203125 0.328125,0.203125 z m 0,0"
-               style="stroke:none;stroke-width:0" />
+               id="path2190" />
           </symbol>
           <symbol
-             id="symbol2196"
-             overflow="visible">
+             overflow="visible"
+             id="symbol2196">
             <path
-               id="path2194"
+               style="stroke:none;stroke-width:0"
                d=""
-               style="stroke:none;stroke-width:0" />
+               id="path2194" />
           </symbol>
           <symbol
-             id="symbol2200"
-             overflow="visible">
+             overflow="visible"
+             id="symbol2200">
             <path
-               id="path2198"
+               style="stroke:none;stroke-width:0"
                d="m 2.875,-4.1875 c 0.0625,-0.25 0.078125,-0.328125 0.71875,-0.328125 0.21875,0 0.28125,0 0.28125,-0.140625 0,-0.015625 0,-0.109375 -0.109375,-0.109375 -0.15625,0 -0.34375,0.015625 -0.515625,0.03125 -0.171875,0 -0.390625,0 -0.5625,0 -0.140625,0 -0.328125,0 -0.484375,0 -0.140625,0 -0.3125,-0.03125 -0.453125,-0.03125 -0.03125,0 -0.140625,0 -0.140625,0.15625 0,0.09375 0.078125,0.09375 0.21875,0.09375 0.015625,0 0.140625,0 0.265625,0.015625 0.15625,0.015625 0.171875,0.03125 0.171875,0.109375 0,0 0,0.046875 -0.03125,0.140625 l -0.9375,3.703125 C 1.234375,-0.3125 1.21875,-0.25 0.6875,-0.25 c -0.109375,0 -0.203125,0 -0.203125,0.140625 C 0.484375,0 0.5625,0 0.6875,0 h 3.5 c 0.1875,0 0.1875,0 0.25,-0.140625 0.0625,-0.1875 0.59375,-1.53125 0.59375,-1.59375 0,-0.015625 -0.015625,-0.09375 -0.125,-0.09375 -0.078125,0 -0.09375,0.03125 -0.140625,0.140625 C 4.5,-1.03125 4.1875,-0.25 2.921875,-0.25 H 2.125 c -0.203125,0 -0.21875,-0.015625 -0.21875,-0.078125 0,0 0,-0.03125 0.03125,-0.140625 z m 0,0"
-               style="stroke:none;stroke-width:0" />
+               id="path2198" />
           </symbol>
           <symbol
-             id="symbol2204"
-             overflow="visible">
+             overflow="visible"
+             id="symbol2204">
             <path
-               id="path2202"
+               style="stroke:none;stroke-width:0"
                d="m 2.1875,-4.625 c 0,-0.015625 0.015625,-0.109375 0.015625,-0.109375 0,-0.046875 -0.015625,-0.109375 -0.109375,-0.109375 -0.140625,0 -0.71875,0.0625 -0.890625,0.078125 -0.046875,0 -0.15625,0.015625 -0.15625,0.15625 0,0.09375 0.109375,0.09375 0.1875,0.09375 0.328125,0 0.328125,0.0625 0.328125,0.109375 0,0.046875 -0.015625,0.09375 -0.015625,0.15625 L 0.5625,-0.3125 c -0.046875,0.125 -0.046875,0.140625 -0.046875,0.15625 0,0.109375 0.09375,0.21875 0.25,0.21875 0.1875,0 0.265625,-0.125 0.3125,-0.28125 0.015625,-0.03125 0.3125,-1.265625 0.34375,-1.359375 0.5,0.046875 0.890625,0.21875 0.890625,0.578125 0,0.03125 0,0.0625 -0.015625,0.140625 -0.03125,0.09375 -0.03125,0.140625 -0.03125,0.21875 0,0.484375 0.40625,0.703125 0.75,0.703125 0.671875,0 0.875,-1.046875 0.875,-1.0625 0,-0.09375 -0.078125,-0.09375 -0.109375,-0.09375 -0.09375,0 -0.109375,0.046875 -0.140625,0.171875 C 3.5625,-0.625 3.375,-0.125 3.03125,-0.125 c -0.1875,0 -0.25,-0.171875 -0.25,-0.359375 0,-0.125 0,-0.140625 0.046875,-0.3125 0.015625,-0.03125 0.03125,-0.140625 0.03125,-0.21875 0,-0.625 -0.828125,-0.71875 -1.125,-0.734375 C 1.9375,-1.875 2.1875,-2.109375 2.3125,-2.21875 2.671875,-2.546875 3.015625,-2.875 3.40625,-2.875 c 0.078125,0 0.171875,0.015625 0.234375,0.09375 C 3.34375,-2.734375 3.28125,-2.5 3.28125,-2.390625 c 0,0.140625 0.109375,0.25 0.265625,0.25 0.203125,0 0.40625,-0.15625 0.40625,-0.4375 0,-0.234375 -0.171875,-0.5 -0.53125,-0.5 -0.40625,0 -0.765625,0.296875 -1.125,0.625 C 2,-2.1875 1.78125,-1.96875 1.484375,-1.84375 Z m 0,0"
-               style="stroke:none;stroke-width:0" />
+               id="path2202" />
           </symbol>
           <symbol
-             id="symbol2208"
-             overflow="visible">
+             overflow="visible"
+             id="symbol2208">
             <path
-               id="path2206"
+               style="stroke:none;stroke-width:0"
                d="m 1.4375,-0.84375 c -0.25,0.390625 -0.46875,0.5625 -0.875,0.59375 -0.078125,0 -0.171875,0 -0.171875,0.140625 C 0.390625,-0.03125 0.453125,0 0.5,0 0.671875,0 0.90625,-0.03125 1.09375,-0.03125 1.3125,-0.03125 1.609375,0 1.8125,0 1.84375,0 1.953125,0 1.953125,-0.15625 1.953125,-0.25 1.859375,-0.25 1.828125,-0.25 1.78125,-0.265625 1.53125,-0.265625 1.53125,-0.453125 c 0,-0.09375 0.0625,-0.203125 0.09375,-0.265625 l 0.5625,-0.875 h 2 L 4.34375,-0.4375 C 4.328125,-0.359375 4.28125,-0.25 3.875,-0.25 c -0.09375,0 -0.1875,0 -0.1875,0.15625 C 3.6875,-0.0625 3.703125,0 3.796875,0 4,0 4.5,-0.03125 4.703125,-0.03125 c 0.125,0 0.28125,0.015625 0.40625,0.015625 C 5.234375,-0.015625 5.375,0 5.5,0 5.59375,0 5.640625,-0.0625 5.640625,-0.140625 5.640625,-0.25 5.5625,-0.25 5.453125,-0.25 c -0.40625,0 -0.421875,-0.0625 -0.4375,-0.21875 l -0.625,-4.3125 C 4.375,-4.921875 4.359375,-4.96875 4.234375,-4.96875 4.09375,-4.96875 4.0625,-4.90625 4,-4.8125 Z m 0.921875,-1 L 3.8125,-4.125 4.140625,-1.84375 Z m 0,0"
-               style="stroke:none;stroke-width:0" />
+               id="path2206" />
           </symbol>
         </g>
       </defs>
       <g
-         transform="translate(-149.118,-126.076)"
-         id="id-2690b570-7dff-4cf1-9409-7c96216426bf">
+         id="id-2690b570-7dff-4cf1-9409-7c96216426bf"
+         transform="translate(-149.118,-126.076)">
         <g
-           id="id-68218d88-b38e-42ef-9e73-40a9d1b85eda"
-           style="fill:#000000;fill-opacity:1">
+           style="fill:#000000;fill-opacity:1"
+           id="id-68218d88-b38e-42ef-9e73-40a9d1b85eda">
           <g
-             transform="translate(148.712,134.765)"
-             id="g1512">
+             id="g1512"
+             transform="translate(148.712,134.765)">
             <path
-               id="id-fd845bca-105b-4a4d-87ee-064891abfde1"
+               style="stroke:none;stroke-width:0"
                d="m 3.734375,-6.125 c 0.0625,-0.234375 0.09375,-0.328125 0.28125,-0.359375 C 4.109375,-6.5 4.421875,-6.5 4.625,-6.5 c 0.703125,0 1.8125,0 1.8125,0.984375 0,0.34375 -0.15625,1.03125 -0.546875,1.421875 -0.265625,0.25 -0.78125,0.578125 -1.6875,0.578125 H 3.09375 Z m 1.4375,2.734375 c 1.015625,-0.21875 2.1875,-0.921875 2.1875,-1.921875 0,-0.859375 -0.890625,-1.5 -2.203125,-1.5 H 2.328125 c -0.203125,0 -0.296875,0 -0.296875,0.203125 C 2.03125,-6.5 2.125,-6.5 2.3125,-6.5 c 0.015625,0 0.203125,0 0.375,0.015625 0.1875,0.03125 0.265625,0.03125 0.265625,0.171875 0,0.03125 0,0.0625 -0.03125,0.1875 l -1.34375,5.34375 C 1.484375,-0.390625 1.46875,-0.3125 0.671875,-0.3125 0.5,-0.3125 0.40625,-0.3125 0.40625,-0.109375 0.40625,0 0.53125,0 0.546875,0 c 0.28125,0 0.984375,-0.03125 1.25,-0.03125 0.28125,0 1,0.03125 1.28125,0.03125 0.078125,0 0.1875,0 0.1875,-0.203125 0,-0.109375 -0.078125,-0.109375 -0.28125,-0.109375 -0.359375,0 -0.640625,0 -0.640625,-0.171875 0,-0.0625 0.015625,-0.109375 0.03125,-0.171875 l 0.65625,-2.640625 h 1.1875 c 0.90625,0 1.078125,0.5625 1.078125,0.90625 0,0.140625 -0.078125,0.453125 -0.140625,0.6875 C 5.09375,-1.421875 5,-1.0625 5,-0.859375 5,0.21875 6.203125,0.21875 6.328125,0.21875 c 0.84375,0 1.203125,-1 1.203125,-1.140625 0,-0.125 -0.109375,-0.125 -0.125,-0.125 -0.09375,0 -0.109375,0.0625 -0.125,0.140625 C 7.03125,-0.171875 6.59375,0 6.375,0 6.046875,0 5.96875,-0.21875 5.96875,-0.609375 c 0,-0.3125 0.0625,-0.8125 0.109375,-1.140625 0.015625,-0.140625 0.03125,-0.328125 0.03125,-0.46875 0,-0.765625 -0.671875,-1.078125 -0.9375,-1.171875 z m 0,0"
-               style="stroke:none;stroke-width:0" />
+               id="id-fd845bca-105b-4a4d-87ee-064891abfde1" />
           </g>
         </g>
         <g
-           id="id-11a55091-87a9-407e-a44a-ce2e40b924e6"
-           style="fill:#000000;fill-opacity:1">
+           style="fill:#000000;fill-opacity:1"
+           id="id-11a55091-87a9-407e-a44a-ce2e40b924e6">
           <g
-             transform="translate(156.277,136.259)"
-             id="g1516">
+             id="g1516"
+             transform="translate(156.277,136.259)">
             <path
-               id="id-1a9c5037-2463-40d0-9d68-e38573adb667"
+               style="stroke:none;stroke-width:0"
                d="m 1.9375,1.09375 c -0.453125,0 -0.515625,0 -0.515625,-0.296875 v -1.125 C 1.453125,-0.296875 1.78125,0.0625 2.359375,0.0625 3.28125,0.0625 4.0625,-0.625 4.0625,-1.5 c 0,-0.859375 -0.703125,-1.578125 -1.59375,-1.578125 -0.390625,0 -0.796875,0.15625 -1.078125,0.4375 v -0.4375 L 0.34375,-3 v 0.25 c 0.484375,0 0.515625,0.046875 0.515625,0.328125 v 3.21875 c 0,0.296875 -0.0625,0.296875 -0.515625,0.296875 v 0.265625 c 0.015625,0 0.5,-0.03125 0.796875,-0.03125 0.25,0 0.734375,0.015625 0.796875,0.03125 z M 1.421875,-2.328125 C 1.625,-2.671875 2.03125,-2.84375 2.390625,-2.84375 c 0.59375,0 1.046875,0.609375 1.046875,1.34375 0,0.796875 -0.53125,1.375 -1.109375,1.375 -0.625,0 -0.890625,-0.53125 -0.90625,-0.578125 z m 0,0"
-               style="stroke:none;stroke-width:0" />
+               id="id-1a9c5037-2463-40d0-9d68-e38573adb667" />
           </g>
         </g>
         <g
-           id="id-c3803b17-2e55-4ca6-8893-4e340a4f2971"
-           style="fill:#000000;fill-opacity:1">
+           style="fill:#000000;fill-opacity:1"
+           id="id-c3803b17-2e55-4ca6-8893-4e340a4f2971">
           <g
-             transform="translate(163.942,134.765)"
-             id="g1520">
+             id="g1520"
+             transform="translate(163.942,134.765)">
             <path
-               id="id-1bace3f1-ea2b-445c-ae53-704ebe0fc842"
+               style="stroke:none;stroke-width:0"
                d="m 6.84375,-3.265625 c 0.15625,0 0.34375,0 0.34375,-0.1875 C 7.1875,-3.65625 7,-3.65625 6.859375,-3.65625 h -5.96875 c -0.140625,0 -0.328125,0 -0.328125,0.203125 0,0.1875 0.1875,0.1875 0.328125,0.1875 z m 0.015625,1.9375 c 0.140625,0 0.328125,0 0.328125,-0.203125 0,-0.1875 -0.1875,-0.1875 -0.34375,-0.1875 H 0.890625 c -0.140625,0 -0.328125,0 -0.328125,0.1875 0,0.203125 0.1875,0.203125 0.328125,0.203125 z m 0,0"
-               style="stroke:none;stroke-width:0" />
+               id="id-1bace3f1-ea2b-445c-ae53-704ebe0fc842" />
           </g>
         </g>
         <g
-           id="id-1b894180-70b8-4251-89bd-ec2d85212d08"
-           style="fill:#000000;fill-opacity:1">
+           style="fill:#000000;fill-opacity:1"
+           id="id-1b894180-70b8-4251-89bd-ec2d85212d08">
           <g
-             transform="translate(178.119,130.842)"
-             id="g1524">
+             id="g1524"
+             transform="translate(178.119,130.842)">
             <path
-               id="id-12e3178b-79c5-459c-b7ab-730654eb49e9"
+               style="stroke:none;stroke-width:0"
                d="m 2.875,-4.1875 c 0.0625,-0.25 0.078125,-0.328125 0.71875,-0.328125 0.21875,0 0.28125,0 0.28125,-0.140625 0,-0.015625 0,-0.109375 -0.109375,-0.109375 -0.15625,0 -0.34375,0.015625 -0.515625,0.03125 -0.171875,0 -0.390625,0 -0.5625,0 -0.140625,0 -0.328125,0 -0.484375,0 -0.140625,0 -0.3125,-0.03125 -0.453125,-0.03125 -0.03125,0 -0.140625,0 -0.140625,0.15625 0,0.09375 0.078125,0.09375 0.21875,0.09375 0.015625,0 0.140625,0 0.265625,0.015625 0.15625,0.015625 0.171875,0.03125 0.171875,0.109375 0,0 0,0.046875 -0.03125,0.140625 l -0.9375,3.703125 C 1.234375,-0.3125 1.21875,-0.25 0.6875,-0.25 c -0.109375,0 -0.203125,0 -0.203125,0.140625 C 0.484375,0 0.5625,0 0.6875,0 h 3.5 c 0.1875,0 0.1875,0 0.25,-0.140625 0.0625,-0.1875 0.59375,-1.53125 0.59375,-1.59375 0,-0.015625 -0.015625,-0.09375 -0.125,-0.09375 -0.078125,0 -0.09375,0.03125 -0.140625,0.140625 C 4.5,-1.03125 4.1875,-0.25 2.921875,-0.25 H 2.125 c -0.203125,0 -0.21875,-0.015625 -0.21875,-0.078125 0,0 0,-0.03125 0.03125,-0.140625 z m 0,0"
-               style="stroke:none;stroke-width:0" />
+               id="id-12e3178b-79c5-459c-b7ab-730654eb49e9" />
           </g>
         </g>
         <path
-           id="id-b07e44e8-17ea-4d2c-9608-e3bc6b40c5a2"
-           transform="matrix(1,0,0,-1,175.654,132.274)"
+           style="fill:none;stroke:#000000;stroke-width:0.398;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-opacity:1"
            d="M -0.00165625,5.625e-4 H 10.396781"
-           style="fill:none;stroke:#000000;stroke-width:0.398;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-opacity:1" />
+           transform="matrix(1,0,0,-1,175.654,132.274)"
+           id="id-b07e44e8-17ea-4d2c-9608-e3bc6b40c5a2" />
         <g
-           id="id-fc708497-66a8-4c0b-8b30-352532c7c673"
-           style="fill:#000000;fill-opacity:1">
+           style="fill:#000000;fill-opacity:1"
+           id="id-fc708497-66a8-4c0b-8b30-352532c7c673">
           <g
-             transform="translate(175.654,138.2)"
-             id="g1529">
+             id="g1529"
+             transform="translate(175.654,138.2)">
             <path
-               id="id-ff2ec420-9050-48c5-9939-759325896d37"
+               style="stroke:none;stroke-width:0"
                d="m 2.1875,-4.625 c 0,-0.015625 0.015625,-0.109375 0.015625,-0.109375 0,-0.046875 -0.015625,-0.109375 -0.109375,-0.109375 -0.140625,0 -0.71875,0.0625 -0.890625,0.078125 -0.046875,0 -0.15625,0.015625 -0.15625,0.15625 0,0.09375 0.109375,0.09375 0.1875,0.09375 0.328125,0 0.328125,0.0625 0.328125,0.109375 0,0.046875 -0.015625,0.09375 -0.015625,0.15625 L 0.5625,-0.3125 c -0.046875,0.125 -0.046875,0.140625 -0.046875,0.15625 0,0.109375 0.09375,0.21875 0.25,0.21875 0.1875,0 0.265625,-0.125 0.3125,-0.28125 0.015625,-0.03125 0.3125,-1.265625 0.34375,-1.359375 0.5,0.046875 0.890625,0.21875 0.890625,0.578125 0,0.03125 0,0.0625 -0.015625,0.140625 -0.03125,0.09375 -0.03125,0.140625 -0.03125,0.21875 0,0.484375 0.40625,0.703125 0.75,0.703125 0.671875,0 0.875,-1.046875 0.875,-1.0625 0,-0.09375 -0.078125,-0.09375 -0.109375,-0.09375 -0.09375,0 -0.109375,0.046875 -0.140625,0.171875 C 3.5625,-0.625 3.375,-0.125 3.03125,-0.125 c -0.1875,0 -0.25,-0.171875 -0.25,-0.359375 0,-0.125 0,-0.140625 0.046875,-0.3125 0.015625,-0.03125 0.03125,-0.140625 0.03125,-0.21875 0,-0.625 -0.828125,-0.71875 -1.125,-0.734375 C 1.9375,-1.875 2.1875,-2.109375 2.3125,-2.21875 2.671875,-2.546875 3.015625,-2.875 3.40625,-2.875 c 0.078125,0 0.171875,0.015625 0.234375,0.09375 C 3.34375,-2.734375 3.28125,-2.5 3.28125,-2.390625 c 0,0.140625 0.109375,0.25 0.265625,0.25 0.203125,0 0.40625,-0.15625 0.40625,-0.4375 0,-0.234375 -0.171875,-0.5 -0.53125,-0.5 -0.40625,0 -0.765625,0.296875 -1.125,0.625 C 2,-2.1875 1.78125,-1.96875 1.484375,-1.84375 Z m 0,0"
-               style="stroke:none;stroke-width:0" />
+               id="id-ff2ec420-9050-48c5-9939-759325896d37" />
           </g>
         </g>
         <g
-           id="id-e732ea44-67e9-4688-9db6-ae7b28dde8b0"
-           style="fill:#000000;fill-opacity:1">
+           style="fill:#000000;fill-opacity:1"
+           id="id-e732ea44-67e9-4688-9db6-ae7b28dde8b0">
           <g
-             transform="translate(180.057,138.2)"
-             id="g1533">
+             id="g1533"
+             transform="translate(180.057,138.2)">
             <path
-               id="id-414feaac-14f4-4649-93b6-f1ed7bb4efbd"
+               style="stroke:none;stroke-width:0"
                d="m 1.4375,-0.84375 c -0.25,0.390625 -0.46875,0.5625 -0.875,0.59375 -0.078125,0 -0.171875,0 -0.171875,0.140625 C 0.390625,-0.03125 0.453125,0 0.5,0 0.671875,0 0.90625,-0.03125 1.09375,-0.03125 1.3125,-0.03125 1.609375,0 1.8125,0 1.84375,0 1.953125,0 1.953125,-0.15625 1.953125,-0.25 1.859375,-0.25 1.828125,-0.25 1.78125,-0.265625 1.53125,-0.265625 1.53125,-0.453125 c 0,-0.09375 0.0625,-0.203125 0.09375,-0.265625 l 0.5625,-0.875 h 2 L 4.34375,-0.4375 C 4.328125,-0.359375 4.28125,-0.25 3.875,-0.25 c -0.09375,0 -0.1875,0 -0.1875,0.15625 C 3.6875,-0.0625 3.703125,0 3.796875,0 4,0 4.5,-0.03125 4.703125,-0.03125 c 0.125,0 0.28125,0.015625 0.40625,0.015625 C 5.234375,-0.015625 5.375,0 5.5,0 5.59375,0 5.640625,-0.0625 5.640625,-0.140625 5.640625,-0.25 5.5625,-0.25 5.453125,-0.25 c -0.40625,0 -0.421875,-0.0625 -0.4375,-0.21875 l -0.625,-4.3125 C 4.375,-4.921875 4.359375,-4.96875 4.234375,-4.96875 4.09375,-4.96875 4.0625,-4.90625 4,-4.8125 Z m 0.921875,-1 L 3.8125,-4.125 4.140625,-1.84375 Z m 0,0"
-               style="stroke:none;stroke-width:0" />
+               id="id-414feaac-14f4-4649-93b6-f1ed7bb4efbd" />
           </g>
         </g>
       </g>
     </g>
     <path
-       sodipodi:nodetypes="cc"
-       id="path1595"
+       style="fill:none;stroke:#000000;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#marker1599)"
        d="m 8.848372,47.82311 h 10.16756"
-       style="fill:none;stroke:#000000;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#marker1599)" />
+       id="path1595"
+       sodipodi:nodetypes="cc" />
     <path
-       sodipodi:nodetypes="cc"
-       style="fill:none;stroke:#000000;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#marker1599-5)"
+       id="path1595-9"
        d="M 46.630973,47.823113 H 59.444365"
-       id="path1595-9" />
+       style="fill:none;stroke:#000000;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#marker1599-5)"
+       sodipodi:nodetypes="cc" />
     <text
-       id="text1706"
-       y="46.224873"
-       x="60.920074"
+       xml:space="preserve"
        style="font-size:4.23333px;line-height:1.25;font-family:'Latin Modern Math';-inkscape-font-specification:'Latin Modern Math';text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;stroke-width:0.264583"
-       xml:space="preserve"><tspan
-         style="font-size:4.23333px;stroke-width:0.264583"
-         y="46.224873"
-         x="60.920074"
+       x="60.920074"
+       y="46.224873"
+       id="text1706"><tspan
+         sodipodi:role="line"
          id="tspan1704"
-         sodipodi:role="line">Heat flow</tspan></text>
-    <g
-       transform="matrix(0.352778,0,0,0.352778,15.301521,52.054986)"
-       ns1:version="1.7.1"
-       ns1:texconverter="pdflatex"
-       ns1:pdfconverter="inkscape"
-       ns1:text="$L_1$"
-       ns1:preamble="C:\Users\Martin Johnson\AppData\Roaming\inkscape\extensions\textext\default_packages.tex"
-       ns1:scale="1.0000003685037664"
-       ns1:alignment="middle center"
-       ns1:stroke-to-path="0"
-       ns1:jacobian_sqrt="0.352778"
-       id="g2462">
-      <defs
-         id="id-e0018390-c29c-4877-9e72-18f3c9801056">
-        <g
-           id="id-09854d53-9bcd-4282-b63f-b538f2d1feee">
-          <symbol
-             id="id-4f3ca652-6c58-4137-bc28-d0cbc568f46f"
-             overflow="visible">
-            <path
-               id="id-8bfe8654-0934-451a-b4ae-454482a32930"
-               d=""
-               style="stroke:none;stroke-width:0" />
-          </symbol>
-          <symbol
-             id="id-38597e5d-c100-4999-b031-8236bd39207e"
-             overflow="visible">
-            <path
-               id="id-62872e79-6c93-445a-8b47-d365e7c05ef2"
-               d="M 3.734375,-6.03125 C 3.8125,-6.390625 3.84375,-6.5 4.78125,-6.5 c 0.296875,0 0.375,0 0.375,-0.1875 0,-0.125 -0.109375,-0.125 -0.15625,-0.125 -0.328125,0 -1.140625,0.03125 -1.46875,0.03125 -0.296875,0 -1.03125,-0.03125 -1.328125,-0.03125 -0.0625,0 -0.1875,0 -0.1875,0.203125 0,0.109375 0.09375,0.109375 0.28125,0.109375 0.015625,0 0.203125,0 0.375,0.015625 0.171875,0.03125 0.265625,0.03125 0.265625,0.171875 0,0.03125 0,0.0625 -0.03125,0.1875 L 1.5625,-0.78125 c -0.09375,0.390625 -0.109375,0.46875 -0.90625,0.46875 -0.171875,0 -0.265625,0 -0.265625,0.203125 C 0.390625,0 0.484375,0 0.65625,0 h 4.625 C 5.515625,0 5.515625,0 5.578125,-0.171875 L 6.375,-2.328125 c 0.03125,-0.109375 0.03125,-0.125 0.03125,-0.140625 0,-0.03125 -0.03125,-0.109375 -0.109375,-0.109375 -0.09375,0 -0.109375,0.0625 -0.171875,0.21875 -0.34375,0.90625 -0.78125,2.046875 -2.5,2.046875 H 2.6875 c -0.140625,0 -0.171875,0 -0.21875,0 -0.109375,-0.015625 -0.140625,-0.03125 -0.140625,-0.109375 0,-0.03125 0,-0.046875 0.046875,-0.21875 z m 0,0"
-               style="stroke:none;stroke-width:0" />
-          </symbol>
-          <symbol
-             id="id-13b81b6b-d6f8-40db-b902-49ff0f45c9f1"
-             overflow="visible">
-            <path
-               id="id-67ce64d1-5e28-4578-9b60-714fc3464c37"
-               d=""
-               style="stroke:none;stroke-width:0" />
-          </symbol>
-          <symbol
-             id="id-1b0ffc1c-7de8-4164-bf7a-1a75f7a580a3"
-             overflow="visible">
-            <path
-               id="id-704a71ff-0a36-4541-b203-45ab579188e1"
-               d="m 2.328125,-4.4375 c 0,-0.1875 0,-0.1875 -0.203125,-0.1875 -0.453125,0.4375 -1.078125,0.4375 -1.359375,0.4375 v 0.25 c 0.15625,0 0.625,0 1,-0.1875 v 3.546875 c 0,0.234375 0,0.328125 -0.6875,0.328125 H 0.8125 V 0 c 0.125,0 0.984375,-0.03125 1.234375,-0.03125 0.21875,0 1.09375,0.03125 1.25,0.03125 V -0.25 H 3.03125 c -0.703125,0 -0.703125,-0.09375 -0.703125,-0.328125 z m 0,0"
-               style="stroke:none;stroke-width:0" />
-          </symbol>
-        </g>
-      </defs>
-      <g
-         transform="translate(-149.103,-127.953)"
-         id="id-60a5b842-7b98-4720-ae02-4421f31511c0">
-        <g
-           id="id-178755dc-144e-45f3-94fd-079b89f8a1a0"
-           style="fill:#000000;fill-opacity:1">
-          <g
-             transform="translate(148.712,134.765)"
-             id="g2454">
-            <path
-               id="id-acc201bb-9d90-4996-86d2-9d42c705a702"
-               d="M 3.734375,-6.03125 C 3.8125,-6.390625 3.84375,-6.5 4.78125,-6.5 c 0.296875,0 0.375,0 0.375,-0.1875 0,-0.125 -0.109375,-0.125 -0.15625,-0.125 -0.328125,0 -1.140625,0.03125 -1.46875,0.03125 -0.296875,0 -1.03125,-0.03125 -1.328125,-0.03125 -0.0625,0 -0.1875,0 -0.1875,0.203125 0,0.109375 0.09375,0.109375 0.28125,0.109375 0.015625,0 0.203125,0 0.375,0.015625 0.171875,0.03125 0.265625,0.03125 0.265625,0.171875 0,0.03125 0,0.0625 -0.03125,0.1875 L 1.5625,-0.78125 c -0.09375,0.390625 -0.109375,0.46875 -0.90625,0.46875 -0.171875,0 -0.265625,0 -0.265625,0.203125 C 0.390625,0 0.484375,0 0.65625,0 h 4.625 C 5.515625,0 5.515625,0 5.578125,-0.171875 L 6.375,-2.328125 c 0.03125,-0.109375 0.03125,-0.125 0.03125,-0.140625 0,-0.03125 -0.03125,-0.109375 -0.109375,-0.109375 -0.09375,0 -0.109375,0.0625 -0.171875,0.21875 -0.34375,0.90625 -0.78125,2.046875 -2.5,2.046875 H 2.6875 c -0.140625,0 -0.171875,0 -0.21875,0 -0.109375,-0.015625 -0.140625,-0.03125 -0.140625,-0.109375 0,-0.03125 0,-0.046875 0.046875,-0.21875 z m 0,0"
-               style="stroke:none;stroke-width:0" />
-          </g>
-        </g>
-        <g
-           id="id-e55c192b-a03f-4b34-933c-5fdb99d4d06a"
-           style="fill:#000000;fill-opacity:1">
-          <g
-             transform="translate(155.492,136.259)"
-             id="g2458">
-            <path
-               id="id-1a69b4bf-1a83-4b04-b5db-c79c9145d426"
-               d="m 2.328125,-4.4375 c 0,-0.1875 0,-0.1875 -0.203125,-0.1875 -0.453125,0.4375 -1.078125,0.4375 -1.359375,0.4375 v 0.25 c 0.15625,0 0.625,0 1,-0.1875 v 3.546875 c 0,0.234375 0,0.328125 -0.6875,0.328125 H 0.8125 V 0 c 0.125,0 0.984375,-0.03125 1.234375,-0.03125 0.21875,0 1.09375,0.03125 1.25,0.03125 V -0.25 H 3.03125 c -0.703125,0 -0.703125,-0.09375 -0.703125,-0.328125 z m 0,0"
-               style="stroke:none;stroke-width:0" />
-          </g>
-        </g>
-      </g>
-    </g>
-    <g
-       transform="matrix(0.352778,0,0,0.352778,41.878588,52.172429)"
-       ns1:version="1.7.1"
-       ns1:texconverter="pdflatex"
-       ns1:pdfconverter="inkscape"
-       ns1:text="$L_2$"
-       ns1:preamble="C:\Users\Martin Johnson\AppData\Roaming\inkscape\extensions\textext\default_packages.tex"
-       ns1:scale="1.0000003968502156"
-       ns1:alignment="middle center"
-       ns1:stroke-to-path="0"
-       ns1:jacobian_sqrt="0.352778"
-       id="g2462-0">
-      <defs
-         id="id-aa62d1fb-1fd7-42b2-aadb-8aeed6f47600">
-        <g
-           id="id-1afd97c1-379b-45b6-a951-6003969a966f">
-          <symbol
-             id="id-8fc212ee-9bcb-4e1f-94ef-0927047a0e92"
-             overflow="visible">
-            <path
-               id="id-176b9c17-65da-4108-9291-ab813e813a69"
-               d=""
-               style="stroke:none" />
-          </symbol>
-          <symbol
-             id="id-9ff915ec-5d11-411b-9e13-565e6c830ae1"
-             overflow="visible">
-            <path
-               id="id-bf5762f2-2e9d-4973-9193-d6e3248319bc"
-               d="M 3.734375,-6.03125 C 3.8125,-6.390625 3.84375,-6.5 4.78125,-6.5 c 0.296875,0 0.375,0 0.375,-0.1875 0,-0.125 -0.109375,-0.125 -0.15625,-0.125 -0.328125,0 -1.140625,0.03125 -1.46875,0.03125 -0.296875,0 -1.03125,-0.03125 -1.328125,-0.03125 -0.0625,0 -0.1875,0 -0.1875,0.203125 0,0.109375 0.09375,0.109375 0.28125,0.109375 0.015625,0 0.203125,0 0.375,0.015625 0.171875,0.03125 0.265625,0.03125 0.265625,0.171875 0,0.03125 0,0.0625 -0.03125,0.1875 L 1.5625,-0.78125 c -0.09375,0.390625 -0.109375,0.46875 -0.90625,0.46875 -0.171875,0 -0.265625,0 -0.265625,0.203125 C 0.390625,0 0.484375,0 0.65625,0 h 4.625 C 5.515625,0 5.515625,0 5.578125,-0.171875 L 6.375,-2.328125 c 0.03125,-0.109375 0.03125,-0.125 0.03125,-0.140625 0,-0.03125 -0.03125,-0.109375 -0.109375,-0.109375 -0.09375,0 -0.109375,0.0625 -0.171875,0.21875 -0.34375,0.90625 -0.78125,2.046875 -2.5,2.046875 H 2.6875 c -0.140625,0 -0.171875,0 -0.21875,0 -0.109375,-0.015625 -0.140625,-0.03125 -0.140625,-0.109375 0,-0.03125 0,-0.046875 0.046875,-0.21875 z m 0,0"
-               style="stroke:none" />
-          </symbol>
-          <symbol
-             id="id-54406115-f417-4290-a7e1-97e31c245928"
-             overflow="visible">
-            <path
-               id="id-63d9ffdc-10ef-4af2-a52e-4c815ec00c6e"
-               d=""
-               style="stroke:none" />
-          </symbol>
-          <symbol
-             id="id-420691ec-f9a3-4d35-b34e-22e545f27106"
-             overflow="visible">
-            <path
-               id="id-5de95171-7b75-499f-952c-8d563b37839e"
-               d="M 3.515625,-1.265625 H 3.28125 c -0.015625,0.15625 -0.09375,0.5625 -0.1875,0.625 C 3.046875,-0.59375 2.515625,-0.59375 2.40625,-0.59375 H 1.125 c 0.734375,-0.640625 0.984375,-0.84375 1.390625,-1.171875 0.515625,-0.40625 1,-0.84375 1,-1.5 0,-0.84375 -0.734375,-1.359375 -1.625,-1.359375 -0.859375,0 -1.453125,0.609375 -1.453125,1.25 0,0.34375 0.296875,0.390625 0.375,0.390625 0.15625,0 0.359375,-0.125 0.359375,-0.375 0,-0.125 -0.046875,-0.375 -0.40625,-0.375 C 0.984375,-4.21875 1.453125,-4.375 1.78125,-4.375 c 0.703125,0 1.0625,0.546875 1.0625,1.109375 0,0.609375 -0.4375,1.078125 -0.65625,1.328125 L 0.515625,-0.265625 C 0.4375,-0.203125 0.4375,-0.1875 0.4375,0 h 2.875 z m 0,0"
-               style="stroke:none" />
-          </symbol>
-        </g>
-      </defs>
-      <g
-         transform="translate(-149.103,-127.953)"
-         id="id-1e56fd2c-b347-431e-b0fc-f55f3a631522">
-        <g
-           id="id-81b13b1a-f800-4707-b5c2-62bc8c2836f3"
-           style="fill:#000000;fill-opacity:1">
-          <g
-             transform="translate(148.712,134.765)"
-             id="g2739">
-            <path
-               id="id-fd8547f8-fb0d-4538-911f-6894f84de8f0"
-               d="M 3.734375,-6.03125 C 3.8125,-6.390625 3.84375,-6.5 4.78125,-6.5 c 0.296875,0 0.375,0 0.375,-0.1875 0,-0.125 -0.109375,-0.125 -0.15625,-0.125 -0.328125,0 -1.140625,0.03125 -1.46875,0.03125 -0.296875,0 -1.03125,-0.03125 -1.328125,-0.03125 -0.0625,0 -0.1875,0 -0.1875,0.203125 0,0.109375 0.09375,0.109375 0.28125,0.109375 0.015625,0 0.203125,0 0.375,0.015625 0.171875,0.03125 0.265625,0.03125 0.265625,0.171875 0,0.03125 0,0.0625 -0.03125,0.1875 L 1.5625,-0.78125 c -0.09375,0.390625 -0.109375,0.46875 -0.90625,0.46875 -0.171875,0 -0.265625,0 -0.265625,0.203125 C 0.390625,0 0.484375,0 0.65625,0 h 4.625 C 5.515625,0 5.515625,0 5.578125,-0.171875 L 6.375,-2.328125 c 0.03125,-0.109375 0.03125,-0.125 0.03125,-0.140625 0,-0.03125 -0.03125,-0.109375 -0.109375,-0.109375 -0.09375,0 -0.109375,0.0625 -0.171875,0.21875 -0.34375,0.90625 -0.78125,2.046875 -2.5,2.046875 H 2.6875 c -0.140625,0 -0.171875,0 -0.21875,0 -0.109375,-0.015625 -0.140625,-0.03125 -0.140625,-0.109375 0,-0.03125 0,-0.046875 0.046875,-0.21875 z m 0,0"
-               style="stroke:none" />
-          </g>
-        </g>
-        <g
-           id="id-1b9d1b35-fd21-4ebc-9da6-564b4d071b05"
-           style="fill:#000000;fill-opacity:1">
-          <g
-             transform="translate(155.492,136.259)"
-             id="g2743">
-            <path
-               id="id-fed60239-534a-4b25-82b7-8881783bb4df"
-               d="M 3.515625,-1.265625 H 3.28125 c -0.015625,0.15625 -0.09375,0.5625 -0.1875,0.625 C 3.046875,-0.59375 2.515625,-0.59375 2.40625,-0.59375 H 1.125 c 0.734375,-0.640625 0.984375,-0.84375 1.390625,-1.171875 0.515625,-0.40625 1,-0.84375 1,-1.5 0,-0.84375 -0.734375,-1.359375 -1.625,-1.359375 -0.859375,0 -1.453125,0.609375 -1.453125,1.25 0,0.34375 0.296875,0.390625 0.375,0.390625 0.15625,0 0.359375,-0.125 0.359375,-0.375 0,-0.125 -0.046875,-0.375 -0.40625,-0.375 C 0.984375,-4.21875 1.453125,-4.375 1.78125,-4.375 c 0.703125,0 1.0625,0.546875 1.0625,1.109375 0,0.609375 -0.4375,1.078125 -0.65625,1.328125 L 0.515625,-0.265625 C 0.4375,-0.203125 0.4375,-0.1875 0.4375,0 h 2.875 z m 0,0"
-               style="stroke:none" />
-          </g>
-        </g>
-      </g>
-    </g>
+         x="60.920074"
+         y="46.224873"
+         style="font-size:4.23333px;stroke-width:0.264583">Heat flow</tspan></text>
   </g>
 </svg>

--- a/docs/source/general_analyzers/thermal_res_net_analyzer.rst
+++ b/docs/source/general_analyzers/thermal_res_net_analyzer.rst
@@ -89,13 +89,11 @@ plane_wall
    :align: center
    :width: 200 
 
-The plane wall resistance is initialized by the following: ``plane_wall(Material,Node_1,Node_2,L1,L2,A)``. The required parameters are defined as follows:
+The plane wall resistance is initialized by the following: ``plane_wall(Material,Node_1,Node_2,L,A)``. Node-1 is located on one of the walls perpendicular to the heat flow, while Node-2 is located on the opposite face. The required parameters are defined as follows:
 
-* ``L1`` Location of node 1 on first face of plane wall [m]
-* ``L2`` Location of node 2 on second face of plane wall [m]
+* ``L`` Thickness of plane wall [m]
 * ``A`` cross sectional area of plane wall [m^2]
 
-Note that the thickness of the plane wall is ``L2-L1``, so ``L2`` should be defined as the larger value of the two nodes.
 
 cylind_wall
 -----------
@@ -196,34 +194,34 @@ The following code-block demonstrate how to generate the list of ``Resistance`` 
     # Path 0
     ##############
     Descr = "R_1,2"
-    Resistances.append(plane_wall(mat1, 1, 2, 0, L_1, A_1))
+    Resistances.append(plane_wall(mat1, 1, 2, L_1, A_1))
     Resistances[0].Descr = Descr
     ##############
     # Path 1
     ##############
     Descr = "R_2,3"
-    Resistances.append(plane_wall(mat2, 2, 3, L_1, L_2, A_2))
+    Resistances.append(plane_wall(mat2, 2, 3, L_2-L_1, A_2))
     Resistances[1].Descr = Descr
 
     ##############
     # Path 2
     ##############
     Descr = "R_2,4"
-    Resistances.append(plane_wall(mat3, 2, 4, L_1, L_2, A_2))
+    Resistances.append(plane_wall(mat3, 2, 4, L_2-L_1, A_2))
     Resistances[2].Descr = Descr
 
     ##############
     # Path 3
     ##############
     Descr = "R_3,5"
-    Resistances.append(plane_wall(mat2, 3, 5, 0, w/4, A_3))
+    Resistances.append(plane_wall(mat2, 3, 5, w/4, A_3))
     Resistances[3].Descr = Descr
 
     ##############
     # Path 4
     ##############
     Descr = "R_4,5"
-    Resistances.append(plane_wall(mat3, 4, 5, 0, w/4, A_3))
+    Resistances.append(plane_wall(mat3, 4, 5, w/4, A_3))
     Resistances[4].Descr = Descr
 
     ##############

--- a/mach_eval/analyzers/general/thermal_network.py
+++ b/mach_eval/analyzers/general/thermal_network.py
@@ -132,7 +132,7 @@ class plane_wall(Resistance):
                  L: float,
                  A: float):
         super().__init__(Material, Node1, Node2)
-        self.L= L
+        self.L= abs(L)
         self.A = A
 
     @property

--- a/mach_eval/analyzers/general/thermal_network.py
+++ b/mach_eval/analyzers/general/thermal_network.py
@@ -129,17 +129,15 @@ class plane_wall(Resistance):
     def __init__(self, Material: Material,
                  Node1: int,
                  Node2: int,
-                 L1: float,
-                 L2: float,
+                 L: float,
                  A: float):
         super().__init__(Material, Node1, Node2)
-        self.L1 = L1
-        self.L2 = L2
+        self.L= L
         self.A = A
 
     @property
     def resistance_value(self):
-        return (self.L2 - self.L1) / (self.Material.k * self.A)
+        return (self.L) / (self.Material.k * self.A)
 
 
 class cylind_wall(Resistance):

--- a/mach_eval/analyzers/spm/rotor_thermal.py
+++ b/mach_eval/analyzers/spm/rotor_thermal.py
@@ -190,13 +190,13 @@ class SPM_RotorThermalAnalyzer:
         ##############
         Descr = "Shaft to rotor core interface (Approximated as Plane Wall)"
         A_sh_1 = stack_length * 2 * np.pi * R_1
-        Resistances.append(tb.plane_wall(sh_mat, 1, 2, 0, R_1, A_sh_1))
+        Resistances.append(tb.plane_wall(sh_mat, 1, 2, R_1, A_sh_1))
         Resistances[0].Descr = Descr
         ##############
         # Path 1
         ##############
         Descr = "Shaft/RC interface to rotor core center"
-        Resistances.append(tb.cylind_wall(rc_mat, 2, 3, R_1, R_rc, stack_length))
+        Resistances.append(tb.cylind_wall(rc_mat, 2, 3,R_1,R_rc, stack_length))
         Resistances[1].Descr = Descr
         ##############
         # Path 2
@@ -243,53 +243,53 @@ class SPM_RotorThermalAnalyzer:
         ##############
         Descr = "Rotor core center to Hub/RotorCore Interface"
         A_rcHub = np.pi * (R_2 ** 2 - R_1 ** 2)
-        Resistances.append(tb.plane_wall(rc_mat, 3, 9, 0, L_1, A_rcHub))
+        Resistances.append(tb.plane_wall(rc_mat, 3, 9, L_1, A_rcHub))
         Resistances[8].Descr = Descr
         ##############
         # Path 9
         ##############
         Descr = "PM center to Hub/PM Interface"
         A_pmHub = np.pi * (R_3 ** 2 - R_2 ** 2)
-        Resistances.append(tb.plane_wall(pm_mat, 5, 10, 0, L_1, A_pmHub))
+        Resistances.append(tb.plane_wall(pm_mat, 5, 10, L_1, A_pmHub))
         Resistances[9].Descr = Descr
         ##############
         # Path 10
         ##############
         Descr = "Sleeve center to Hub/Sleeve Interface"
         A_slHub = np.pi * (R_4 ** 2 - R_3 ** 2)
-        Resistances.append(tb.plane_wall(sl_mat, 7, 11, 0, L_1, A_slHub))
+        Resistances.append(tb.plane_wall(sl_mat, 7, 11, L_1, A_slHub))
         Resistances[10].Descr = Descr
         ##############
         # Path 11
         ##############
         Descr = "Shaft Center to shaft Inline with Hub center"
         A_sh = np.pi * (R_1 ** 2)
-        Resistances.append(tb.plane_wall(sh_mat, 1, 12, 0, L_2, A_sh))
+        Resistances.append(tb.plane_wall(sh_mat, 1, 12, L_2, A_sh))
         Resistances[11].Descr = Descr
         ##############
         # Path 12
         ##############
         Descr = "Hub/Rotor Core interface to Center of Hub inline with Rotor Core"
-        Resistances.append(tb.plane_wall(hub_mat, 9, 14, L_1, L_2, A_rcHub))
+        Resistances.append(tb.plane_wall(hub_mat, 9, 14, L_2-L_1, A_rcHub))
         Resistances[12].Descr = Descr
         ##############
         # Path 13
         ##############
         Descr = "Hub/PM interface to Center of Hub inline with PM"
-        Resistances.append(tb.plane_wall(hub_mat, 10, 15, L_1, L_2, A_pmHub))
+        Resistances.append(tb.plane_wall(hub_mat, 10, 15, L_2-L_1, A_pmHub))
         Resistances[13].Descr = Descr
         ##############
         # Path 14
         ##############
         Descr = "Hub/Sleeve interface to Center of Hub inline with Sleeve"
-        Resistances.append(tb.plane_wall(hub_mat, 11, 16, L_1, L_2, A_slHub))
+        Resistances.append(tb.plane_wall(hub_mat, 11, 16, L_2-L_1, A_slHub))
         Resistances[14].Descr = Descr
         ##############
         # Path 15
         ##############
         Descr = "Shaft inline with Hub center to Hub/Shaft interface"
         A_sh_2 = 2 * np.pi * R_1 * hub_length
-        Resistances.append(tb.plane_wall(sh_mat, 12, 13, 0, R_1, A_sh_2))
+        Resistances.append(tb.plane_wall(sh_mat, 12, 13, R_1, A_sh_2))
         Resistances[15].Descr = Descr
         ##############
         # Path 16
@@ -313,25 +313,25 @@ class SPM_RotorThermalAnalyzer:
         # Path 19
         ##############
         Descr = "Shaft inline with Hub center to Shaft Out "
-        Resistances.append(tb.plane_wall(sh_mat, 12, 17, L_2, L_4, A_sh))
+        Resistances.append(tb.plane_wall(sh_mat, 12, 17, L_4-L_2, A_sh))
         Resistances[19].Descr = Descr
         ##############
         # Path 20
         ##############
         Descr = "Hub inline with Rotor Core to Outer Hub Inline with Rotor Core "
-        Resistances.append(tb.plane_wall(hub_mat, 14, 18, L_2, L_3, A_rcHub))
+        Resistances.append(tb.plane_wall(hub_mat, 14, 18, L_3-L_2, A_rcHub))
         Resistances[20].Descr = Descr
         ##############
         # Path 21
         ##############
         Descr = "Hub inline with PM to Outer Hub Inline with PM "
-        Resistances.append(tb.plane_wall(hub_mat, 15, 19, L_2, L_3, A_pmHub))
+        Resistances.append(tb.plane_wall(hub_mat, 15, 19, L_3-L_2, A_pmHub))
         Resistances[21].Descr = Descr
         ##############
         # Path 22
         ##############
         Descr = "Hub inline with Sleeve to Outer Hub Inline with Sleeve"
-        Resistances.append(tb.plane_wall(hub_mat, 16, 20, L_2, L_3, A_slHub))
+        Resistances.append(tb.plane_wall(hub_mat, 16, 20, L_3-L_2, A_slHub))
         Resistances[22].Descr = Descr
         ##############
         # Path 23
@@ -363,53 +363,53 @@ class SPM_RotorThermalAnalyzer:
         ##############
         Descr = "Rotor Core center to Hub/RotorCore Interface"
         A_rcHub = np.pi * (R_2 ** 2 - R_1 ** 2)
-        Resistances.append(tb.plane_wall(rc_mat, 3, 21, 0, L_1, A_rcHub))
+        Resistances.append(tb.plane_wall(rc_mat, 3, 21, L_1, A_rcHub))
         Resistances[27].Descr = Descr
         ##############
         # Path 28
         ##############
         Descr = "PM center to Hub/PM Interface"
         A_pmHub = np.pi * (R_3 ** 2 - R_4 ** 2)
-        Resistances.append(tb.plane_wall(pm_mat, 5, 22, 0, L_1, A_pmHub))
+        Resistances.append(tb.plane_wall(pm_mat, 5, 22, L_1, A_pmHub))
         Resistances[28].Descr = Descr
         ##############
         # Path 29
         ##############
         Descr = "Sleeve center to Hub/Sleeve Interface"
         A_slHub = np.pi * (R_4 ** 2 - R_3 ** 2)
-        Resistances.append(tb.plane_wall(sl_mat, 7, 23, 0, L_1, A_slHub))
+        Resistances.append(tb.plane_wall(sl_mat, 7, 23, L_1, A_slHub))
         Resistances[29].Descr = Descr
         ##############
         # Path 30
         ##############
         Descr = "Shaft Center to shaft Inline with Hub center"
         A_sh = np.pi * (R_1 ** 2)
-        Resistances.append(tb.plane_wall(sh_mat, 1, 24, 0, L_2, A_sh))
+        Resistances.append(tb.plane_wall(sh_mat, 1, 24, L_2, A_sh))
         Resistances[30].Descr = Descr
         ##############
         # Path 31
         ##############
         Descr = "Hub/Rotor Core interface to Center of Hub inline with Rotor Core"
-        Resistances.append(tb.plane_wall(hub_mat, 21, 26, L_1, L_2, A_rcHub))
+        Resistances.append(tb.plane_wall(hub_mat, 21, 26, L_2-L_1, A_rcHub))
         Resistances[31].Descr = Descr
         ##############
         # Path 32
         ##############
         Descr = "Hub/PM interface to Center of Hub inline with PM"
-        Resistances.append(tb.plane_wall(hub_mat, 22, 27, L_1, L_2, A_pmHub))
+        Resistances.append(tb.plane_wall(hub_mat, 22, 27,  L_2-L_1, A_pmHub))
         Resistances[32].Descr = Descr
         ##############
         # Path 33
         ##############
         Descr = "Hub/Sleeve interface to Center of Hub inline with Sleeve"
-        Resistances.append(tb.plane_wall(hub_mat, 23, 28, L_1, L_2, A_slHub))
+        Resistances.append(tb.plane_wall(hub_mat, 23, 28,  L_2-L_1, A_slHub))
         Resistances[33].Descr = Descr
         ##############
         # Path 34
         ##############
         Descr = "Shaft inline with Hub center to Hub/Shaft interface"
         A_sh_2 = 2 * np.pi * R_1 * hub_length
-        Resistances.append(tb.plane_wall(sh_mat, 24, 25, 0, R_1, A_sh_2))
+        Resistances.append(tb.plane_wall(sh_mat, 24, 25, R_1, A_sh_2))
         Resistances[34].Descr = Descr
         ##############
         # Path 35
@@ -433,25 +433,25 @@ class SPM_RotorThermalAnalyzer:
         # Path 38
         ##############
         Descr = "Shaft inline with Hub center to Shaft Out "
-        Resistances.append(tb.plane_wall(sh_mat, 24, 29, L_2, L_4, A_sh))
+        Resistances.append(tb.plane_wall(sh_mat, 24, 29,  L_4-L_2, A_sh))
         Resistances[38].Descr = Descr
         ##############
         # Path 39
         ##############
         Descr = "Hub inline with Rotor Core to Outer Hub Inline with Rotor Core "
-        Resistances.append(tb.plane_wall(hub_mat, 26, 30, L_2, L_3, A_rcHub))
+        Resistances.append(tb.plane_wall(hub_mat, 26, 30,  L_3-L_2, A_rcHub))
         Resistances[39].Descr = Descr
         ##############
         # Path 40
         ##############
         Descr = "Hub inline with PM to Outer Hub Inline with PM "
-        Resistances.append(tb.plane_wall(hub_mat, 27, 31, L_2, L_3, A_pmHub))
+        Resistances.append(tb.plane_wall(hub_mat, 27, 31, L_3-L_2, A_pmHub))
         Resistances[40].Descr = Descr
         ##############
         # Path 41
         ##############
         Descr = "Hub inline with Sleeve to Outer Hub Inline with Sleeve"
-        Resistances.append(tb.plane_wall(hub_mat, 28, 32, L_2, L_3, A_slHub))
+        Resistances.append(tb.plane_wall(hub_mat, 28, 32, L_3-L_2, A_slHub))
         Resistances[41].Descr = Descr
         ##############
         # Path 42


### PR DESCRIPTION
This PR modifies the function signature for the `plane_wall` resistance to take in only one length, instead of `L_1`, `L_2`. The associated documentation has been updated to reflect this change, and the `SPM_RotorThermalAnalyzer` has been updated to reflect the new function signature.