### PR TITLE
Fix clone method bug

### DIFF
--- a/mach_eval/machines/bspm/bspm_machine.py
+++ b/mach_eval/machines/bspm/bspm_machine.py
@@ -160,9 +160,9 @@ class BSPM_Machine(Machine, PM_Rotor_Sleeved, Stator, DPNVWinding):
                 for key, value in updated_values.items():
                     cloned_machine._dimensions_dict[key] = value
 
-            if dict_to_update == "parameter_dict":
+            if dict_to_update == "parameters_dict":
                 for key, value in updated_values.items():
-                    cloned_machine._parameter_dict[key] = value
+                    cloned_machine._parameters_dict[key] = value
 
             if dict_to_update == "materials_dict":
                 for key, value in updated_values.items():


### PR DESCRIPTION
Fix #215 

This PR fixes type-o in the clone method for cloning BSPM machines that prevented updating the `parameters_dict`