### PR TITLE
Update bspm_jmag2d_analyzer.rst

### DIFF
--- a/docs/source/EM_analyzers/bspm_jmag2d_analyzer.rst
+++ b/docs/source/EM_analyzers/bspm_jmag2d_analyzer.rst
@@ -154,6 +154,7 @@ is shown below:
     "Z_q": 49,
     "Kov": 1.8,
     "Kcu": 0.5,
+    "phase_current_offset": 0 
     }
 
     ecce_2020_machine = BSPM_Machine(


### PR DESCRIPTION
Add `phase_current_offset` to example of using the JMAG 2D BSPM analyzer. This fixes an issue inadvertently created by #205.