### PR TITLE
Update sigma to raise ValueError if radius is outside of bounds

### DIFF
--- a/docs/source/SPM_Analyzers/SPM_structural_analyzer.rst
+++ b/docs/source/SPM_Analyzers/SPM_structural_analyzer.rst
@@ -133,7 +133,7 @@ The SPM structural analyzer returns a list of ``sigma`` objects (referred to as 
 * ``sigmas[2]``: Magnets
 * ``sigmas[3]``: Sleeve
 
-The user can obtain the stress (in units of Pa) at any radius in a rotor component using the ``sigma.radial()`` and ``sigma.tangential()`` methods. For example, ``sigmas[2].radial(r_ro)`` would return the radial stress at the outer edge of the magnets (radius of ``r_ro`` in units of m), and ``sigmas[2].tangential(r_ro)`` would return the tangential stress. Note that the sigma objects determine the stress by solving equation (4) in the supporting `paper <https://ieeexplore.ieee.org/document/9595523>`_.
+The user can obtain the stress (in units of Pa) at any radius in a rotor component using the ``sigma.radial()`` and ``sigma.tangential()`` methods. For example, ``sigmas[2].radial(r_ro)`` would return the radial stress at the outer edge of the magnets (radius of ``r_ro`` in units of m), and ``sigmas[2].tangential(r_ro)`` would return the tangential stress. If the user attempts to pass a radius which is outside of the range of the rotor component, then the ``sigma`` object will raise a ``ValueError``. Note that the sigma objects determine the stress by solving equation (4) in the supporting `paper <https://ieeexplore.ieee.org/document/9595523>`_.
 
 
 Example code to calculate the stress distribution in the rotor:

--- a/mach_eval/analyzers/spm/rotor_structural.py
+++ b/mach_eval/analyzers/spm/rotor_structural.py
@@ -475,10 +475,16 @@ class Sigma:
             R (float): location to evaluate stress.
         """
         # Radial Stress
-        if max(R) > self.rotComp.R_o:
-            raise ValueError("Provided radius larger than outer radius of rotor component")
-        if min(R) < self.rotComp.R_i:
-            raise ValueError("Provided radius smaller than inner radius of rotor component")
+        try:
+            if max(R) > self.rotComp.R_o:
+                raise ValueError("Provided radius larger than outer radius of rotor component")
+            if min(R) < self.rotComp.R_i:
+                raise ValueError("Provided radius smaller than inner radius of rotor component")
+        except TypeError:
+            if R > self.rotComp.R_o:
+                raise ValueError("Provided radius larger than outer radius of rotor component")
+            if R < self.rotComp.R_i:
+                raise ValueError("Provided radius smaller than inner radius of rotor component")
         sigma_r = (
             self.A[0]
             * (self.rotComp.C1 * self.rotComp.h + self.rotComp.C2)
@@ -502,6 +508,16 @@ class Sigma:
             R (float): location to evaluate stress.
         """
         # Tangential Stress
+        try:
+            if max(R) > self.rotComp.R_o:
+                raise ValueError("Provided radius larger than outer radius of rotor component")
+            if min(R) < self.rotComp.R_i:
+                raise ValueError("Provided radius smaller than inner radius of rotor component")
+        except TypeError:
+            if R > self.rotComp.R_o:
+                raise ValueError("Provided radius larger than outer radius of rotor component")
+            if R < self.rotComp.R_i:
+                raise ValueError("Provided radius smaller than inner radius of rotor component")
         sigma_t = (
             self.A[0]
             * (self.rotComp.C2 * self.rotComp.h + self.rotComp.C3)

--- a/mach_eval/analyzers/spm/rotor_structural.py
+++ b/mach_eval/analyzers/spm/rotor_structural.py
@@ -475,6 +475,10 @@ class Sigma:
             R (float): location to evaluate stress.
         """
         # Radial Stress
+        if max(R) > self.rotComp.R_o:
+            raise ValueError("Provided radius larger than outer radius of rotor component")
+        if min(R) < self.rotComp.R_i:
+            raise ValueError("Provided radius smaller than inner radius of rotor component")
         sigma_r = (
             self.A[0]
             * (self.rotComp.C1 * self.rotComp.h + self.rotComp.C2)


### PR DESCRIPTION
This PR modifies the `Sigma` class of the `rotor_structural` module, so that it will raise a `ValueError` if the passed in radius is outside of the bound of the rotor component. This method works if R is a vector or a scaler. 