### PR TITLE
Add capability to add relative phase between currents and rotor

### DIFF
--- a/mach_eval/analyzers/electromagnetic/bspm/jmag_2d.py
+++ b/mach_eval/analyzers/electromagnetic/bspm/jmag_2d.py
@@ -112,7 +112,7 @@ class BSPM_EM_Analyzer:
         return fea_rated_output
 
     def initial_excitation_bias_compensation_deg(self):
-        return 0
+        return self.machine_variant.phase_current_offset
 
     @property
     def current_trms(self):

--- a/mach_eval/machines/machine.py
+++ b/mach_eval/machines/machine.py
@@ -52,6 +52,7 @@ class Winding:
             "Z_q",
             "Kov",
             "Kcu",
+            "phase_current_offset"
         )
 
     @staticmethod
@@ -89,6 +90,10 @@ class Winding:
     @property
     def Z_q(self):
         return self._winding_dict["Z_q"]
+    
+    @property
+    def phase_current_offset(self):
+        return self._winding_dict["phase_current_offset"]
 
 
 class Winding_IM(MachineComponent):


### PR DESCRIPTION
This PR adds in the capability to control the relative angle between the current space vector and the rotor position in JMAG for MTPA