### PR TITLE
mach_cad_private contents

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,9 @@ __pycache__/
 *.jproj
 *.xml
 LegacyCode/run_data/
+*.jfiles
+*.fem
+*.ans
 
 # Sphinx documentation
 docs/build/

--- a/examples/mach_cad_examples/example_induction_motor.py
+++ b/examples/mach_cad_examples/example_induction_motor.py
@@ -1,0 +1,342 @@
+import os
+import sys
+
+# change current working directory to file location
+os.chdir(os.path.dirname(__file__))
+# add the directory immediately above this file's directory to path for module import
+sys.path.append("../..")
+
+import mach_cad.tools.jmag as JMAG
+from mach_cad.tools.femm import FEMM
+import mach_cad.model_obj as mo
+import numpy as np
+from mach_eval.machines.materials.electric_steels import M19Gauge29
+from mach_eval.machines.materials.electric_steels import M19Gauge29
+from mach_eval.machines.materials.miscellaneous_materials import (
+    Steel,
+    Copper,
+    Hub,
+    Air,
+)
+
+# Motor dimensions
+stator_dimensions = {
+    'alpha_st': 50,
+    'alpha_so': 22.25,
+    'r_si': 14.16,
+    'd_so': 2.71,
+    'd_sp': 4.07,
+    'd_st': 11.27,
+    'd_sy': 9,
+    'w_st': 9.09,
+    'alpha_m': 178.78,
+    'l_st': 1,
+}
+
+rotor_dimensions = {
+    'r_ri': 3,
+    'd_ri': 4,
+    'd_rb': 2,
+    'r_rb1': 1,
+    'r_rb2': 0.5,
+    'd_so': 2,
+    'w_so': 0.5,
+}
+
+# Number of stator and rotor slots
+Q = 6
+Qr = 12
+
+# Boundary parameters (for FEMM)
+radius_boundary = 100
+radius_air_region1 = 13.6
+radius_air_region2 = 70
+
+# Materials
+Aluminium = {
+    "bar_material": "Aluminium"
+}
+
+bim_materials = {
+    "air_mat": Air,
+    "rotor_iron_mat": M19Gauge29,
+    "stator_iron_mat": M19Gauge29,
+    "coil_mat": Copper,
+    "rotor_bar_mat": Aluminium,
+    "shaft_mat": Steel,
+    "rotor_hub": Hub,
+}
+
+
+###################### Create cross-section objects ######################
+# Partial models are used in JMAG (to reduce drawing time)
+
+stator = mo.CrossSectInnerRotorStator(
+    name="StatorCore",
+    dim_alpha_st=mo.DimDegree(stator_dimensions["alpha_st"]),
+    dim_alpha_so=mo.DimDegree(stator_dimensions["alpha_so"]),
+    dim_r_si=mo.DimMillimeter(stator_dimensions["r_si"]),
+    dim_d_so=mo.DimMillimeter(stator_dimensions["d_so"]),
+    dim_d_sp=mo.DimMillimeter(stator_dimensions["d_sp"]),
+    dim_d_st=mo.DimMillimeter(stator_dimensions["d_st"]),
+    dim_d_sy=mo.DimMillimeter(stator_dimensions["d_sy"]),
+    dim_w_st=mo.DimMillimeter(stator_dimensions["w_st"]),
+    dim_r_st=mo.DimMillimeter(0),
+    dim_r_sf=mo.DimMillimeter(0),
+    dim_r_sb=mo.DimMillimeter(0),
+    Q=Q,
+    location=mo.Location2D(anchor_xy=[mo.DimMillimeter(0), mo.DimMillimeter(0)],theta=mo.DimRadian(0)),
+    theta=mo.DimDegree(0),
+)
+
+stator_partial = mo.CrossSectInnerRotorStatorPartial(
+    name="StatorCore",
+    dim_alpha_st=mo.DimDegree(stator_dimensions["alpha_st"]),
+    dim_alpha_so=mo.DimDegree(stator_dimensions["alpha_so"]),
+    dim_r_si=mo.DimMillimeter(stator_dimensions["r_si"]),
+    dim_d_so=mo.DimMillimeter(stator_dimensions["d_so"]),
+    dim_d_sp=mo.DimMillimeter(stator_dimensions["d_sp"]),
+    dim_d_st=mo.DimMillimeter(stator_dimensions["d_st"]),
+    dim_d_sy=mo.DimMillimeter(stator_dimensions["d_sy"]),
+    dim_w_st=mo.DimMillimeter(stator_dimensions["w_st"]),
+    dim_r_st=mo.DimMillimeter(0),
+    dim_r_sf=mo.DimMillimeter(0),
+    dim_r_sb=mo.DimMillimeter(0),
+    Q=Q,
+    location=mo.Location2D(anchor_xy=[mo.DimMillimeter(0), mo.DimMillimeter(0)],theta=mo.DimRadian(0)),
+    theta=mo.DimDegree(0),
+)
+
+winding_layer1 = []
+for i in range (0, Q):
+    winding_layer1.append(mo.CrossSectInnerRotorStatorRightSlot(
+        name="WindingLayer1",
+        stator_core=stator,
+        location=mo.Location2D(anchor_xy=[mo.DimMillimeter(0), mo.DimMillimeter(0)],theta=mo.DimRadian(2 * np.pi / Q * i)),
+        ))
+    
+winding_layer1_partial = winding_layer1[0]
+
+winding_layer2 = []
+for i in range (0, Q):
+    winding_layer2.append(mo.CrossSectInnerRotorStatorLeftSlot(
+        name="WindingLayer2",
+        stator_core=stator,
+        location=mo.Location2D(anchor_xy=[mo.DimMillimeter(0), mo.DimMillimeter(0)],theta=mo.DimRadian(2 * np.pi / Q * i)),
+        theta=mo.DimDegree(0),
+        ))
+
+winding_layer2_partial = winding_layer2[0]
+
+rotor = mo.CrossSectInnerRotorDropSlots(
+    name="RotorCore",
+    dim_r_ri=mo.DimMillimeter(rotor_dimensions["r_ri"]),
+    dim_d_ri=mo.DimMillimeter(rotor_dimensions["d_ri"]),
+    dim_d_rb=mo.DimMillimeter(rotor_dimensions["d_rb"]),
+    dim_r_rb1=mo.DimMillimeter(rotor_dimensions["r_rb1"]),
+    dim_r_rb2=mo.DimMillimeter(rotor_dimensions["r_rb2"]),
+    dim_d_so=mo.DimMillimeter(rotor_dimensions["d_so"]),
+    dim_w_so=mo.DimMillimeter(rotor_dimensions["w_so"]),
+    Qr=Qr,
+    location=mo.Location2D(anchor_xy=[mo.DimMillimeter(0), mo.DimMillimeter(0)]),
+    theta=mo.DimDegree(0),
+)
+
+rotor_partial = mo.CrossSectInnerRotorDropSlotsPartial(
+    name="RotorCore",
+    dim_r_ri=mo.DimMillimeter(rotor_dimensions["r_ri"]),
+    dim_d_ri=mo.DimMillimeter(rotor_dimensions["d_ri"]),
+    dim_d_rb=mo.DimMillimeter(rotor_dimensions["d_rb"]),
+    dim_r_rb1=mo.DimMillimeter(rotor_dimensions["r_rb1"]),
+    dim_r_rb2=mo.DimMillimeter(rotor_dimensions["r_rb2"]),
+    dim_d_so=mo.DimMillimeter(rotor_dimensions["d_so"]),
+    dim_w_so=mo.DimMillimeter(rotor_dimensions["w_so"]),
+    Qr=Qr,
+    location=mo.Location2D(anchor_xy=[mo.DimMillimeter(0), mo.DimMillimeter(0)]),
+    theta=mo.DimDegree(0),
+)
+
+bar = []
+for i in range(0,Qr):
+    bar.append(mo.CrossSectInnerRotorDropSlotsBar(
+    name="Bar",
+    rotor_core=rotor,
+    location=mo.Location2D(anchor_xy=[mo.DimMillimeter(0), mo.DimMillimeter(0)],theta=mo.DimRadian(2 * np.pi / Qr * i)),
+    theta=mo.DimDegree(0),
+    ))
+
+bar_partial = bar[0]
+
+
+###################### Create component objects ######################
+# Only used in FEMM. Can also be used in JMAG, but increases drawing time.
+
+comp_stator = mo.Component(
+        name="StatorCore",
+        cross_sections=[stator],
+        material=mo.MaterialGeneric(name=bim_materials["stator_iron_mat"]["core_material"]),
+        make_solid=mo.MakeExtrude(location=mo.Location3D(), dim_depth=mo.DimMillimeter(stator_dimensions["l_st"])),
+        )
+
+comp_winding_layer1 = []
+for i in range(0,Q):
+    comp_winding_layer1.append(mo.Component(
+        name="WindingLayer1",
+        cross_sections=[winding_layer1[i]],
+        material=mo.MaterialGeneric(name="Copper", color=r"#4d4b4f"),
+        make_solid=mo.MakeExtrude(location=mo.Location3D(), dim_depth=mo.DimMillimeter(stator_dimensions["l_st"])),
+        ))
+
+comp_winding_layer2 = []
+for i in range(0,Q):
+    comp_winding_layer2.append(mo.Component(
+        name="WindingLayer2",
+        cross_sections=[winding_layer2[i]],
+        material=mo.MaterialGeneric(name="Copper", color=r"#4d4b4f"),
+        make_solid=mo.MakeExtrude(location=mo.Location3D(), dim_depth=mo.DimMillimeter(stator_dimensions["l_st"])),
+        ))
+
+comp_rotor = mo.Component(
+    name="RotorCore",
+    cross_sections=[rotor],
+    material=mo.MaterialGeneric(name=bim_materials["rotor_iron_mat"]["core_material"]),
+    make_solid=mo.MakeExtrude(location=mo.Location3D(), dim_depth=mo.DimMillimeter(stator_dimensions["l_st"])),
+    )
+
+comp_bar = []
+for i in range(0,Qr):
+    comp_bar.append(mo.Component(
+    name="Bar",
+    cross_sections=[bar[i]],
+    material=mo.MaterialGeneric(name="Copper", color=r"#4d4b4f"),
+    make_solid=mo.MakeExtrude(location=mo.Location3D(), dim_depth=mo.DimMillimeter(1)),
+    ))
+
+
+###################### Draw the motor in FEMM ######################
+tool_femm = FEMM.FEMMDesigner()
+tool_femm.newdocument(1, 0)
+tool_femm.probdef(0, 'millimeters', 'planar', 1e-8, 1, 30, 1)
+# Add materials
+tool_femm.add_material("Air")
+tool_femm.add_material("Copper")
+tool_femm.add_new_material(mat_name=bim_materials["rotor_bar_mat"]["bar_material"])
+hdata, bdata = np.loadtxt(bim_materials["stator_iron_mat"]['core_bh_file'], unpack=True, usecols=(0, 1))
+tool_femm.add_new_material(mat_name=bim_materials["stator_iron_mat"]["core_material"],hdata=hdata,bdata=bdata)
+
+# Draw the model
+stator_tool = comp_stator.make(tool_femm, tool_femm)
+winding_tool1 = []
+for i in range(0,Q):
+    winding_tool1.append(comp_winding_layer1[i].make(tool_femm, tool_femm))
+winding_tool2 = []
+for i in range(0,Q):
+    winding_tool2.append(comp_winding_layer2[i].make(tool_femm, tool_femm))
+rotor_tool = comp_rotor.make(tool_femm, tool_femm)
+bar_tool = []
+for i in range(0,Qr):
+    bar_tool.append(comp_bar[i].make(tool_femm, tool_femm))
+
+# Assign 'Air' material
+tool_femm.set_block_prop(
+    new_block=1,
+    inner_coord=[0, 0],
+    material_name='Air',
+    )
+tool_femm.set_block_prop(
+    new_block=1,
+    inner_coord=[radius_air_region1, 0],
+    material_name='Air',
+    )
+tool_femm.set_block_prop(
+    new_block=1,
+    inner_coord=[radius_air_region2, 0],
+    material_name='Air',
+    )
+
+# Create boundary condition
+tool_femm.create_boundary_condition(number_of_shells=7, radius=radius_boundary, centerxy=(0,0), bc=1)
+
+# Check if a specified file name exists already
+file = r"example_induction_motor.fem"
+attempts = 1
+if os.path.exists(file):
+    print(
+        "FEMM project exists already, I will not delete it but create a new one with a different name instead."
+    )
+    attempts = 2
+    temp_path = file[
+        : -len(".fem")
+    ] + "_attempts_%d.fem" % (attempts)
+    while os.path.exists(temp_path):
+        attempts += 1
+        temp_path = file[
+            : -len(".fem")
+        ] + "_attempts_%d.fem" % (attempts)
+
+    file = temp_path
+
+# Save the file
+tool_femm.save_as(file)
+
+
+###################### Draw the motor in JMAG ######################
+tool_jmag = JMAG.JmagDesigner()
+
+# Check if a specified file name exists already
+file = r"example_induction_motor.jproj"
+attempts = 1
+if os.path.exists(file):
+    print(
+        "JMAG project exists already, I will not delete it but create a new one with a different name instead."
+    )
+    attempts = 2
+    temp_path = file[
+        : -len(".jproj")
+    ] + "_attempts_%d.jproj" % (attempts)
+    while os.path.exists(temp_path):
+        attempts += 1
+        temp_path = file[
+            : -len(".jproj")
+        ] + "_attempts_%d.jproj" % (attempts)
+
+    file = temp_path
+
+tool_jmag.open(comp_filepath=file, length_unit="DimMillimeter", study_type="Transient")
+tool_jmag.set_visibility(True)
+
+# Draw the model
+tool_jmag.sketch = tool_jmag.create_sketch()
+tool_jmag.sketch.SetProperty("Name", stator_partial.name)
+tool_jmag.sketch.SetProperty("Color", r"#808080")
+cs_stator = stator_partial.draw(tool_jmag)
+stator_tool = tool_jmag.prepare_section(cs_stator, num_copy_rotate=Q)
+
+tool_jmag.sketch = tool_jmag.create_sketch()
+tool_jmag.sketch.SetProperty("Name", winding_layer1_partial.name)
+tool_jmag.sketch.SetProperty("Color", r"#B87333")
+cs_winding_layer1 = winding_layer1_partial.draw(tool_jmag)
+winding_tool1 = tool_jmag.prepare_section(cs_winding_layer1, num_copy_rotate=Q)
+
+tool_jmag.sketch = tool_jmag.create_sketch()
+tool_jmag.sketch.SetProperty("Name", winding_layer2_partial.name)
+tool_jmag.sketch.SetProperty("Color", r"#B87333")
+cs_winding_layer2 = winding_layer2_partial.draw(tool_jmag)
+winding_tool2 = tool_jmag.prepare_section(cs_winding_layer2, num_copy_rotate=Q)
+
+tool_jmag.sketch = tool_jmag.create_sketch()
+tool_jmag.sketch.SetProperty("Name", rotor_partial.name)
+tool_jmag.sketch.SetProperty("Color", r"#808080")
+cs_rotor_core = rotor_partial.draw(tool_jmag)
+rotor_tool = tool_jmag.prepare_section(cs_rotor_core, num_copy_rotate=Qr)
+
+tool_jmag.sketch = tool_jmag.create_sketch()
+tool_jmag.sketch.SetProperty("Name", bar_partial.name)
+tool_jmag.sketch.SetProperty("Color", r"#C89E9B")
+cs_rotor_bar = bar_partial.draw(tool_jmag)
+rotor_bar_tool = tool_jmag.prepare_section(cs_rotor_bar, num_copy_rotate=Qr)
+
+tool_jmag.doc.SaveModel(False)
+
+# Save the file
+tool_jmag.save()

--- a/examples/mach_cad_examples/example_inner_rotor_drop_slots.py
+++ b/examples/mach_cad_examples/example_inner_rotor_drop_slots.py
@@ -1,0 +1,165 @@
+import os
+import sys
+
+# change current working directory to file location
+os.chdir(os.path.dirname(__file__))
+# add the directory immediately above this file's directory to path for module import
+sys.path.append("../..")
+
+import mach_cad.tools.jmag as JMAG
+from mach_cad.tools.femm import FEMM
+import mach_cad.model_obj as mo
+import numpy as np
+from mach_eval.machines.materials.electric_steels import M19Gauge29
+
+# rotor dimensions
+rotor_dimensions = {
+    'r_ri': 3,
+    'd_ri': 4,
+    'd_rb': 2,
+    'r_rb1': 1,
+    'r_rb2': 0.5,
+    'd_so': 2,
+    'w_so': 0.5,
+}
+
+Qr = 12
+
+###################### Create cross-section objects ######################
+# Partial models are used in JMAG (to reduce drawing time)
+
+rotor = mo.CrossSectInnerRotorDropSlots(
+    name="RotorCore",
+    dim_r_ri=mo.DimMillimeter(rotor_dimensions["r_ri"]),
+    dim_d_ri=mo.DimMillimeter(rotor_dimensions["d_ri"]),
+    dim_d_rb=mo.DimMillimeter(rotor_dimensions["d_rb"]),
+    dim_r_rb1=mo.DimMillimeter(rotor_dimensions["r_rb1"]),
+    dim_r_rb2=mo.DimMillimeter(rotor_dimensions["r_rb2"]),
+    dim_d_so=mo.DimMillimeter(rotor_dimensions["d_so"]),
+    dim_w_so=mo.DimMillimeter(rotor_dimensions["w_so"]),
+    Qr=Qr,
+    location=mo.Location2D(anchor_xy=[mo.DimMillimeter(0), mo.DimMillimeter(0)]),
+    theta=mo.DimDegree(0),
+)
+
+rotor_partial = mo.CrossSectInnerRotorDropSlotsPartial(
+    name="RotorCore",
+    dim_r_ri=mo.DimMillimeter(rotor_dimensions["r_ri"]),
+    dim_d_ri=mo.DimMillimeter(rotor_dimensions["d_ri"]),
+    dim_d_rb=mo.DimMillimeter(rotor_dimensions["d_rb"]),
+    dim_r_rb1=mo.DimMillimeter(rotor_dimensions["r_rb1"]),
+    dim_r_rb2=mo.DimMillimeter(rotor_dimensions["r_rb2"]),
+    dim_d_so=mo.DimMillimeter(rotor_dimensions["d_so"]),
+    dim_w_so=mo.DimMillimeter(rotor_dimensions["w_so"]),
+    Qr=Qr,
+    location=mo.Location2D(anchor_xy=[mo.DimMillimeter(0), mo.DimMillimeter(0)]),
+    theta=mo.DimDegree(0),
+)
+
+bar = []
+for i in range(0,Qr):
+    bar.append(mo.CrossSectInnerRotorDropSlotsBar(
+    name="bar",
+    rotor_core=rotor,
+    location=mo.Location2D(anchor_xy=[mo.DimMillimeter(0), mo.DimMillimeter(0)],theta=mo.DimRadian(2 * np.pi / Qr * i)),
+    theta=mo.DimDegree(0),
+    ))
+
+bar_partial = bar[0]
+
+###################### Create component objects ######################
+# Only used in FEMM. Can also be used in JMAG, but increases drawing time.
+
+comp_rotor = mo.Component(
+    name="RotorCore",
+    cross_sections=[rotor],
+    material=mo.MaterialGeneric(name=M19Gauge29["core_material"]),
+    make_solid=mo.MakeExtrude(location=mo.Location3D(), dim_depth=mo.DimMillimeter(1)),
+)
+
+comp_bar = []
+for i in range(0,Qr):
+    comp_bar.append(mo.Component(
+    name="bar",
+    cross_sections=[bar[i]],
+    material=mo.MaterialGeneric(name="Copper", color=r"#4d4b4f"),
+    make_solid=mo.MakeExtrude(location=mo.Location3D(), dim_depth=mo.DimMillimeter(1)),
+    ))
+
+
+###################### Draw the motor in FEMM ######################
+tool_femm = FEMM.FEMMDesigner()
+tool_femm.newdocument(hide_window=1, problem_type=0)
+tool_femm.probdef()
+tool_femm.add_material("Copper")
+# Add a new material and its BH curve to the FEMM project
+hdata, bdata = np.loadtxt(M19Gauge29['core_bh_file'], unpack=True, usecols=(0, 1))
+tool_femm.add_new_material(mat_name=M19Gauge29["core_material"],hdata=hdata,bdata=bdata)
+rotor_tool = comp_rotor.make(tool_femm, tool_femm)
+bar_tool = []
+for i in range(0,Qr):
+    bar_tool.append(comp_bar[i].make(tool_femm, tool_femm))
+
+# Check if a specified file name exists already
+file = r"inner_rotor_drop_slots.fem"
+attempts = 1
+if os.path.exists(file):
+    print(
+        "FEMM project exists already, I will not delete it but create a new one with a different name instead."
+    )
+    attempts = 2
+    temp_path = file[
+        : -len(".fem")
+    ] + "_attempts_%d.fem" % (attempts)
+    while os.path.exists(temp_path):
+        attempts += 1
+        temp_path = file[
+            : -len(".fem")
+        ] + "_attempts_%d.fem" % (attempts)
+
+    file = temp_path
+
+# Save the file
+tool_femm.save_as(file)
+
+###################### Draw the motor in JMAG ######################
+tool_jmag = JMAG.JmagDesigner()
+# Check if a specified file name exists already
+file = r"inner_rotor_drop_slots.jproj"
+attempts = 1
+if os.path.exists(file):
+    print(
+        "JMAG project exists already, I will not delete it but create a new one with a different name instead."
+    )
+    attempts = 2
+    temp_path = file[
+        : -len(".jproj")
+    ] + "_attempts_%d.jproj" % (attempts)
+    while os.path.exists(temp_path):
+        attempts += 1
+        temp_path = file[
+            : -len(".jproj")
+        ] + "_attempts_%d.jproj" % (attempts)
+
+    file = temp_path
+
+tool_jmag.open(comp_filepath=file, length_unit="DimMillimeter", study_type="Transient")
+tool_jmag.set_visibility(True)
+
+# Draw the model
+tool_jmag.sketch = tool_jmag.create_sketch()
+tool_jmag.sketch.SetProperty("Name", rotor_partial.name)
+tool_jmag.sketch.SetProperty("Color", r"#808080")
+cs_rotor_core = rotor_partial.draw(tool_jmag)
+rotor_tool = tool_jmag.prepare_section(cs_rotor_core, num_copy_rotate=Qr)
+
+tool_jmag.sketch = tool_jmag.create_sketch()
+tool_jmag.sketch.SetProperty("Name", bar_partial.name)
+tool_jmag.sketch.SetProperty("Color", r"#C89E9B")
+cs_rotor_bar = bar_partial.draw(tool_jmag)
+rotor_bar_tool = tool_jmag.prepare_section(cs_rotor_bar, num_copy_rotate=Qr)
+
+tool_jmag.doc.SaveModel(False)
+
+# Save the file
+tool_jmag.save()

--- a/examples/mach_cad_examples/example_inner_rotor_round_slots.py
+++ b/examples/mach_cad_examples/example_inner_rotor_round_slots.py
@@ -1,0 +1,160 @@
+import os
+import sys
+
+# change current working directory to file location
+os.chdir(os.path.dirname(__file__))
+# add the directory immediately above this file's directory to path for module import
+sys.path.append("../..")
+
+import mach_cad.tools.jmag as JMAG
+from mach_cad.tools.femm import FEMM
+import mach_cad.model_obj as mo
+import numpy as np
+from mach_eval.machines.materials.electric_steels import M19Gauge29
+
+# rotor dimensions
+rotor_dimensions = {
+    'r_ri': 3,
+    'd_ri': 4,
+    'r_rb': 1,
+    'd_so': 2,
+    'w_so': 0.5,
+}
+
+Qr = 12
+
+###################### Create cross-section objects ######################
+# Partial models are used in JMAG (to reduce drawing time)
+
+rotor = mo.CrossSectInnerRotorRoundSlots(
+    name="RotorCore",
+    dim_r_ri=mo.DimMillimeter(rotor_dimensions["r_ri"]),
+    dim_d_ri=mo.DimMillimeter(rotor_dimensions["d_ri"]),
+    dim_r_rb=mo.DimMillimeter(rotor_dimensions["r_rb"]),
+    dim_d_so=mo.DimMillimeter(rotor_dimensions["d_so"]),
+    dim_w_so=mo.DimMillimeter(rotor_dimensions["w_so"]),
+    Qr=Qr,
+    location=mo.Location2D(anchor_xy=[mo.DimMillimeter(0), mo.DimMillimeter(0)]),
+    theta=mo.DimDegree(0),
+)
+
+rotor_partial = mo.CrossSectInnerRotorRoundSlotsPartial(
+    name="RotorCore",
+    dim_r_ri=mo.DimMillimeter(rotor_dimensions["r_ri"]),
+    dim_d_ri=mo.DimMillimeter(rotor_dimensions["d_ri"]),
+    dim_r_rb=mo.DimMillimeter(rotor_dimensions["r_rb"]),
+    dim_d_so=mo.DimMillimeter(rotor_dimensions["d_so"]),
+    dim_w_so=mo.DimMillimeter(rotor_dimensions["w_so"]),
+    Qr=Qr,
+    location=mo.Location2D(anchor_xy=[mo.DimMillimeter(0), mo.DimMillimeter(0)]),
+    theta=mo.DimDegree(0),
+)
+
+bar = []
+for i in range(0,Qr):
+    bar.append(mo.CrossSectInnerRotorRoundSlotsBar(
+    name="Bar",
+    rotor_core=rotor,
+    location=mo.Location2D(anchor_xy=[mo.DimMillimeter(0), mo.DimMillimeter(0)],theta=mo.DimRadian(2 * np.pi / Qr * i)),
+    theta=mo.DimDegree(0),
+    ))
+
+bar_partial = bar[0]
+
+###################### Create component objects ######################
+# Only used in FEMM. Can also be used in JMAG, but increases drawing time.
+
+comp_rotor = mo.Component(
+    name="RotorCore",
+    cross_sections=[rotor],
+    material=mo.MaterialGeneric(name=M19Gauge29["core_material"]),
+    make_solid=mo.MakeExtrude(location=mo.Location3D(), dim_depth=mo.DimMillimeter(1)),
+)
+
+comp_bar = []
+for i in range(0,Qr):
+    comp_bar.append(mo.Component(
+    name="bar",
+    cross_sections=[bar[i]],
+    material=mo.MaterialGeneric(name="Copper", color=r"#4d4b4f"),
+    make_solid=mo.MakeExtrude(location=mo.Location3D(), dim_depth=mo.DimMillimeter(1)),
+    ))
+
+
+###################### Draw the motor in FEMM ######################
+tool_femm = FEMM.FEMMDesigner()
+tool_femm.newdocument(hide_window=1, problem_type=0)
+tool_femm.probdef()
+tool_femm.add_material("Copper")
+# Add a new material and its BH curve to the FEMM project
+hdata, bdata = np.loadtxt(M19Gauge29['core_bh_file'], unpack=True, usecols=(0, 1))
+tool_femm.add_new_material(mat_name=M19Gauge29["core_material"],hdata=hdata,bdata=bdata)
+rotor_tool = comp_rotor.make(tool_femm, tool_femm)
+bar_tool = []
+for i in range(0,Qr):
+    bar_tool.append(comp_bar[i].make(tool_femm, tool_femm))
+
+# Check if a specified file name exists already
+file = r"inner_rotor_round_slots.fem"
+attempts = 1
+if os.path.exists(file):
+    print(
+        "FEMM project exists already, I will not delete it but create a new one with a different name instead."
+    )
+    attempts = 2
+    temp_path = file[
+        : -len(".fem")
+    ] + "_attempts_%d.fem" % (attempts)
+    while os.path.exists(temp_path):
+        attempts += 1
+        temp_path = file[
+            : -len(".fem")
+        ] + "_attempts_%d.fem" % (attempts)
+
+    file = temp_path
+
+# Save the file
+tool_femm.save_as(file)
+
+
+###################### Draw the motor in JMAG ######################
+tool_jmag = JMAG.JmagDesigner()
+# Check if a specified file name exists already
+file = r"inner_rotor_round_slots.jproj"
+attempts = 1
+if os.path.exists(file):
+    print(
+        "JMAG project exists already, I will not delete it but create a new one with a different name instead."
+    )
+    attempts = 2
+    temp_path = file[
+        : -len(".jproj")
+    ] + "_attempts_%d.jproj" % (attempts)
+    while os.path.exists(temp_path):
+        attempts += 1
+        temp_path = file[
+            : -len(".jproj")
+        ] + "_attempts_%d.jproj" % (attempts)
+
+    file = temp_path
+
+tool_jmag.open(comp_filepath=file, length_unit="DimMillimeter", study_type="Transient")
+tool_jmag.set_visibility(True)
+
+# Draw the model
+tool_jmag.sketch = tool_jmag.create_sketch()
+tool_jmag.sketch.SetProperty("Name", rotor_partial.name)
+tool_jmag.sketch.SetProperty("Color", r"#808080")
+cs_rotor_core = rotor_partial.draw(tool_jmag)
+rotor_tool = tool_jmag.prepare_section(cs_rotor_core, num_copy_rotate=Qr)
+
+tool_jmag.sketch = tool_jmag.create_sketch()
+tool_jmag.sketch.SetProperty("Name", bar_partial.name)
+tool_jmag.sketch.SetProperty("Color", r"#C89E9B")
+cs_rotor_bar = bar_partial.draw(tool_jmag)
+rotor_bar_tool = tool_jmag.prepare_section(cs_rotor_bar, num_copy_rotate=Qr)
+
+tool_jmag.doc.SaveModel(False)
+
+# Save the file
+tool_jmag.save()

--- a/examples/mach_cad_examples/example_inner_rotor_round_slots_double_cage.py
+++ b/examples/mach_cad_examples/example_inner_rotor_round_slots_double_cage.py
@@ -1,0 +1,192 @@
+import os
+import sys
+
+# change current working directory to file location
+os.chdir(os.path.dirname(__file__))
+# add the directory immediately above this file's directory to path for module import
+sys.path.append("../..")
+
+import mach_cad.tools.jmag as JMAG
+from mach_cad.tools.femm import FEMM
+import mach_cad.model_obj as mo
+import numpy as np
+from mach_eval.machines.materials.electric_steels import M19Gauge29
+
+# rotor dimensions
+rotor_dimensions = {
+    'r_ri': 3,
+    'd_ri': 4,
+    'd_rb': 1,
+    'r_rb': 1,
+    'd_so': 2,
+    'w_so': 0.5,
+}
+
+Qr = 12
+
+###################### Create cross-section objects ######################
+# Partial models are used in JMAG (to reduce drawing time)
+
+rotor = mo.CrossSectInnerRotorRoundSlotsDoubleCage(
+    name="RotorCore",
+    dim_r_ri=mo.DimMillimeter(rotor_dimensions["r_ri"]),
+    dim_d_ri=mo.DimMillimeter(rotor_dimensions["d_ri"]),
+    dim_d_rb=mo.DimMillimeter(rotor_dimensions["d_rb"]),
+    dim_r_rb=mo.DimMillimeter(rotor_dimensions["r_rb"]),
+    dim_d_so=mo.DimMillimeter(rotor_dimensions["d_so"]),
+    dim_w_so=mo.DimMillimeter(rotor_dimensions["w_so"]),
+    Qr=12,
+    location=mo.Location2D(anchor_xy=[mo.DimMillimeter(0), mo.DimMillimeter(0)]),
+    theta=mo.DimDegree(0),
+)
+
+rotor_partial = mo.CrossSectInnerRotorRoundSlotsDoubleCagePartial(
+    name="RotorCore",
+    dim_r_ri=mo.DimMillimeter(rotor_dimensions["r_ri"]),
+    dim_d_ri=mo.DimMillimeter(rotor_dimensions["d_ri"]),
+    dim_d_rb=mo.DimMillimeter(rotor_dimensions["d_rb"]),
+    dim_r_rb=mo.DimMillimeter(rotor_dimensions["r_rb"]),
+    dim_d_so=mo.DimMillimeter(rotor_dimensions["d_so"]),
+    dim_w_so=mo.DimMillimeter(rotor_dimensions["w_so"]),
+    Qr=12,
+    location=mo.Location2D(anchor_xy=[mo.DimMillimeter(0), mo.DimMillimeter(0)]),
+    theta=mo.DimDegree(0),
+)
+
+bar1 = []
+for i in range(0,Qr):
+    bar1.append(mo.CrossSectInnerRotorRoundSlotsDoubleCageBar1(
+    name="Bar1",
+    rotor_core=rotor,
+    location=mo.Location2D(anchor_xy=[mo.DimMillimeter(0), mo.DimMillimeter(0)],theta=mo.DimRadian(2 * np.pi / Qr * i)),
+    theta=mo.DimDegree(0),
+    ))
+
+bar1_partial = bar1[0]
+
+bar2 = []
+for i in range(0,Qr):
+    bar2.append(mo.CrossSectInnerRotorRoundSlotsDoubleCageBar2(
+    name="Bar2",
+    rotor_core=rotor,
+    location=mo.Location2D(anchor_xy=[mo.DimMillimeter(0), mo.DimMillimeter(0)],theta=mo.DimRadian(2 * np.pi / Qr * i)),
+    theta=mo.DimDegree(0),
+    ))
+
+bar2_partial = bar2[0]
+
+
+###################### Create component objects ######################
+# Only used in FEMM. Can also be used in JMAG, but increases drawing time.
+
+comp_rotor = mo.Component(
+    name="RotorCore",
+    cross_sections=[rotor],
+    material=mo.MaterialGeneric(name=M19Gauge29["core_material"]),
+    make_solid=mo.MakeExtrude(location=mo.Location3D(), dim_depth=mo.DimMillimeter(1)),
+)
+
+comp_bar1 = []
+for i in range(0,Qr):
+    comp_bar1.append(mo.Component(
+    name="Bar1",
+    cross_sections=[bar1[i]],
+    material=mo.MaterialGeneric(name="Copper", color=r"#4d4b4f"),
+    make_solid=mo.MakeExtrude(location=mo.Location3D(), dim_depth=mo.DimMillimeter(1)),
+    ))
+
+comp_bar2 = []
+for i in range(0,Qr):
+    comp_bar2.append(mo.Component(
+    name="Bar2",
+    cross_sections=[bar2[i]],
+    material=mo.MaterialGeneric(name="Copper", color=r"#4d4b4f"),
+    make_solid=mo.MakeExtrude(location=mo.Location3D(), dim_depth=mo.DimMillimeter(1)),
+    ))
+
+
+###################### Draw the motor in FEMM ######################
+tool_femm = FEMM.FEMMDesigner()
+tool_femm.newdocument(hide_window=1, problem_type=0)
+tool_femm.probdef()
+tool_femm.add_material("Copper")
+# Add a new material and its BH curve to the FEMM project
+hdata, bdata = np.loadtxt(M19Gauge29['core_bh_file'], unpack=True, usecols=(0, 1))
+tool_femm.add_new_material(mat_name=M19Gauge29["core_material"],hdata=hdata,bdata=bdata)
+rotor_tool = comp_rotor.make(tool_femm, tool_femm)
+bar1_tool = []
+for i in range(0,Qr):
+    bar1_tool.append(comp_bar1[i].make(tool_femm, tool_femm))
+bar2_tool = []
+for i in range(0,Qr):
+    bar2_tool.append(comp_bar2[i].make(tool_femm, tool_femm))
+
+# Check if a specified file name exists already
+file = r"inner_rotor_round_slots_double_cage.fem"
+attempts = 1
+if os.path.exists(file):
+    print(
+        "FEMM project exists already, I will not delete it but create a new one with a different name instead."
+    )
+    attempts = 2
+    temp_path = file[
+        : -len(".fem")
+    ] + "_attempts_%d.fem" % (attempts)
+    while os.path.exists(temp_path):
+        attempts += 1
+        temp_path = file[
+            : -len(".fem")
+        ] + "_attempts_%d.fem" % (attempts)
+
+    file = temp_path
+
+# Save the file
+tool_femm.save_as(file)
+
+
+###################### Draw the motor in JMAG ######################
+tool_jmag = JMAG.JmagDesigner()
+file = r"inner_rotor_round_slots_double_cage.jproj"
+attempts = 1
+if os.path.exists(file):
+    print(
+        "JMAG project exists already, I will not delete it but create a new one with a different name instead."
+    )
+    attempts = 2
+    temp_path = file[
+        : -len(".jproj")
+    ] + "_attempts_%d.jproj" % (attempts)
+    while os.path.exists(temp_path):
+        attempts += 1
+        temp_path = file[
+            : -len(".jproj")
+        ] + "_attempts_%d.jproj" % (attempts)
+
+    file = temp_path
+
+tool_jmag.open(comp_filepath=file, length_unit="DimMillimeter", study_type="Transient")
+tool_jmag.set_visibility(True)
+
+# Draw the model
+tool_jmag.sketch = tool_jmag.create_sketch()
+tool_jmag.sketch.SetProperty("Name", rotor_partial.name)
+tool_jmag.sketch.SetProperty("Color", r"#808080")
+cs_rotor_core = rotor_partial.draw(tool_jmag)
+rotor_tool = tool_jmag.prepare_section(cs_rotor_core, num_copy_rotate=Qr)
+
+tool_jmag.sketch = tool_jmag.create_sketch()
+tool_jmag.sketch.SetProperty("Name", bar1_partial.name)
+tool_jmag.sketch.SetProperty("Color", r"#C89E9B")
+cs_rotor_bar1 = bar1_partial.draw(tool_jmag)
+rotor_bar_tool1 = tool_jmag.prepare_section(cs_rotor_bar1, num_copy_rotate=Qr)
+
+tool_jmag.sketch = tool_jmag.create_sketch()
+tool_jmag.sketch.SetProperty("Name", bar2_partial.name)
+tool_jmag.sketch.SetProperty("Color", r"#C89E9B")
+cs_rotor_bar2 = bar2_partial.draw(tool_jmag)
+rotor_bar_tool2 = tool_jmag.prepare_section(cs_rotor_bar2, num_copy_rotate=Qr)
+
+tool_jmag.doc.SaveModel(False)
+
+# Save the file
+tool_jmag.save()

--- a/mach_cad/model_obj/cross_sects/__init__.py
+++ b/mach_cad/model_obj/cross_sects/__init__.py
@@ -14,6 +14,9 @@ from .breadloaf import *
 from .arc import*
 from .flux_barrier_rotor import*
 from .inner_reluctance_rotor import*
+from .inner_rotor_round_slots import *
+from .inner_rotor_drop_slots import *
+from .inner_rotor_round_slots_double_cage import *
 
 __all__ = []
 __all__ += hollow_cylinder.__all__
@@ -31,4 +34,6 @@ __all__ += breadloaf.__all__
 __all__ += arc.__all__
 __all__ += flux_barrier_rotor.__all__
 __all__ += inner_reluctance_rotor.__all__
-
+__all__ += inner_rotor_round_slots.__all__
+__all__ += inner_rotor_drop_slots.__all__
+__all__ += inner_rotor_round_slots_double_cage.__all__

--- a/mach_cad/model_obj/cross_sects/inner_rotor_drop_slots/CrossSectInnerRotorDropSlots.svg
+++ b/mach_cad/model_obj/cross_sects/inner_rotor_drop_slots/CrossSectInnerRotorDropSlots.svg
@@ -1,0 +1,1853 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   inkscape:export-ydpi="150"
+   inkscape:export-xdpi="150"
+   inkscape:export-filename="C:\Users\nheme\Documents\Research\Bearingless Motor\Bearinless_Parametrization_Rev1_wht_bckgrnd.png"
+   inkscape:version="1.0.1 (3bc2e813f5, 2020-09-07)"
+   sodipodi:docname="CrossSectInnerRotorDropSlots.svg"
+   id="svg837"
+   version="1.1"
+   viewBox="0 0 207.79715 169.77094"
+   height="169.77094mm"
+   width="207.79715mm">
+  <defs
+     id="defs831">
+    <marker
+       inkscape:stockid="Arrow1Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker11428"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path11426"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker8873"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path8871"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker8863"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mend">
+      <path
+         transform="matrix(-0.4,0,0,-0.4,-4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path8861" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker7321"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path7319"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker7311"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mstart">
+      <path
+         transform="matrix(0.4,0,0,0.4,4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path7309" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker6185"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path6183"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker6175"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mstart">
+      <path
+         transform="matrix(0.4,0,0,0.4,4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path6173" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker5345"
+       style="overflow:visible"
+       inkscape:isstock="true"
+       inkscape:collect="always">
+      <path
+         id="path5343"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker5335"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mstart"
+       inkscape:collect="always">
+      <path
+         transform="matrix(0.4,0,0,0.4,4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path5333" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker4547"
+       style="overflow:visible"
+       inkscape:isstock="true"
+       inkscape:collect="always">
+      <path
+         id="path4545"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker4537"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mstart"
+       inkscape:collect="always">
+      <path
+         transform="matrix(0.4,0,0,0.4,4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path4535" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker3321"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path3319"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker3311"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mstart">
+      <path
+         transform="matrix(0.4,0,0,0.4,4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path3309" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker2565"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path2563"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#ff0000;fill-opacity:1;fill-rule:evenodd;stroke:#ff0000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker2555"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mend">
+      <path
+         transform="matrix(-0.4,0,0,-0.4,-4,0)"
+         style="fill:#ff0000;fill-opacity:1;fill-rule:evenodd;stroke:#ff0000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path2553" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker2545"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path2543"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker2535"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mstart">
+      <path
+         transform="matrix(0.4,0,0,0.4,4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path2533" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker6553"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path6551"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker5313"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mend">
+      <path
+         transform="matrix(-0.4,0,0,-0.4,-4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path5311" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker3363"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path3361"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mstart"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker2957"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path2955"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(0.4,0,0,0.4,4,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mstart"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker4727"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path4725"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(0.4,0,0,0.4,4,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mstart"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker4345"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path4343"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(0.4,0,0,0.4,4,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mstart"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker3969"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path3967"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(0.4,0,0,0.4,4,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mstart"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker3599"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path3597"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(0.4,0,0,0.4,4,0)" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker2905"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow2Send">
+      <path
+         transform="matrix(-0.3,0,0,-0.3,0.69,0)"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         id="path2903" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker3124"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow2Send">
+      <path
+         transform="matrix(-0.3,0,0,-0.3,0.69,0)"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         id="path3122" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow2Send"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker4852"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path4850"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         transform="matrix(-0.3,0,0,-0.3,0.69,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow2Send"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker3691"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path3689"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         transform="matrix(-0.3,0,0,-0.3,0.69,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Sstart"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker3429"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path3427"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(0.2,0,0,0.2,1.2,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow2Send"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker2019"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path2017"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         transform="matrix(-0.3,0,0,-0.3,0.69,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow2Sstart"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker1781"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path1779"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         transform="matrix(0.3,0,0,0.3,-0.69,0)" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker1488"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mend">
+      <path
+         transform="matrix(-0.4,0,0,-0.4,-4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path1486" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker1244"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mend">
+      <path
+         inkscape:connector-curvature="0"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path1242" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow2Send"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker16235"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path16233"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         transform="matrix(-0.3,0,0,-0.3,0.69,0)" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:stockid="Arrow2Send"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker15733"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path15731"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         transform="matrix(-0.3,0,0,-0.3,0.69,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker15525"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path15523"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker9500"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mend">
+      <path
+         transform="matrix(-0.4,0,0,-0.4,-4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path9498" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker8403"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mstart">
+      <path
+         transform="matrix(0.4,0,0,0.4,4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path8401" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker8209"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mend">
+      <path
+         transform="matrix(-0.4,0,0,-0.4,-4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path8207" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker8061"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mstart">
+      <path
+         transform="matrix(0.4,0,0,0.4,4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path8059" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker7820"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path7818"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mstart"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker7684"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path7682"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(0.4,0,0,0.4,4,0)" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:stockid="Arrow1Mstart"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker6757"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path6755"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(0.4,0,0,0.4,4,0)" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:stockid="Arrow1Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker6627"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path6625"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker6012"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mstart">
+      <path
+         transform="matrix(0.4,0,0,0.4,4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path6010" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker5894"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mend">
+      <path
+         transform="matrix(-0.4,0,0,-0.4,-4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path5892" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:stockid="Arrow1Mstart"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker5567"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path5565"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(0.4,0,0,0.4,4,0)" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:stockid="Arrow1Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker5461"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path5459"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:stockid="Arrow1Mstart"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker5080"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path5078"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(0.4,0,0,0.4,4,0)" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker4986"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mend">
+      <path
+         transform="matrix(-0.4,0,0,-0.4,-4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path4984" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker4450"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow2Send">
+      <path
+         transform="matrix(-0.3,0,0,-0.3,0.69,0)"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         id="path4448" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker4374"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path4372"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:stockid="Arrow1Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker4128"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path4126"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker3864"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mend">
+      <path
+         transform="matrix(-0.4,0,0,-0.4,-4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path3862" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="Arrow1Mstart"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mstart">
+      <path
+         transform="matrix(0.4,0,0,0.4,4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path1491" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="Arrow1Sstart"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Sstart">
+      <path
+         transform="matrix(0.2,0,0,0.2,1.2,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path1497" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker1939"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow2Send">
+      <path
+         transform="matrix(-0.3,0,0,-0.3,0.69,0)"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         id="path1937" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="Arrow2Sstart"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow2Sstart">
+      <path
+         transform="matrix(0.3,0,0,0.3,-0.69,0)"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         id="path1515" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="Arrow2Send"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow2Send">
+      <path
+         transform="matrix(-0.3,0,0,-0.3,0.69,0)"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         id="path1518" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="Arrow2Mstart"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow2Mstart">
+      <path
+         transform="scale(0.6)"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         id="path1509" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="Arrow1Mend"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mend">
+      <path
+         transform="matrix(-0.4,0,0,-0.4,-4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path1494" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:stockid="Arrow1Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker4128-8"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path4126-2"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow2Send"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker4852-2"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path4850-0"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         transform="matrix(-0.3,0,0,-0.3,0.69,0)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow2Send"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker4852-2-2"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path4850-0-3"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         transform="matrix(-0.3,0,0,-0.3,0.69,0)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       id="DistanceX"
+       orient="auto"
+       refX="0"
+       refY="0"
+       style="overflow:visible">
+      <path
+         d="M 3,-3 -3,3 M 0,-5 V 5"
+         style="stroke:#000000;stroke-width:0.5"
+         id="path1492" />
+    </marker>
+    <pattern
+       id="Hatch"
+       patternUnits="userSpaceOnUse"
+       width="8"
+       height="8"
+       x="0"
+       y="0">
+      <path
+         d="M8 4 l-4,4"
+         stroke="#000000"
+         stroke-width="0.25"
+         linecap="square"
+         id="path1495" />
+      <path
+         d="M6 2 l-4,4"
+         stroke="#000000"
+         stroke-width="0.25"
+         linecap="square"
+         id="path1497-9" />
+      <path
+         d="M4 0 l-4,4"
+         stroke="#000000"
+         stroke-width="0.25"
+         linecap="square"
+         id="path1499" />
+    </pattern>
+    <marker
+       id="DistanceX-3"
+       orient="auto"
+       refX="0"
+       refY="0"
+       style="overflow:visible">
+      <path
+         d="M 3,-3 -3,3 M 0,-5 V 5"
+         style="stroke:#000000;stroke-width:0.5"
+         id="path1451" />
+    </marker>
+    <pattern
+       id="Hatch-7"
+       patternUnits="userSpaceOnUse"
+       width="8"
+       height="8"
+       x="0"
+       y="0">
+      <path
+         d="M8 4 l-4,4"
+         stroke="#000000"
+         stroke-width="0.25"
+         linecap="square"
+         id="path1454" />
+      <path
+         d="M6 2 l-4,4"
+         stroke="#000000"
+         stroke-width="0.25"
+         linecap="square"
+         id="path1456" />
+      <path
+         d="M4 0 l-4,4"
+         stroke="#000000"
+         stroke-width="0.25"
+         linecap="square"
+         id="path1458" />
+    </pattern>
+    <marker
+       inkscape:stockid="Arrow1Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker5969-8"
+       style="overflow:visible"
+       inkscape:isstock="true"
+       inkscape:collect="always">
+      <path
+         id="path5967-4"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker6553-9"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path6551-2"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)" />
+    </marker>
+  </defs>
+  <sodipodi:namedview
+     height="281mm"
+     inkscape:document-rotation="0"
+     inkscape:snap-to-guides="true"
+     inkscape:snap-global="true"
+     inkscape:snap-bbox="false"
+     inkscape:object-paths="true"
+     inkscape:snap-intersection-paths="true"
+     inkscape:snap-object-midpoints="true"
+     inkscape:snap-others="true"
+     inkscape:snap-smooth-nodes="true"
+     inkscape:snap-midpoints="true"
+     inkscape:snap-center="true"
+     inkscape:window-maximized="1"
+     inkscape:window-y="-8"
+     inkscape:window-x="-8"
+     inkscape:window-height="1017"
+     inkscape:window-width="1920"
+     inkscape:guide-bbox="true"
+     showguides="false"
+     showborder="true"
+     showgrid="false"
+     inkscape:current-layer="layer4"
+     inkscape:document-units="mm"
+     inkscape:cy="214.56096"
+     inkscape:cx="111.44055"
+     inkscape:zoom="0.7071068"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     borderopacity="1.0"
+     bordercolor="#666666"
+     pagecolor="#ffffff"
+     id="base" />
+  <metadata
+     id="metadata834">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     style="display:none"
+     inkscape:label="Background"
+     id="layer5"
+     inkscape:groupmode="layer"
+     transform="translate(0.11219308,26.269005)" />
+  <g
+     style="display:none"
+     id="layer1"
+     inkscape:groupmode="layer"
+     inkscape:label="Total_Motor"
+     transform="translate(0.11219308,26.269005)">
+    <path
+       inkscape:connector-curvature="0"
+       id="path1388"
+       transform="scale(0.26458333)"
+       d="M 0,650.07812 A 472.4409,472.4409 0 0 0 -472.44141,1122.5195 472.4409,472.4409 0 0 0 0,1594.9609 472.4409,472.4409 0 0 0 472.44141,1122.5195 472.4409,472.4409 0 0 0 0,650.07812 Z m -62.580078,131.7168 c 2.119773,-0.0633 4.238058,0.0941 6.103516,0.6543 2.541358,0.7632 4.943413,2.47682 6.457031,4.65625 1.450551,2.08861 2.260179,4.14371 2.77539,6.56445 v 96.20703 l -32.126953,32.12696 v 25.01171 A 192.85715,192.85715 0 0 1 0,929.66211 192.85715,192.85715 0 0 1 79.371094,946.94922 V 922.00391 L 47.244141,889.87695 v -96.1914 c 0.515003,-2.42755 1.32369,-4.487 2.777343,-6.58008 1.513618,-2.17943 3.915677,-3.89305 6.457032,-4.65625 1.645518,-0.49416 3.491159,-0.65631 5.357422,-0.64844 A 347.10338,347.10338 0 0 1 262.25586,895.70703 c 1.75673,2.4167 3.37685,5.15152 4.01758,7.86524 0.60972,2.58247 0.32595,5.51939 -0.80469,7.91992 -1.08536,2.30442 -2.46502,4.03425 -4.30859,5.69336 l -83.3086,48.09765 -43.88476,-11.75781 -21.66211,12.50586 a 192.85715,192.85715 0 0 1 54.71484,60.06055 192.85715,192.85715 0 0 1 24.71485,77.3809 L 213.33789,1091 l 11.75781,-43.8867 83.31055,-48.09963 c 2.35704,-0.76605 4.54514,-1.093 7.08203,-0.88086 2.64428,0.2211 5.33009,1.4444 7.26172,3.26369 1.49012,1.4034 2.72559,3.2743 3.76172,5.248 a 347.10338,347.10338 0 0 1 20.5918,115.875 347.10338,347.10338 0 0 1 -20.0625,114.8164 c -1.13505,2.3551 -2.53462,4.6543 -4.28907,6.3067 -1.93162,1.8193 -4.61553,3.0425 -7.25976,3.2636 -2.5387,0.2123 -4.72893,-0.1155 -7.08789,-0.8828 l -83.3086,-48.0976 -11.75781,-43.8848 -21.66211,-12.5058 a 192.85715,192.85715 0 0 1 -24.65625,77.414 192.85715,192.85715 0 0 1 -54.65625,60.0938 l 21.60352,12.4726 43.88476,-11.7597 83.30664,48.0976 c 1.84358,1.6591 3.22324,3.3889 4.3086,5.6934 1.13066,2.4005 1.41246,5.3374 0.80273,7.9199 -0.38563,1.6333 -1.14266,3.2715 -2.05273,4.8496 A 347.10338,347.10338 0 0 1 63.15625,1463.209 c -2.309571,0.1107 -4.639833,-0.01 -6.673828,-0.6192 -2.541351,-0.7632 -4.94539,-2.4748 -6.458984,-4.6543 -1.45523,-2.0953 -2.264404,-4.1588 -2.779297,-6.5898 v -96.1836 l 32.126953,-32.1269 v -25.0118 A 192.85715,192.85715 0 0 1 0,1315.377 192.85715,192.85715 0 0 1 -79.371094,1298.0898 v 24.9454 l 32.126953,32.1269 v 96.1914 c -0.514998,2.4276 -1.323687,4.489 -2.777343,6.582 -1.513614,2.1795 -3.915681,3.8911 -6.457032,4.6543 -1.645521,0.4942 -3.491159,0.6564 -5.357422,0.6485 A 347.10338,347.10338 0 0 1 -262.22656,1349.3672 c -1.76655,-2.4252 -3.39721,-5.1736 -4.04102,-7.9004 -0.60972,-2.5825 -0.32791,-5.5194 0.80274,-7.9199 1.08656,-2.307 2.46775,-4.0385 4.31445,-5.6992 l 83.29883,-48.0918 43.88476,11.7597 21.66211,-12.5058 a 192.85715,192.85715 0 0 1 -54.71484,-60.0606 192.85715,192.85715 0 0 1 -24.71485,-77.3808 l -21.60351,12.4726 -11.75781,43.8848 -83.31055,48.0996 c -2.35704,0.766 -4.54513,1.093 -7.08203,0.8808 -2.64427,-0.2211 -5.33009,-1.4443 -7.26172,-3.2636 -1.49012,-1.4035 -2.72559,-3.2744 -3.76172,-5.2481 a 347.10338,347.10338 0 0 1 -20.5918,-115.875 347.10338,347.10338 0 0 1 20.04688,-114.7754 c 1.13845,-2.3696 2.54575,-4.6855 4.31055,-6.3476 1.93163,-1.81929 4.61551,-3.04259 7.25976,-3.26369 2.53416,-0.21191 4.7201,0.11466 7.07422,0.87891 l 83.31641,48.10158 11.75781,43.8867 21.66211,12.5059 a 192.85715,192.85715 0 0 1 24.65625,-77.4141 192.85715,192.85715 0 0 1 54.65625,-60.09571 l -21.60352,-12.4707 -43.88476,11.75781 -83.30664,-48.09765 c -1.84358,-1.65911 -3.22324,-3.38894 -4.3086,-5.69336 -1.13063,-2.40057 -1.41246,-5.33745 -0.80273,-7.91992 0.3858,-1.63403 1.14211,-3.27284 2.05273,-4.85157 A 347.10338,347.10338 0 0 1 -63.158203,781.83008 c 0.193318,-0.009 0.38466,-0.0294 0.578125,-0.0352 z"
+       style="opacity:1;fill:#008000;fill-opacity:1;stroke:#000000;stroke-width:3.77953;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+    <circle
+       r="43.733097"
+       cy="297"
+       cx="0"
+       id="path1390"
+       style="opacity:1;fill:#ff0000;fill-opacity:1;stroke:#000000;stroke-width:1.09333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+  </g>
+  <g
+     style="display:none"
+     inkscape:label="Motor_Cutaway"
+     id="layer2"
+     inkscape:groupmode="layer"
+     transform="translate(0.11219308,26.269005)" />
+  <g
+     style="display:none"
+     inkscape:label="Annotations_1"
+     id="layer3"
+     inkscape:groupmode="layer"
+     transform="translate(0.11219308,26.269005)">
+    <path
+       inkscape:connector-curvature="0"
+       id="path5884"
+       d="M -7.5563861,234.90369 V 206.70526"
+       style="fill:none;stroke:#000000;stroke-width:0.259632px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-start:url(#marker6012);marker-end:url(#marker5894)" />
+    <rect
+       y="218.84871"
+       x="-8.3674479"
+       height="2.2158854"
+       width="1.5875"
+       id="rect6524"
+       style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.264583;stroke-miterlimit:4;stroke-dasharray:0.79375, 0.264583;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal" />
+    <path
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       id="path1464"
+       d="M -0.02743323,297.01265 35.30925,221.27907"
+       style="fill:none;stroke:#000000;stroke-width:0.202531;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:0.810125, 0.202531;stroke-dashoffset:0;stroke-opacity:1" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.202531;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:0.810125, 0.202531;stroke-dashoffset:0;stroke-opacity:1"
+       d="M 0,297 -35.336683,221.26642"
+       id="path1466"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cc" />
+    <path
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       id="path1470"
+       d="M -21.000268,250.56454 V 221.26642"
+       style="fill:none;stroke:#000000;stroke-width:0.264583;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:0.79375, 0.264583;stroke-dashoffset:0;stroke-opacity:1" />
+    <path
+       sodipodi:nodetypes="csc"
+       inkscape:connector-curvature="0"
+       id="path1482"
+       d="m -11.797594,270.57892 c 3.5813579,-1.66871 7.5752744,-2.60053 11.78682858,-2.60053 4.23356982,0 8.24722062,0.94159 11.84295942,2.62676"
+       style="opacity:1;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.264583;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-start:url(#Arrow2Sstart);marker-end:url(#Arrow2Send);paint-order:normal" />
+    <g
+       transform="translate(-23.187493,-34.196779)"
+       id="g1919">
+      <rect
+         style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.264583;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal"
+         id="rect1907"
+         width="6.160902"
+         height="5.5858846"
+         x="20.12562"
+         y="299.38223" />
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+         x="20.947077"
+         y="304.3931"
+         id="text1895"><tspan
+           sodipodi:role="line"
+           id="tspan1893"
+           x="20.947077"
+           y="304.3931"
+           style="stroke-width:0.264583">θ<tspan
+   style="font-size:3.52778px"
+   id="tspan1897">t</tspan></tspan></text>
+    </g>
+    <flowRoot
+       transform="scale(0.26458333)"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:24px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none"
+       id="flowRoot1899"
+       xml:space="preserve"><flowRegion
+         id="flowRegion1901"><rect
+           y="1122.5197"
+           x="61.473213"
+           height="49.675323"
+           width="50.91721"
+           id="rect1903" /></flowRegion><flowPara
+         id="flowPara1905" /></flowRoot>
+    <path
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       id="path1934"
+       d="m -29.626283,232.40708 c 2.447086,-1.23671 5.213559,-1.9334 8.142751,-1.9334"
+       style="display:inline;opacity:1;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.236671;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-start:url(#Arrow1Sstart);marker-end:url(#marker1939);paint-order:normal" />
+    <rect
+       y="229.11623"
+       x="-27.407322"
+       height="3.6542518"
+       width="3.6240244"
+       id="rect1927"
+       style="display:inline;opacity:1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.13113;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal" />
+    <text
+       id="text1923"
+       y="232.42699"
+       x="-27.561081"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+       xml:space="preserve"><tspan
+         style="stroke-width:0.264583"
+         y="232.42699"
+         x="-27.561081"
+         id="tspan1921"
+         sodipodi:role="line">α</tspan></text>
+    <path
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       id="path3542"
+       d="m 25.501249,208.12668 8.748058,-30.47166"
+       style="fill:none;stroke:#000000;stroke-width:0.251839px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-start:url(#Arrow1Mstart);marker-end:url(#marker3864)" />
+    <text
+       id="text4090"
+       y="162.72395"
+       x="57.811459"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+       xml:space="preserve"><tspan
+         style="stroke-width:0.264583"
+         y="162.72395"
+         x="57.811459"
+         id="tspan4088"
+         sodipodi:role="line" /></text>
+    <path
+       inkscape:connector-curvature="0"
+       id="path3528"
+       d="M -12.500012,236.16224 V 246.8512"
+       style="display:inline;fill:none;stroke:#000000;stroke-width:0.24847px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-start:url(#marker5567);marker-end:url(#marker5461)" />
+    <text
+       id="text4094"
+       y="173.58723"
+       x="-52.318027"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+       xml:space="preserve"><tspan
+         style="stroke-width:0.264583"
+         y="173.58723"
+         x="-52.318027"
+         id="tspan4092"
+         sodipodi:role="line">D<tspan
+   id="tspan4096"
+   style="font-size:3.52778px">os</tspan></tspan></text>
+    <g
+       transform="translate(-16.559098,-7.3212701)"
+       id="g4116">
+      <rect
+         style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:0.237103;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal"
+         id="rect4104"
+         width="6.6424799"
+         height="5.9479485"
+         x="43.113136"
+         y="197.23814" />
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+         x="43.78854"
+         y="202.14687"
+         id="text4100"><tspan
+           sodipodi:role="line"
+           id="tspan4098"
+           x="43.78854"
+           y="202.14687"
+           style="stroke-width:0.264583">T<tspan
+   style="font-size:3.52778px"
+   id="tspan4102">s</tspan></tspan></text>
+    </g>
+    <path
+       sodipodi:nodetypes="ccc"
+       inkscape:connector-curvature="0"
+       id="path4118"
+       d="m -44.334244,171.98437 h 2.000911 l 4.828646,4.82865"
+       style="fill:none;stroke:#000000;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#marker4128)" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path4364"
+       d="m 15.718783,210.03594 -1.547002,-1.79208"
+       style="fill:none;stroke:#000000;stroke-width:0.191617;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:0.383234, 0.191617;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker4450)" />
+    <text
+       id="text4634"
+       y="212.41602"
+       x="15.941146"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+       xml:space="preserve"><tspan
+         style="stroke-width:0.264583"
+         y="212.41602"
+         x="15.941146"
+         id="tspan4632"
+         sodipodi:role="line">r</tspan></text>
+    <path
+       inkscape:connector-curvature="0"
+       id="path4976"
+       d="M -11.547554,219.80781 H 11.547554"
+       style="fill:none;stroke:#000000;stroke-width:0.254303px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-start:url(#marker5080);marker-end:url(#marker4986)" />
+    <g
+       transform="translate(-43.306146,19.473489)"
+       id="g4116-9">
+      <g
+         transform="translate(0,0.18708867)"
+         id="g5421">
+        <rect
+           y="197.24779"
+           x="42.65506"
+           height="5.928659"
+           width="7.7924948"
+           id="rect4104-4"
+           style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:0.256393;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal" />
+        <text
+           id="text4100-8"
+           y="202.70813"
+           x="42.993412"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+           xml:space="preserve"><tspan
+             style="stroke-width:0.264583"
+             y="202.70813"
+             x="42.993412"
+             id="tspan4098-5"
+             sodipodi:role="line">W<tspan
+   style="font-size:3.52778px"
+   id="tspan5415">t</tspan></tspan></text>
+      </g>
+    </g>
+    <path
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       id="path5449"
+       d="m -12.500012,247.56684 h 9.8872516"
+       style="fill:none;stroke:#000000;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+    <path
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       id="path5451"
+       d="m -12.500012,235.4466 h 9.8872516"
+       style="fill:none;stroke:#000000;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+    <path
+       sodipodi:arc-type="arc"
+       style="display:inline;opacity:1;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.265;stroke-miterlimit:4;stroke-dasharray:0.795, 0.265;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal"
+       id="path5875"
+       sodipodi:type="arc"
+       sodipodi:cx="0"
+       sodipodi:cy="296.99997"
+       sodipodi:rx="91.67807"
+       sodipodi:ry="91.67807"
+       sodipodi:start="4.4466291"
+       sodipodi:end="4.5768786"
+       sodipodi:open="true"
+       d="m -24.078562,208.54042 a 91.67807,91.67807 0 0 1 11.693219,-2.37806" />
+    <path
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       id="path5878"
+       d="m -12.500012,213.23104 v -7.0392"
+       style="fill:none;stroke:#000000;stroke-width:0.264583;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:0.79375, 0.264583;stroke-dashoffset:0;stroke-opacity:1" />
+    <path
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       id="path5882"
+       d="m -12.385343,206.16235 h 9.7725826"
+       style="fill:none;stroke:#000000;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+    <g
+       transform="translate(-53.364328,27.478398)"
+       id="g4116-9-8"
+       style="display:inline">
+      <g
+         transform="translate(0,0.18708867)"
+         id="g5421-1">
+        <rect
+           y="197.24779"
+           x="42.65506"
+           height="5.928659"
+           width="7.7924948"
+           id="rect4104-4-4"
+           style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:0.256393;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal" />
+        <text
+           id="text4100-8-5"
+           y="202.17897"
+           x="43.456432"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+           xml:space="preserve"><tspan
+             style="stroke-width:0.264583"
+             y="202.17897"
+             x="43.456432"
+             id="tspan4098-5-6"
+             sodipodi:role="line"><tspan
+               style="font-size:3.52778px"
+               id="tspan5415-7"><tspan
+   id="tspan6615"
+   style="font-size:6.35px">L</tspan>t</tspan></tspan></text>
+      </g>
+    </g>
+    <g
+       transform="translate(-53.364328,40.708055)"
+       id="g4116-9-8-7"
+       style="display:inline">
+      <g
+         transform="translate(0,0.18708867)"
+         id="g5421-1-5">
+        <rect
+           y="197.24779"
+           x="42.65506"
+           height="5.928659"
+           width="7.7924948"
+           id="rect4104-4-4-1"
+           style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:0.256393;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal" />
+        <text
+           id="text4100-8-5-7"
+           y="202.17897"
+           x="43.456432"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+           xml:space="preserve"><tspan
+             style="stroke-width:0.264583"
+             y="202.17897"
+             x="43.456432"
+             id="tspan4098-5-6-6"
+             sodipodi:role="line"><tspan
+               style="font-size:3.52778px"
+               id="tspan5415-7-7"><tspan
+   id="tspan6580-5"
+   style="font-size:6.35px">L</tspan>tt</tspan></tspan></text>
+      </g>
+    </g>
+    <path
+       sodipodi:nodetypes="ccc"
+       inkscape:connector-curvature="0"
+       id="path4118-8"
+       d="m -28.486583,277.7367 h -2.000911 l -4.828646,-4.82865"
+       style="display:inline;fill:none;stroke:#000000;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#marker4128-8)" />
+    <text
+       id="text4094-6"
+       y="279.95316"
+       x="-28.468546"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+       xml:space="preserve"><tspan
+         style="stroke-width:0.264583"
+         y="279.95316"
+         x="-28.468546"
+         id="tspan4092-2"
+         sodipodi:role="line">D<tspan
+   id="tspan4096-9"
+   style="font-size:3.52778px;stroke-width:0.264583">or</tspan></tspan></text>
+    <path
+       inkscape:transform-center-y="-47.336963"
+       inkscape:transform-center-x="-0.53635573"
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       id="path6617"
+       d="m 0.49341607,252.4546 0.0643483,-5.62927"
+       style="display:inline;fill:none;stroke:#000000;stroke-width:0.204665px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-start:url(#marker6757);marker-end:url(#marker6627)" />
+    <text
+       id="text4100-8-5-7-6"
+       y="251.6891"
+       x="1.700698"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+       xml:space="preserve"><tspan
+         style="stroke-width:0.264583"
+         y="251.6891"
+         x="1.700698"
+         id="tspan4098-5-6-6-5"
+         sodipodi:role="line"><tspan
+           style="font-size:3.52778px"
+           id="tspan5415-7-7-3"><tspan
+   id="tspan6580-5-5"
+   style="font-size:6.35px">L</tspan>g</tspan></tspan></text>
+    <path
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       id="path15507"
+       d="m 21.000268,250.54698 h 8.688366"
+       style="fill:none;stroke:#000000;stroke-width:0.23934px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+    <path
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       id="path15509"
+       d="m 21.000268,243.94686 h 8.688366"
+       style="fill:none;stroke:#000000;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+    <text
+       id="text15513"
+       y="248.73111"
+       x="25.765221"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+       xml:space="preserve"><tspan
+         style="stroke-width:0.264583"
+         y="248.73111"
+         x="25.765221"
+         id="tspan15511"
+         sodipodi:role="line">s</tspan></text>
+    <path
+       inkscape:connector-curvature="0"
+       id="path15515"
+       d="m 27.057699,249.05852 v 0.97042"
+       style="fill:none;stroke:#000000;stroke-width:0.276484px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#marker15733)" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path15945"
+       d="m 27.060298,245.50384 v -1.05237"
+       style="fill:none;stroke:#000000;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#marker16235)" />
+  </g>
+  <g
+     style="display:inline"
+     inkscape:label="Annotations_2"
+     id="layer4"
+     inkscape:groupmode="layer"
+     transform="translate(0.11219308,26.269005)">
+    <g
+       transform="translate(125.42796,-33.89125)"
+       id="g4116-9-8-2-5"
+       style="display:inline">
+      <g
+         transform="translate(0,0.18708867)"
+         id="g5421-1-7-0">
+        <text
+           id="text4100-8-5-1-8"
+           y="202.24512"
+           x="42.629608"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+           xml:space="preserve"><tspan
+             style="stroke-width:0.264583"
+             y="0"
+             x="0"
+             id="tspan4098-5-6-1-3"
+             sodipodi:role="line"><tspan
+               style="font-size:3.52778px"
+               id="tspan5415-7-3-8"><tspan
+                 id="tspan6615-5-9"
+                 style="font-size:6.35px" /></tspan></tspan></text>
+      </g>
+    </g>
+    <text
+       xml:space="preserve"
+       style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;line-height:1.25;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman, Italic';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#999999;fill-opacity:1;stroke:none;stroke-width:0.264583"
+       x="79.321648"
+       y="79.647224"
+       id="text9973"><tspan
+         sodipodi:role="line"
+         id="tspan9971"
+         x="79.321648"
+         y="79.647224"
+         style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman,  Italic';fill:#000000;stroke-width:0.264583">d<tspan
+   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:65%;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman, ';baseline-shift:sub;fill:#000000"
+   id="tspan9969">ri</tspan></tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-size:6.35px;line-height:0.95;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math';display:inline;stroke-width:0.264583"
+       x="152.3165"
+       y="137.58136"
+       id="text1453"><tspan
+         sodipodi:role="line"
+         id="tspan1451"
+         x="152.3165"
+         y="137.58136"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman, ';stroke-width:0.264583"><tspan
+   style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman, Italic';stroke-width:0.264583"
+   id="tspan1455">Q<tspan
+   style="font-style:normal;font-size:65%;baseline-shift:sub"
+   id="tspan1571">r</tspan></tspan> = number of slots</tspan></text>
+    <path
+       d="M 157.13096,84.827288 H 136.85158"
+       style="fill:none;stroke:#000000;stroke-width:0.8;stroke-miterlimit:4;stroke-dasharray:none"
+       id="path1463" />
+    <path
+       d="M 124.49895,92.10997 105.48704,87.20101"
+       style="fill:none;stroke:#000000;stroke-width:0.8;stroke-miterlimit:4;stroke-dasharray:none"
+       id="path1465" />
+    <path
+       d="m 105.48704,77.383346 19.01191,-4.908705"
+       style="fill:none;stroke:#000000;stroke-width:0.8;stroke-miterlimit:4;stroke-dasharray:none"
+       id="path1467" />
+    <path
+       d="m 136.85158,79.757348 h 20.27938"
+       style="fill:none;stroke:#000000;stroke-width:0.8;stroke-miterlimit:4;stroke-dasharray:none"
+       id="path1469" />
+    <path
+       d="M 141.46079,21.275436 123.89835,31.415317"
+       style="fill:none;stroke:#000000;stroke-width:0.8;stroke-miterlimit:4;stroke-dasharray:none"
+       id="path1471" />
+    <path
+       d="M 116.84205,43.898615 97.922827,49.1534"
+       style="fill:none;stroke:#000000;stroke-width:0.8;stroke-miterlimit:4;stroke-dasharray:none"
+       id="path1473" />
+    <path
+       d="M 93.013967,40.651096 107.02433,26.893739"
+       style="fill:none;stroke:#000000;stroke-width:0.8;stroke-miterlimit:4;stroke-dasharray:none"
+       id="path1475" />
+    <path
+       d="M 121.36342,27.024661 138.92588,16.885048"
+       style="fill:none;stroke:#000000;stroke-width:0.8;stroke-miterlimit:4;stroke-dasharray:none"
+       id="path1477" />
+    <path
+       d="m 152.8477,115.01966 a 126.44951,126.44951 0 0 0 4.28326,-30.192372"
+       style="fill:none;stroke:#000000;stroke-width:0.8;stroke-miterlimit:4;stroke-dasharray:none"
+       id="path1559" />
+    <path
+       d="m 124.49895,92.10997 a 10.139687,10.139687 0 0 0 12.35263,-7.282682"
+       style="fill:none;stroke:#000000;stroke-width:0.8;stroke-miterlimit:4;stroke-dasharray:none"
+       id="path1561" />
+    <path
+       d="m 101.68465,82.292318 a 5.0698434,5.0698434 0 0 0 3.80239,4.908692"
+       style="fill:none;stroke:#000000;stroke-width:0.8;stroke-miterlimit:4;stroke-dasharray:none"
+       id="path1563" />
+    <path
+       d="m 105.48704,77.383346 a 5.0698434,5.0698434 0 0 0 -3.80239,4.908972"
+       style="fill:none;stroke:#000000;stroke-width:0.8;stroke-miterlimit:4;stroke-dasharray:none"
+       id="path1565" />
+    <path
+       d="M 136.85158,79.757348 A 10.139687,10.139687 0 0 0 124.49895,72.474641"
+       style="fill:none;stroke:#000000;stroke-width:0.8;stroke-miterlimit:4;stroke-dasharray:none"
+       id="path1567" />
+    <path
+       d="M 157.13096,79.757348 A 126.44951,126.44951 0 0 0 152.8477,49.564672"
+       style="fill:none;stroke:#000000;stroke-width:0.8;stroke-miterlimit:4;stroke-dasharray:none"
+       id="path1569" />
+    <path
+       d="M 152.8477,49.564672 A 126.44951,126.44951 0 0 0 141.46079,21.275436"
+       style="fill:none;stroke:#000000;stroke-width:0.8;stroke-miterlimit:4;stroke-dasharray:none"
+       id="path1571" />
+    <path
+       d="m 116.84204,43.898615 a 10.139687,10.139687 0 0 0 7.0563,-12.483298"
+       style="fill:none;stroke:#000000;stroke-width:0.8;stroke-miterlimit:4;stroke-dasharray:none"
+       id="path1573" />
+    <path
+       d="m 92.175437,46.803274 a 5.0698434,5.0698434 0 0 0 5.74739,2.350126"
+       style="fill:none;stroke:#000000;stroke-width:0.8;stroke-miterlimit:4;stroke-dasharray:none"
+       id="path1575" />
+    <path
+       d="m 93.013967,40.651096 a 5.0698434,5.0698434 0 0 0 -0.83853,6.152178"
+       style="fill:none;stroke:#000000;stroke-width:0.8;stroke-miterlimit:4;stroke-dasharray:none"
+       id="path1577" />
+    <path
+       d="M 121.36342,27.024661 A 10.139687,10.139687 0 0 0 107.02433,26.8932"
+       style="fill:none;stroke:#000000;stroke-width:0.8;stroke-miterlimit:4;stroke-dasharray:none"
+       id="path1579" />
+    <path
+       d="M 138.92587,16.885048 A 126.44951,126.44951 0 0 0 120.12015,-7.1211101"
+       style="fill:none;stroke:#000000;stroke-width:0.8;stroke-miterlimit:4;stroke-dasharray:none"
+       id="path1581" />
+    <path
+       d="M 120.12015,-7.1211101 A 126.44951,126.44951 0 0 0 96.114207,-25.926673"
+       style="fill:none;stroke:#000000;stroke-width:0.8;stroke-miterlimit:4;stroke-dasharray:none"
+       id="path1583" />
+    <path
+       d="M 141.46079,143.30891 A 126.44951,126.44951 0 0 0 152.8477,115.01966"
+       style="fill:none;stroke:#000000;stroke-width:0.8;stroke-miterlimit:4;stroke-dasharray:none"
+       id="path1701" />
+    <path
+       d="m 61.125897,82.292318 a 30.419058,30.419058 0 0 0 -60.83809024,0"
+       style="fill:none;stroke:#000000;stroke-width:0.8;stroke-miterlimit:4;stroke-dasharray:none"
+       id="path1703" />
+    <path
+       d="m 0.28780676,82.292318 a 30.419058,30.419058 0 0 0 60.83809024,0"
+       style="fill:none;stroke:#000000;stroke-width:0.8;stroke-miterlimit:4;stroke-dasharray:none"
+       id="path1705" />
+    <g
+       id="g2523"
+       transform="translate(107.66222,-50.712303)"
+       style="stroke-width:0.8;stroke-miterlimit:4;stroke-dasharray:none">
+      <text
+         xml:space="preserve"
+         style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.23333px;line-height:1.25;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman, Italic';letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.8;stroke-miterlimit:4;stroke-dasharray:none"
+         x="-61.300587"
+         y="137.48808"
+         id="text2513"><tspan
+           sodipodi:role="line"
+           id="tspan2511"
+           x="-61.300587"
+           y="137.48808"
+           style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman, Italic';stroke-width:0.8;stroke-miterlimit:4;stroke-dasharray:none">x</tspan></text>
+      <text
+         xml:space="preserve"
+         style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:10.5833px;line-height:1.25;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman, Italic';letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.8;stroke-miterlimit:4;stroke-dasharray:none"
+         x="-81.795479"
+         y="117.64843"
+         id="text2517"><tspan
+           sodipodi:role="line"
+           id="tspan2515"
+           x="-81.795479"
+           y="117.64843"
+           style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman, Italic';stroke-width:0.8;stroke-miterlimit:4;stroke-dasharray:none">y</tspan></text>
+      <path
+         inkscape:connector-curvature="0"
+         id="path2519"
+         d="m -76.955365,132.96748 h 17.58635"
+         style="fill:none;stroke:#ff0000;stroke-width:0.8;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#marker2555)" />
+      <path
+         inkscape:transform-center-x="8.793175"
+         style="fill:none;stroke:#ff0000;stroke-width:0.8;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#marker2565)"
+         d="M -76.955365,132.96748 V 115.38113"
+         id="path2521"
+         inkscape:connector-curvature="0" />
+    </g>
+    <path
+       id="path2525"
+       d="m 11.312387,59.991898 19.02068,21.719196"
+       style="fill:none;stroke:#000000;stroke-width:0.4;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-start:url(#marker2535);marker-end:url(#marker2545)" />
+    <text
+       xml:space="preserve"
+       style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;line-height:1.25;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman, Italic';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#999999;fill-opacity:1;stroke:none;stroke-width:0.264583"
+       x="15.44718"
+       y="73.376472"
+       id="text2531"><tspan
+         sodipodi:role="line"
+         id="tspan2529"
+         x="15.44718"
+         y="73.376472"
+         style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman,  Italic';fill:#000000;stroke-width:0.264583">r<tspan
+   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:65%;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman, ';baseline-shift:sub;fill:#000000"
+   id="tspan2527"
+   dy="0 0">ri</tspan></tspan></text>
+    <path
+       id="path3307"
+       d="m 100.57363,82.288517 -38.412073,0.0017"
+       style="fill:none;stroke:#000000;stroke-width:0.4;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-start:url(#marker3311);marker-end:url(#marker3321)" />
+    <path
+       id="path4527"
+       d="m 132.87268,75.436581 -4.75932,6.46664"
+       style="fill:none;stroke:#000000;stroke-width:0.4;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-start:url(#marker4537);marker-end:url(#marker4547)" />
+    <text
+       xml:space="preserve"
+       style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;line-height:1.25;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman, Italic';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#999999;fill-opacity:1;stroke:none;stroke-width:0.264583"
+       x="122.71404"
+       y="76.712883"
+       id="text4533"><tspan
+         sodipodi:role="line"
+         id="tspan4531"
+         x="122.71404"
+         y="76.712883"
+         style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman,  Italic';fill:#000000;stroke-width:0.264583">r<tspan
+   style="font-style:normal;font-size:65%;baseline-shift:sub"
+   id="tspan5317">rb1</tspan></tspan></text>
+    <path
+       id="path5331"
+       d="m 105.8762,82.06802 -1.68835,-3.487815"
+       style="fill:none;stroke:#000000;stroke-width:0.25;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-start:url(#marker5335);marker-end:url(#marker5345)" />
+    <path
+       id="path6171"
+       d="m 126.88819,82.477926 -20.07646,-0.07875"
+       style="fill:none;stroke:#000000;stroke-width:0.4;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-start:url(#marker6175);marker-end:url(#marker6185)" />
+    <text
+       xml:space="preserve"
+       style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;line-height:1.25;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman, Italic';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#999999;fill-opacity:1;stroke:none;stroke-width:0.264583"
+       x="102.17577"
+       y="73.240227"
+       id="text7227"><tspan
+         sodipodi:role="line"
+         id="tspan7225"
+         x="102.17577"
+         y="73.240227"
+         style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman,  Italic';fill:#000000;stroke-width:0.264583">r<tspan
+   style="font-style:normal;font-size:65%;baseline-shift:sub"
+   id="tspan7223">rb2</tspan></tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;line-height:1.25;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman, Italic';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#999999;fill-opacity:1;stroke:none;stroke-width:0.264583"
+       x="114.44508"
+       y="79.977951"
+       id="text7233"><tspan
+         sodipodi:role="line"
+         id="tspan7231"
+         x="114.44508"
+         y="79.977951"
+         style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman,  Italic';fill:#000000;stroke-width:0.264583">d<tspan
+   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:65%;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman, ';baseline-shift:sub;fill:#000000"
+   id="tspan7229">rb</tspan></tspan></text>
+    <path
+       id="path7307"
+       d="m 105.66975,79.45798 1.93529,-4.423406"
+       style="fill:none;stroke:#000000;stroke-width:0.15;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <path
+       style="fill:#000000;stroke:#000000;stroke-width:0.4;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#marker8873)"
+       d="m 152.38215,72.43127 v 6.284433"
+       id="path8851"
+       inkscape:connector-curvature="0" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path8853"
+       d="M 152.38215,91.61654 V 85.951767"
+       style="fill:#000000;stroke:#000000;stroke-width:0.4;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#marker8863)" />
+    <text
+       xml:space="preserve"
+       style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;line-height:1.25;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman, Italic';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#999999;fill-opacity:1;stroke:none;stroke-width:0.264583"
+       x="144.91766"
+       y="92.878181"
+       id="text8859"><tspan
+         sodipodi:role="line"
+         id="tspan8857"
+         x="144.91766"
+         y="92.878181"
+         style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman,  Italic';fill:#000000;stroke-width:0.264583">w<tspan
+   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:65%;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman, ';baseline-shift:sub;fill:#000000"
+   id="tspan8855">so</tspan></tspan></text>
+    <path
+       style="display:inline;fill:#000000;stroke:#000000;stroke-width:0.4;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#marker5969-8)"
+       d="m 131.97755,81.633688 4.06942,-0.16849"
+       id="path5965-4"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 136.85092,82.582388 6.6e-4,-2.82504"
+       style="display:inline;fill:none;stroke:#000000;stroke-width:0.2;stroke-miterlimit:4;stroke-dasharray:none"
+       id="path6533-4" />
+    <path
+       d="m 157.10899,82.652548 6.6e-4,-2.82504"
+       style="display:inline;fill:none;stroke:#000000;stroke-width:0.2;stroke-miterlimit:4;stroke-dasharray:none"
+       id="path6541-9" />
+    <text
+       xml:space="preserve"
+       style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;line-height:1.25;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman, Italic';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#999999;fill-opacity:1;stroke:none;stroke-width:0.264583"
+       x="159.60399"
+       y="79.063927"
+       id="text7129-4"><tspan
+         sodipodi:role="line"
+         id="tspan7127-1"
+         x="159.60399"
+         y="79.063927"
+         style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman,  Italic';fill:#000000;stroke-width:0.264583">d<tspan
+   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.1275px;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman, ';baseline-shift:sub;fill:#000000;stroke-width:0.264583"
+   id="tspan7125-7">so</tspan></tspan></text>
+    <path
+       style="display:inline;fill:#000000;stroke:#000000;stroke-width:0.4;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#marker11428)"
+       d="m 161.99136,81.633688 -4.06943,-0.16849"
+       id="path10768"
+       inkscape:connector-curvature="0" />
+  </g>
+</svg>

--- a/mach_cad/model_obj/cross_sects/inner_rotor_drop_slots/CrossSectInnerRotorDropSlotsBar.svg
+++ b/mach_cad/model_obj/cross_sects/inner_rotor_drop_slots/CrossSectInnerRotorDropSlotsBar.svg
@@ -1,0 +1,1734 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   inkscape:export-ydpi="150"
+   inkscape:export-xdpi="150"
+   inkscape:export-filename="C:\Users\nheme\Documents\Research\Bearingless Motor\Bearinless_Parametrization_Rev1_wht_bckgrnd.png"
+   inkscape:version="1.0.1 (3bc2e813f5, 2020-09-07)"
+   sodipodi:docname="CrossSectInnerRotorDropSlotsBar.svg"
+   id="svg837"
+   version="1.1"
+   viewBox="0 0 207.79715 169.77094"
+   height="169.77094mm"
+   width="207.79715mm">
+  <defs
+     id="defs831">
+    <marker
+       inkscape:stockid="Arrow1Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker11428"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path11426"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker8873"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path8871"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker8863"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mend">
+      <path
+         transform="matrix(-0.4,0,0,-0.4,-4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path8861" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker7321"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path7319"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker7311"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mstart">
+      <path
+         transform="matrix(0.4,0,0,0.4,4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path7309" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker6185"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path6183"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker6175"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mstart">
+      <path
+         transform="matrix(0.4,0,0,0.4,4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path6173" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker3321"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path3319"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker3311"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mstart">
+      <path
+         transform="matrix(0.4,0,0,0.4,4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path3309" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker2565"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path2563"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#ff0000;fill-opacity:1;fill-rule:evenodd;stroke:#ff0000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker2555"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mend">
+      <path
+         transform="matrix(-0.4,0,0,-0.4,-4,0)"
+         style="fill:#ff0000;fill-opacity:1;fill-rule:evenodd;stroke:#ff0000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path2553" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker2545"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path2543"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker2535"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mstart">
+      <path
+         transform="matrix(0.4,0,0,0.4,4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path2533" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker6553"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path6551"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker5313"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mend">
+      <path
+         transform="matrix(-0.4,0,0,-0.4,-4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path5311" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker3363"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path3361"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mstart"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker2957"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path2955"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(0.4,0,0,0.4,4,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mstart"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker4727"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path4725"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(0.4,0,0,0.4,4,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mstart"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker4345"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path4343"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(0.4,0,0,0.4,4,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mstart"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker3969"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path3967"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(0.4,0,0,0.4,4,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mstart"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker3599"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path3597"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(0.4,0,0,0.4,4,0)" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker2905"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow2Send">
+      <path
+         transform="matrix(-0.3,0,0,-0.3,0.69,0)"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         id="path2903" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker3124"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow2Send">
+      <path
+         transform="matrix(-0.3,0,0,-0.3,0.69,0)"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         id="path3122" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow2Send"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker4852"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path4850"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         transform="matrix(-0.3,0,0,-0.3,0.69,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow2Send"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker3691"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path3689"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         transform="matrix(-0.3,0,0,-0.3,0.69,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Sstart"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker3429"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path3427"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(0.2,0,0,0.2,1.2,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow2Send"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker2019"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path2017"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         transform="matrix(-0.3,0,0,-0.3,0.69,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow2Sstart"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker1781"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path1779"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         transform="matrix(0.3,0,0,0.3,-0.69,0)" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker1488"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mend">
+      <path
+         transform="matrix(-0.4,0,0,-0.4,-4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path1486" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker1244"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mend">
+      <path
+         inkscape:connector-curvature="0"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path1242" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow2Send"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker16235"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path16233"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         transform="matrix(-0.3,0,0,-0.3,0.69,0)" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:stockid="Arrow2Send"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker15733"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path15731"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         transform="matrix(-0.3,0,0,-0.3,0.69,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker15525"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path15523"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker9500"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mend">
+      <path
+         transform="matrix(-0.4,0,0,-0.4,-4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path9498" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker8403"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mstart">
+      <path
+         transform="matrix(0.4,0,0,0.4,4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path8401" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker8209"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mend">
+      <path
+         transform="matrix(-0.4,0,0,-0.4,-4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path8207" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker8061"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mstart">
+      <path
+         transform="matrix(0.4,0,0,0.4,4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path8059" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker7820"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path7818"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mstart"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker7684"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path7682"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(0.4,0,0,0.4,4,0)" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:stockid="Arrow1Mstart"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker6757"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path6755"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(0.4,0,0,0.4,4,0)" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:stockid="Arrow1Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker6627"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path6625"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker6012"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mstart">
+      <path
+         transform="matrix(0.4,0,0,0.4,4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path6010" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker5894"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mend">
+      <path
+         transform="matrix(-0.4,0,0,-0.4,-4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path5892" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:stockid="Arrow1Mstart"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker5567"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path5565"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(0.4,0,0,0.4,4,0)" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:stockid="Arrow1Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker5461"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path5459"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:stockid="Arrow1Mstart"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker5080"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path5078"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(0.4,0,0,0.4,4,0)" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker4986"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mend">
+      <path
+         transform="matrix(-0.4,0,0,-0.4,-4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path4984" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker4450"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow2Send">
+      <path
+         transform="matrix(-0.3,0,0,-0.3,0.69,0)"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         id="path4448" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker4374"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path4372"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:stockid="Arrow1Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker4128"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path4126"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker3864"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mend">
+      <path
+         transform="matrix(-0.4,0,0,-0.4,-4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path3862" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="Arrow1Mstart"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mstart">
+      <path
+         transform="matrix(0.4,0,0,0.4,4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path1491" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="Arrow1Sstart"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Sstart">
+      <path
+         transform="matrix(0.2,0,0,0.2,1.2,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path1497" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker1939"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow2Send">
+      <path
+         transform="matrix(-0.3,0,0,-0.3,0.69,0)"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         id="path1937" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="Arrow2Sstart"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow2Sstart">
+      <path
+         transform="matrix(0.3,0,0,0.3,-0.69,0)"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         id="path1515" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="Arrow2Send"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow2Send">
+      <path
+         transform="matrix(-0.3,0,0,-0.3,0.69,0)"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         id="path1518" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="Arrow2Mstart"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow2Mstart">
+      <path
+         transform="scale(0.6)"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         id="path1509" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="Arrow1Mend"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mend">
+      <path
+         transform="matrix(-0.4,0,0,-0.4,-4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path1494" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:stockid="Arrow1Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker4128-8"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path4126-2"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow2Send"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker4852-2"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path4850-0"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         transform="matrix(-0.3,0,0,-0.3,0.69,0)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow2Send"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker4852-2-2"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path4850-0-3"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         transform="matrix(-0.3,0,0,-0.3,0.69,0)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       id="DistanceX"
+       orient="auto"
+       refX="0"
+       refY="0"
+       style="overflow:visible">
+      <path
+         d="M 3,-3 -3,3 M 0,-5 V 5"
+         style="stroke:#000000;stroke-width:0.5"
+         id="path1492" />
+    </marker>
+    <pattern
+       id="Hatch"
+       patternUnits="userSpaceOnUse"
+       width="8"
+       height="8"
+       x="0"
+       y="0">
+      <path
+         d="M8 4 l-4,4"
+         stroke="#000000"
+         stroke-width="0.25"
+         linecap="square"
+         id="path1495" />
+      <path
+         d="M6 2 l-4,4"
+         stroke="#000000"
+         stroke-width="0.25"
+         linecap="square"
+         id="path1497-9" />
+      <path
+         d="M4 0 l-4,4"
+         stroke="#000000"
+         stroke-width="0.25"
+         linecap="square"
+         id="path1499" />
+    </pattern>
+    <marker
+       id="DistanceX-3"
+       orient="auto"
+       refX="0"
+       refY="0"
+       style="overflow:visible">
+      <path
+         d="M 3,-3 -3,3 M 0,-5 V 5"
+         style="stroke:#000000;stroke-width:0.5"
+         id="path1451" />
+    </marker>
+    <pattern
+       id="Hatch-7"
+       patternUnits="userSpaceOnUse"
+       width="8"
+       height="8"
+       x="0"
+       y="0">
+      <path
+         d="M8 4 l-4,4"
+         stroke="#000000"
+         stroke-width="0.25"
+         linecap="square"
+         id="path1454" />
+      <path
+         d="M6 2 l-4,4"
+         stroke="#000000"
+         stroke-width="0.25"
+         linecap="square"
+         id="path1456" />
+      <path
+         d="M4 0 l-4,4"
+         stroke="#000000"
+         stroke-width="0.25"
+         linecap="square"
+         id="path1458" />
+    </pattern>
+    <marker
+       inkscape:stockid="Arrow1Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker6553-9"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path6551-2"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)" />
+    </marker>
+    <marker
+       id="DistanceX-1"
+       orient="auto"
+       refX="0.0"
+       refY="0.0"
+       style="overflow:visible">
+      <path
+         d="M 3,-3 L -3,3 M 0,-5 L  0,5"
+         style="stroke:#000000; stroke-width:0.5"
+         id="path309" />
+    </marker>
+    <pattern
+       id="Hatch-5"
+       patternUnits="userSpaceOnUse"
+       width="8"
+       height="8"
+       x="0"
+       y="0">
+      <path
+         d="M8 4 l-4,4"
+         stroke="#000000"
+         stroke-width="0.25"
+         linecap="square"
+         id="path312" />
+      <path
+         d="M6 2 l-4,4"
+         stroke="#000000"
+         stroke-width="0.25"
+         linecap="square"
+         id="path314" />
+      <path
+         d="M4 0 l-4,4"
+         stroke="#000000"
+         stroke-width="0.25"
+         linecap="square"
+         id="path316" />
+    </pattern>
+    <marker
+       id="DistanceX-2"
+       orient="auto"
+       refX="0.0"
+       refY="0.0"
+       style="overflow:visible">
+      <path
+         d="M 3,-3 L -3,3 M 0,-5 L  0,5"
+         style="stroke:#000000; stroke-width:0.5"
+         id="path1952" />
+    </marker>
+    <pattern
+       id="Hatch-3"
+       patternUnits="userSpaceOnUse"
+       width="8"
+       height="8"
+       x="0"
+       y="0">
+      <path
+         d="M8 4 l-4,4"
+         stroke="#000000"
+         stroke-width="0.25"
+         linecap="square"
+         id="path1955" />
+      <path
+         d="M6 2 l-4,4"
+         stroke="#000000"
+         stroke-width="0.25"
+         linecap="square"
+         id="path1957" />
+      <path
+         d="M4 0 l-4,4"
+         stroke="#000000"
+         stroke-width="0.25"
+         linecap="square"
+         id="path1959" />
+    </pattern>
+  </defs>
+  <sodipodi:namedview
+     height="281mm"
+     inkscape:document-rotation="0"
+     inkscape:snap-to-guides="true"
+     inkscape:snap-global="true"
+     inkscape:snap-bbox="false"
+     inkscape:object-paths="true"
+     inkscape:snap-intersection-paths="true"
+     inkscape:snap-object-midpoints="true"
+     inkscape:snap-others="true"
+     inkscape:snap-smooth-nodes="true"
+     inkscape:snap-midpoints="true"
+     inkscape:snap-center="true"
+     inkscape:window-maximized="1"
+     inkscape:window-y="-8"
+     inkscape:window-x="-8"
+     inkscape:window-height="1017"
+     inkscape:window-width="1920"
+     inkscape:guide-bbox="true"
+     showguides="false"
+     showborder="true"
+     showgrid="false"
+     inkscape:current-layer="layer4"
+     inkscape:document-units="mm"
+     inkscape:cy="334.78971"
+     inkscape:cx="782.33676"
+     inkscape:zoom="0.7071068"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     borderopacity="1.0"
+     bordercolor="#666666"
+     pagecolor="#ffffff"
+     id="base" />
+  <metadata
+     id="metadata834">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     style="display:none"
+     inkscape:label="Background"
+     id="layer5"
+     inkscape:groupmode="layer"
+     transform="translate(0.11219308,26.269005)" />
+  <g
+     style="display:none"
+     id="layer1"
+     inkscape:groupmode="layer"
+     inkscape:label="Total_Motor"
+     transform="translate(0.11219308,26.269005)">
+    <path
+       inkscape:connector-curvature="0"
+       id="path1388"
+       transform="scale(0.26458333)"
+       d="M 0,650.07812 A 472.4409,472.4409 0 0 0 -472.44141,1122.5195 472.4409,472.4409 0 0 0 0,1594.9609 472.4409,472.4409 0 0 0 472.44141,1122.5195 472.4409,472.4409 0 0 0 0,650.07812 Z m -62.580078,131.7168 c 2.119773,-0.0633 4.238058,0.0941 6.103516,0.6543 2.541358,0.7632 4.943413,2.47682 6.457031,4.65625 1.450551,2.08861 2.260179,4.14371 2.77539,6.56445 v 96.20703 l -32.126953,32.12696 v 25.01171 A 192.85715,192.85715 0 0 1 0,929.66211 192.85715,192.85715 0 0 1 79.371094,946.94922 V 922.00391 L 47.244141,889.87695 v -96.1914 c 0.515003,-2.42755 1.32369,-4.487 2.777343,-6.58008 1.513618,-2.17943 3.915677,-3.89305 6.457032,-4.65625 1.645518,-0.49416 3.491159,-0.65631 5.357422,-0.64844 A 347.10338,347.10338 0 0 1 262.25586,895.70703 c 1.75673,2.4167 3.37685,5.15152 4.01758,7.86524 0.60972,2.58247 0.32595,5.51939 -0.80469,7.91992 -1.08536,2.30442 -2.46502,4.03425 -4.30859,5.69336 l -83.3086,48.09765 -43.88476,-11.75781 -21.66211,12.50586 a 192.85715,192.85715 0 0 1 54.71484,60.06055 192.85715,192.85715 0 0 1 24.71485,77.3809 L 213.33789,1091 l 11.75781,-43.8867 83.31055,-48.09963 c 2.35704,-0.76605 4.54514,-1.093 7.08203,-0.88086 2.64428,0.2211 5.33009,1.4444 7.26172,3.26369 1.49012,1.4034 2.72559,3.2743 3.76172,5.248 a 347.10338,347.10338 0 0 1 20.5918,115.875 347.10338,347.10338 0 0 1 -20.0625,114.8164 c -1.13505,2.3551 -2.53462,4.6543 -4.28907,6.3067 -1.93162,1.8193 -4.61553,3.0425 -7.25976,3.2636 -2.5387,0.2123 -4.72893,-0.1155 -7.08789,-0.8828 l -83.3086,-48.0976 -11.75781,-43.8848 -21.66211,-12.5058 a 192.85715,192.85715 0 0 1 -24.65625,77.414 192.85715,192.85715 0 0 1 -54.65625,60.0938 l 21.60352,12.4726 43.88476,-11.7597 83.30664,48.0976 c 1.84358,1.6591 3.22324,3.3889 4.3086,5.6934 1.13066,2.4005 1.41246,5.3374 0.80273,7.9199 -0.38563,1.6333 -1.14266,3.2715 -2.05273,4.8496 A 347.10338,347.10338 0 0 1 63.15625,1463.209 c -2.309571,0.1107 -4.639833,-0.01 -6.673828,-0.6192 -2.541351,-0.7632 -4.94539,-2.4748 -6.458984,-4.6543 -1.45523,-2.0953 -2.264404,-4.1588 -2.779297,-6.5898 v -96.1836 l 32.126953,-32.1269 v -25.0118 A 192.85715,192.85715 0 0 1 0,1315.377 192.85715,192.85715 0 0 1 -79.371094,1298.0898 v 24.9454 l 32.126953,32.1269 v 96.1914 c -0.514998,2.4276 -1.323687,4.489 -2.777343,6.582 -1.513614,2.1795 -3.915681,3.8911 -6.457032,4.6543 -1.645521,0.4942 -3.491159,0.6564 -5.357422,0.6485 A 347.10338,347.10338 0 0 1 -262.22656,1349.3672 c -1.76655,-2.4252 -3.39721,-5.1736 -4.04102,-7.9004 -0.60972,-2.5825 -0.32791,-5.5194 0.80274,-7.9199 1.08656,-2.307 2.46775,-4.0385 4.31445,-5.6992 l 83.29883,-48.0918 43.88476,11.7597 21.66211,-12.5058 a 192.85715,192.85715 0 0 1 -54.71484,-60.0606 192.85715,192.85715 0 0 1 -24.71485,-77.3808 l -21.60351,12.4726 -11.75781,43.8848 -83.31055,48.0996 c -2.35704,0.766 -4.54513,1.093 -7.08203,0.8808 -2.64427,-0.2211 -5.33009,-1.4443 -7.26172,-3.2636 -1.49012,-1.4035 -2.72559,-3.2744 -3.76172,-5.2481 a 347.10338,347.10338 0 0 1 -20.5918,-115.875 347.10338,347.10338 0 0 1 20.04688,-114.7754 c 1.13845,-2.3696 2.54575,-4.6855 4.31055,-6.3476 1.93163,-1.81929 4.61551,-3.04259 7.25976,-3.26369 2.53416,-0.21191 4.7201,0.11466 7.07422,0.87891 l 83.31641,48.10158 11.75781,43.8867 21.66211,12.5059 a 192.85715,192.85715 0 0 1 24.65625,-77.4141 192.85715,192.85715 0 0 1 54.65625,-60.09571 l -21.60352,-12.4707 -43.88476,11.75781 -83.30664,-48.09765 c -1.84358,-1.65911 -3.22324,-3.38894 -4.3086,-5.69336 -1.13063,-2.40057 -1.41246,-5.33745 -0.80273,-7.91992 0.3858,-1.63403 1.14211,-3.27284 2.05273,-4.85157 A 347.10338,347.10338 0 0 1 -63.158203,781.83008 c 0.193318,-0.009 0.38466,-0.0294 0.578125,-0.0352 z"
+       style="opacity:1;fill:#008000;fill-opacity:1;stroke:#000000;stroke-width:3.77953;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+    <circle
+       r="43.733097"
+       cy="297"
+       cx="0"
+       id="path1390"
+       style="opacity:1;fill:#ff0000;fill-opacity:1;stroke:#000000;stroke-width:1.09333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+  </g>
+  <g
+     style="display:none"
+     inkscape:label="Motor_Cutaway"
+     id="layer2"
+     inkscape:groupmode="layer"
+     transform="translate(0.11219308,26.269005)" />
+  <g
+     style="display:none"
+     inkscape:label="Annotations_1"
+     id="layer3"
+     inkscape:groupmode="layer"
+     transform="translate(0.11219308,26.269005)">
+    <path
+       inkscape:connector-curvature="0"
+       id="path5884"
+       d="M -7.5563861,234.90369 V 206.70526"
+       style="fill:none;stroke:#000000;stroke-width:0.259632px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-start:url(#marker6012);marker-end:url(#marker5894)" />
+    <rect
+       y="218.84871"
+       x="-8.3674479"
+       height="2.2158854"
+       width="1.5875"
+       id="rect6524"
+       style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.264583;stroke-miterlimit:4;stroke-dasharray:0.79375, 0.264583;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal" />
+    <path
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       id="path1464"
+       d="M -0.02743323,297.01265 35.30925,221.27907"
+       style="fill:none;stroke:#000000;stroke-width:0.202531;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:0.810125, 0.202531;stroke-dashoffset:0;stroke-opacity:1" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.202531;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:0.810125, 0.202531;stroke-dashoffset:0;stroke-opacity:1"
+       d="M 0,297 -35.336683,221.26642"
+       id="path1466"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cc" />
+    <path
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       id="path1470"
+       d="M -21.000268,250.56454 V 221.26642"
+       style="fill:none;stroke:#000000;stroke-width:0.264583;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:0.79375, 0.264583;stroke-dashoffset:0;stroke-opacity:1" />
+    <path
+       sodipodi:nodetypes="csc"
+       inkscape:connector-curvature="0"
+       id="path1482"
+       d="m -11.797594,270.57892 c 3.5813579,-1.66871 7.5752744,-2.60053 11.78682858,-2.60053 4.23356982,0 8.24722062,0.94159 11.84295942,2.62676"
+       style="opacity:1;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.264583;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-start:url(#Arrow2Sstart);marker-end:url(#Arrow2Send);paint-order:normal" />
+    <g
+       transform="translate(-23.187493,-34.196779)"
+       id="g1919">
+      <rect
+         style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.264583;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal"
+         id="rect1907"
+         width="6.160902"
+         height="5.5858846"
+         x="20.12562"
+         y="299.38223" />
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+         x="20.947077"
+         y="304.3931"
+         id="text1895"><tspan
+           sodipodi:role="line"
+           id="tspan1893"
+           x="20.947077"
+           y="304.3931"
+           style="stroke-width:0.264583">θ<tspan
+   style="font-size:3.52778px"
+   id="tspan1897">t</tspan></tspan></text>
+    </g>
+    <flowRoot
+       transform="scale(0.26458333)"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:24px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none"
+       id="flowRoot1899"
+       xml:space="preserve"><flowRegion
+         id="flowRegion1901"><rect
+           y="1122.5197"
+           x="61.473213"
+           height="49.675323"
+           width="50.91721"
+           id="rect1903" /></flowRegion><flowPara
+         id="flowPara1905" /></flowRoot>
+    <path
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       id="path1934"
+       d="m -29.626283,232.40708 c 2.447086,-1.23671 5.213559,-1.9334 8.142751,-1.9334"
+       style="display:inline;opacity:1;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.236671;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-start:url(#Arrow1Sstart);marker-end:url(#marker1939);paint-order:normal" />
+    <rect
+       y="229.11623"
+       x="-27.407322"
+       height="3.6542518"
+       width="3.6240244"
+       id="rect1927"
+       style="display:inline;opacity:1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.13113;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal" />
+    <text
+       id="text1923"
+       y="232.42699"
+       x="-27.561081"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+       xml:space="preserve"><tspan
+         style="stroke-width:0.264583"
+         y="232.42699"
+         x="-27.561081"
+         id="tspan1921"
+         sodipodi:role="line">α</tspan></text>
+    <path
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       id="path3542"
+       d="m 25.501249,208.12668 8.748058,-30.47166"
+       style="fill:none;stroke:#000000;stroke-width:0.251839px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-start:url(#Arrow1Mstart);marker-end:url(#marker3864)" />
+    <text
+       id="text4090"
+       y="162.72395"
+       x="57.811459"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+       xml:space="preserve"><tspan
+         style="stroke-width:0.264583"
+         y="162.72395"
+         x="57.811459"
+         id="tspan4088"
+         sodipodi:role="line" /></text>
+    <path
+       inkscape:connector-curvature="0"
+       id="path3528"
+       d="M -12.500012,236.16224 V 246.8512"
+       style="display:inline;fill:none;stroke:#000000;stroke-width:0.24847px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-start:url(#marker5567);marker-end:url(#marker5461)" />
+    <text
+       id="text4094"
+       y="173.58723"
+       x="-52.318027"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+       xml:space="preserve"><tspan
+         style="stroke-width:0.264583"
+         y="173.58723"
+         x="-52.318027"
+         id="tspan4092"
+         sodipodi:role="line">D<tspan
+   id="tspan4096"
+   style="font-size:3.52778px">os</tspan></tspan></text>
+    <g
+       transform="translate(-16.559098,-7.3212701)"
+       id="g4116">
+      <rect
+         style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:0.237103;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal"
+         id="rect4104"
+         width="6.6424799"
+         height="5.9479485"
+         x="43.113136"
+         y="197.23814" />
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+         x="43.78854"
+         y="202.14687"
+         id="text4100"><tspan
+           sodipodi:role="line"
+           id="tspan4098"
+           x="43.78854"
+           y="202.14687"
+           style="stroke-width:0.264583">T<tspan
+   style="font-size:3.52778px"
+   id="tspan4102">s</tspan></tspan></text>
+    </g>
+    <path
+       sodipodi:nodetypes="ccc"
+       inkscape:connector-curvature="0"
+       id="path4118"
+       d="m -44.334244,171.98437 h 2.000911 l 4.828646,4.82865"
+       style="fill:none;stroke:#000000;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#marker4128)" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path4364"
+       d="m 15.718783,210.03594 -1.547002,-1.79208"
+       style="fill:none;stroke:#000000;stroke-width:0.191617;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:0.383234, 0.191617;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker4450)" />
+    <text
+       id="text4634"
+       y="212.41602"
+       x="15.941146"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+       xml:space="preserve"><tspan
+         style="stroke-width:0.264583"
+         y="212.41602"
+         x="15.941146"
+         id="tspan4632"
+         sodipodi:role="line">r</tspan></text>
+    <path
+       inkscape:connector-curvature="0"
+       id="path4976"
+       d="M -11.547554,219.80781 H 11.547554"
+       style="fill:none;stroke:#000000;stroke-width:0.254303px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-start:url(#marker5080);marker-end:url(#marker4986)" />
+    <g
+       transform="translate(-43.306146,19.473489)"
+       id="g4116-9">
+      <g
+         transform="translate(0,0.18708867)"
+         id="g5421">
+        <rect
+           y="197.24779"
+           x="42.65506"
+           height="5.928659"
+           width="7.7924948"
+           id="rect4104-4"
+           style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:0.256393;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal" />
+        <text
+           id="text4100-8"
+           y="202.70813"
+           x="42.993412"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+           xml:space="preserve"><tspan
+             style="stroke-width:0.264583"
+             y="202.70813"
+             x="42.993412"
+             id="tspan4098-5"
+             sodipodi:role="line">W<tspan
+   style="font-size:3.52778px"
+   id="tspan5415">t</tspan></tspan></text>
+      </g>
+    </g>
+    <path
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       id="path5449"
+       d="m -12.500012,247.56684 h 9.8872516"
+       style="fill:none;stroke:#000000;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+    <path
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       id="path5451"
+       d="m -12.500012,235.4466 h 9.8872516"
+       style="fill:none;stroke:#000000;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+    <path
+       sodipodi:arc-type="arc"
+       style="display:inline;opacity:1;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.265;stroke-miterlimit:4;stroke-dasharray:0.795, 0.265;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal"
+       id="path5875"
+       sodipodi:type="arc"
+       sodipodi:cx="0"
+       sodipodi:cy="296.99997"
+       sodipodi:rx="91.67807"
+       sodipodi:ry="91.67807"
+       sodipodi:start="4.4466291"
+       sodipodi:end="4.5768786"
+       sodipodi:open="true"
+       d="m -24.078562,208.54042 a 91.67807,91.67807 0 0 1 11.693219,-2.37806" />
+    <path
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       id="path5878"
+       d="m -12.500012,213.23104 v -7.0392"
+       style="fill:none;stroke:#000000;stroke-width:0.264583;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:0.79375, 0.264583;stroke-dashoffset:0;stroke-opacity:1" />
+    <path
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       id="path5882"
+       d="m -12.385343,206.16235 h 9.7725826"
+       style="fill:none;stroke:#000000;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+    <g
+       transform="translate(-53.364328,27.478398)"
+       id="g4116-9-8"
+       style="display:inline">
+      <g
+         transform="translate(0,0.18708867)"
+         id="g5421-1">
+        <rect
+           y="197.24779"
+           x="42.65506"
+           height="5.928659"
+           width="7.7924948"
+           id="rect4104-4-4"
+           style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:0.256393;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal" />
+        <text
+           id="text4100-8-5"
+           y="202.17897"
+           x="43.456432"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+           xml:space="preserve"><tspan
+             style="stroke-width:0.264583"
+             y="202.17897"
+             x="43.456432"
+             id="tspan4098-5-6"
+             sodipodi:role="line"><tspan
+               style="font-size:3.52778px"
+               id="tspan5415-7"><tspan
+   id="tspan6615"
+   style="font-size:6.35px">L</tspan>t</tspan></tspan></text>
+      </g>
+    </g>
+    <g
+       transform="translate(-53.364328,40.708055)"
+       id="g4116-9-8-7"
+       style="display:inline">
+      <g
+         transform="translate(0,0.18708867)"
+         id="g5421-1-5">
+        <rect
+           y="197.24779"
+           x="42.65506"
+           height="5.928659"
+           width="7.7924948"
+           id="rect4104-4-4-1"
+           style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:0.256393;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal" />
+        <text
+           id="text4100-8-5-7"
+           y="202.17897"
+           x="43.456432"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+           xml:space="preserve"><tspan
+             style="stroke-width:0.264583"
+             y="202.17897"
+             x="43.456432"
+             id="tspan4098-5-6-6"
+             sodipodi:role="line"><tspan
+               style="font-size:3.52778px"
+               id="tspan5415-7-7"><tspan
+   id="tspan6580-5"
+   style="font-size:6.35px">L</tspan>tt</tspan></tspan></text>
+      </g>
+    </g>
+    <path
+       sodipodi:nodetypes="ccc"
+       inkscape:connector-curvature="0"
+       id="path4118-8"
+       d="m -28.486583,277.7367 h -2.000911 l -4.828646,-4.82865"
+       style="display:inline;fill:none;stroke:#000000;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#marker4128-8)" />
+    <text
+       id="text4094-6"
+       y="279.95316"
+       x="-28.468546"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+       xml:space="preserve"><tspan
+         style="stroke-width:0.264583"
+         y="279.95316"
+         x="-28.468546"
+         id="tspan4092-2"
+         sodipodi:role="line">D<tspan
+   id="tspan4096-9"
+   style="font-size:3.52778px;stroke-width:0.264583">or</tspan></tspan></text>
+    <path
+       inkscape:transform-center-y="-47.336963"
+       inkscape:transform-center-x="-0.53635573"
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       id="path6617"
+       d="m 0.49341607,252.4546 0.0643483,-5.62927"
+       style="display:inline;fill:none;stroke:#000000;stroke-width:0.204665px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-start:url(#marker6757);marker-end:url(#marker6627)" />
+    <text
+       id="text4100-8-5-7-6"
+       y="251.6891"
+       x="1.700698"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+       xml:space="preserve"><tspan
+         style="stroke-width:0.264583"
+         y="251.6891"
+         x="1.700698"
+         id="tspan4098-5-6-6-5"
+         sodipodi:role="line"><tspan
+           style="font-size:3.52778px"
+           id="tspan5415-7-7-3"><tspan
+   id="tspan6580-5-5"
+   style="font-size:6.35px">L</tspan>g</tspan></tspan></text>
+    <path
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       id="path15507"
+       d="m 21.000268,250.54698 h 8.688366"
+       style="fill:none;stroke:#000000;stroke-width:0.23934px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+    <path
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       id="path15509"
+       d="m 21.000268,243.94686 h 8.688366"
+       style="fill:none;stroke:#000000;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+    <text
+       id="text15513"
+       y="248.73111"
+       x="25.765221"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+       xml:space="preserve"><tspan
+         style="stroke-width:0.264583"
+         y="248.73111"
+         x="25.765221"
+         id="tspan15511"
+         sodipodi:role="line">s</tspan></text>
+    <path
+       inkscape:connector-curvature="0"
+       id="path15515"
+       d="m 27.057699,249.05852 v 0.97042"
+       style="fill:none;stroke:#000000;stroke-width:0.276484px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#marker15733)" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path15945"
+       d="m 27.060298,245.50384 v -1.05237"
+       style="fill:none;stroke:#000000;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#marker16235)" />
+  </g>
+  <g
+     style="display:inline"
+     inkscape:label="Annotations_2"
+     id="layer4"
+     inkscape:groupmode="layer"
+     transform="translate(0.11219308,26.269005)">
+    <g
+       transform="translate(125.42796,-33.89125)"
+       id="g4116-9-8-2-5"
+       style="display:inline">
+      <g
+         transform="translate(0,0.18708867)"
+         id="g5421-1-7-0">
+        <text
+           id="text4100-8-5-1-8"
+           y="202.24512"
+           x="42.629608"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+           xml:space="preserve"><tspan
+             style="stroke-width:0.264583"
+             y="0"
+             x="0"
+             id="tspan4098-5-6-1-3"
+             sodipodi:role="line"><tspan
+               style="font-size:3.52778px"
+               id="tspan5415-7-3-8"><tspan
+                 id="tspan6615-5-9"
+                 style="font-size:6.35px" /></tspan></tspan></text>
+      </g>
+    </g>
+    <path
+       d="M 157.13096,84.827288 H 136.85158"
+       style="fill:none;stroke:#b3b3b3;stroke-width:0.7;stroke-miterlimit:4;stroke-dasharray:none"
+       id="path1463" />
+    <path
+       d="M 124.49895,92.10997 105.48704,87.20101"
+       style="fill:none;stroke:#000000;stroke-width:0.8;stroke-miterlimit:4;stroke-dasharray:none"
+       id="path1465" />
+    <path
+       d="m 105.48704,77.383346 19.01191,-4.908705"
+       style="fill:none;stroke:#000000;stroke-width:0.8;stroke-miterlimit:4;stroke-dasharray:none"
+       id="path1467" />
+    <path
+       d="m 136.85158,79.757348 h 20.27938"
+       style="fill:none;stroke:#b3b3b3;stroke-width:0.7;stroke-miterlimit:4;stroke-dasharray:none"
+       id="path1469" />
+    <path
+       d="M 141.46079,21.275436 123.89835,31.415317"
+       style="fill:none;stroke:#b3b3b3;stroke-width:0.7;stroke-miterlimit:4;stroke-dasharray:none"
+       id="path1471" />
+    <path
+       d="M 116.84205,43.898615 97.922827,49.1534"
+       style="fill:none;stroke:#b3b3b3;stroke-width:0.7;stroke-miterlimit:4;stroke-dasharray:none"
+       id="path1473" />
+    <path
+       d="M 93.013967,40.651096 107.02433,26.893739"
+       style="fill:none;stroke:#b3b3b3;stroke-width:0.7;stroke-miterlimit:4;stroke-dasharray:none"
+       id="path1475" />
+    <path
+       d="M 121.36342,27.024661 138.92588,16.885048"
+       style="fill:none;stroke:#b3b3b3;stroke-width:0.7;stroke-miterlimit:4;stroke-dasharray:none"
+       id="path1477" />
+    <path
+       d="m 152.8477,115.01966 a 126.44951,126.44951 0 0 0 4.28326,-30.192372"
+       style="fill:none;stroke:#b3b3b3;stroke-width:0.7;stroke-miterlimit:4;stroke-dasharray:none"
+       id="path1559" />
+    <path
+       d="m 124.49895,92.10997 a 10.139687,10.139687 0 0 0 12.35263,-7.282682"
+       style="fill:none;stroke:#000000;stroke-width:0.8;stroke-miterlimit:4;stroke-dasharray:none"
+       id="path1561" />
+    <path
+       d="m 101.68465,82.292318 a 5.0698434,5.0698434 0 0 0 3.80239,4.908692"
+       style="fill:none;stroke:#000000;stroke-width:0.8;stroke-miterlimit:4;stroke-dasharray:none"
+       id="path1563" />
+    <path
+       d="m 105.48704,77.383346 a 5.0698434,5.0698434 0 0 0 -3.80239,4.908972"
+       style="fill:none;stroke:#000000;stroke-width:0.8;stroke-miterlimit:4;stroke-dasharray:none"
+       id="path1565" />
+    <path
+       d="M 136.85158,79.757348 A 10.139687,10.139687 0 0 0 124.49895,72.474641"
+       style="fill:none;stroke:#000000;stroke-width:0.8;stroke-miterlimit:4;stroke-dasharray:none"
+       id="path1567" />
+    <path
+       d="M 157.13096,79.757348 A 126.44951,126.44951 0 0 0 152.8477,49.564672"
+       style="fill:none;stroke:#b3b3b3;stroke-width:0.7;stroke-miterlimit:4;stroke-dasharray:none"
+       id="path1569" />
+    <path
+       d="M 152.8477,49.564672 A 126.44951,126.44951 0 0 0 141.46079,21.275436"
+       style="fill:none;stroke:#b3b3b3;stroke-width:0.7;stroke-miterlimit:4;stroke-dasharray:none"
+       id="path1571" />
+    <path
+       d="m 116.84204,43.898615 a 10.139687,10.139687 0 0 0 7.0563,-12.483298"
+       style="fill:none;stroke:#b3b3b3;stroke-width:0.7;stroke-miterlimit:4;stroke-dasharray:none"
+       id="path1573" />
+    <path
+       d="m 92.175437,46.803274 a 5.0698434,5.0698434 0 0 0 5.74739,2.350126"
+       style="fill:none;stroke:#b3b3b3;stroke-width:0.7;stroke-miterlimit:4;stroke-dasharray:none"
+       id="path1575" />
+    <path
+       d="m 93.013967,40.651096 a 5.0698434,5.0698434 0 0 0 -0.83853,6.152178"
+       style="fill:none;stroke:#b3b3b3;stroke-width:0.7;stroke-miterlimit:4;stroke-dasharray:none"
+       id="path1577" />
+    <path
+       d="M 121.36342,27.024661 A 10.139687,10.139687 0 0 0 107.02433,26.8932"
+       style="fill:none;stroke:#b3b3b3;stroke-width:0.7;stroke-miterlimit:4;stroke-dasharray:none"
+       id="path1579" />
+    <path
+       d="M 138.92587,16.885048 A 126.44951,126.44951 0 0 0 120.12015,-7.1211101"
+       style="fill:none;stroke:#b3b3b3;stroke-width:0.7;stroke-miterlimit:4;stroke-dasharray:none"
+       id="path1581" />
+    <path
+       d="M 120.12015,-7.1211101 A 126.44951,126.44951 0 0 0 96.114207,-25.926673"
+       style="fill:none;stroke:#b3b3b3;stroke-width:0.7;stroke-miterlimit:4;stroke-dasharray:none"
+       id="path1583" />
+    <path
+       d="M 141.46079,143.30891 A 126.44951,126.44951 0 0 0 152.8477,115.01966"
+       style="fill:none;stroke:#b3b3b3;stroke-width:0.7;stroke-miterlimit:4;stroke-dasharray:none"
+       id="path1701" />
+    <path
+       d="m 61.125897,82.292318 a 30.419058,30.419058 0 0 0 -60.83809024,0"
+       style="fill:none;stroke:#b3b3b3;stroke-width:0.8;stroke-miterlimit:4;stroke-dasharray:none"
+       id="path1703" />
+    <path
+       d="m 0.28780676,82.292318 a 30.419058,30.419058 0 0 0 60.83809024,0"
+       style="fill:none;stroke:#b3b3b3;stroke-width:0.7;stroke-miterlimit:4;stroke-dasharray:none"
+       id="path1705" />
+    <g
+       id="g2523"
+       transform="translate(107.66222,-50.712303)"
+       style="stroke-width:0.8;stroke-miterlimit:4;stroke-dasharray:none">
+      <text
+         xml:space="preserve"
+         style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.23333px;line-height:1.25;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman, Italic';letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.8;stroke-miterlimit:4;stroke-dasharray:none"
+         x="-61.300587"
+         y="137.48808"
+         id="text2513"><tspan
+           sodipodi:role="line"
+           id="tspan2511"
+           x="-61.300587"
+           y="137.48808"
+           style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman, Italic';stroke-width:0.8;stroke-miterlimit:4;stroke-dasharray:none">x</tspan></text>
+      <text
+         xml:space="preserve"
+         style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:10.5833px;line-height:1.25;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman, Italic';letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.8;stroke-miterlimit:4;stroke-dasharray:none"
+         x="-81.795479"
+         y="117.64843"
+         id="text2517"><tspan
+           sodipodi:role="line"
+           id="tspan2515"
+           x="-81.795479"
+           y="117.64843"
+           style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman, Italic';stroke-width:0.8;stroke-miterlimit:4;stroke-dasharray:none">y</tspan></text>
+      <path
+         inkscape:connector-curvature="0"
+         id="path2519"
+         d="m -76.955365,132.96748 h 17.58635"
+         style="fill:none;stroke:#ff0000;stroke-width:0.8;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#marker2555)" />
+      <path
+         inkscape:transform-center-x="8.793175"
+         style="fill:none;stroke:#ff0000;stroke-width:0.8;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#marker2565)"
+         d="M -76.955365,132.96748 V 115.38113"
+         id="path2521"
+         inkscape:connector-curvature="0" />
+    </g>
+    <path
+       d="m 136.85092,82.582388 6.6e-4,-2.82504"
+       style="display:inline;fill:none;stroke:#000000;stroke-width:0.2;stroke-miterlimit:4;stroke-dasharray:none"
+       id="path6533-4" />
+    <g
+       id="g3160"
+       transform="matrix(1.5348365,0,0,1.5443742,-469.29424,-38.881324)"
+       style="stroke-width:0.64952">
+      <path
+         d="m 386.8632,84.791165 -12.2996,-3.17582"
+         style="fill:none;stroke:#000000;stroke-width:0.519616;stroke-miterlimit:4;stroke-dasharray:none"
+         id="path1966" />
+      <path
+         d="m 374.5636,75.263879 12.2996,-3.175647"
+         style="fill:none;stroke:#000000;stroke-width:0.519616;stroke-miterlimit:4;stroke-dasharray:none"
+         id="path1968" />
+      <path
+         d="m 386.8632,84.791165 a 6.5597889,6.5597885 0 0 0 7.99144,-4.711488"
+         style="fill:none;stroke:#000000;stroke-width:0.519616;stroke-miterlimit:4;stroke-dasharray:none"
+         id="path2062" />
+      <path
+         d="m 372.10368,78.439699 a 3.2798944,3.2798942 0 0 0 2.45992,3.175646"
+         style="fill:none;stroke:#000000;stroke-width:0.519616;stroke-miterlimit:4;stroke-dasharray:none"
+         id="path2064" />
+      <path
+         d="m 374.5636,75.263879 a 3.2798944,3.2798942 0 0 0 -2.45992,3.17582"
+         style="fill:none;stroke:#000000;stroke-width:0.519616;stroke-miterlimit:4;stroke-dasharray:none"
+         id="path2066" />
+      <path
+         d="M 394.85464,76.79972 A 6.5597889,6.5597885 0 0 0 386.8632,72.088232"
+         style="fill:none;stroke:#000000;stroke-width:0.519616;stroke-miterlimit:4;stroke-dasharray:none"
+         id="path2068" />
+      <path
+         d="m 394.85464,80.079677 a 6.5597889,6.5597885 0 0 0 0.20829,-1.639978"
+         style="fill:none;stroke:#000000;stroke-width:0.519616;stroke-miterlimit:4;stroke-dasharray:none"
+         id="path2208" />
+      <path
+         d="M 395.06293,78.439699 A 6.5597889,6.5597885 0 0 0 394.85464,76.79972"
+         style="fill:none;stroke:#000000;stroke-width:0.519616;stroke-miterlimit:4;stroke-dasharray:none"
+         id="path2210" />
+    </g>
+  </g>
+</svg>

--- a/mach_cad/model_obj/cross_sects/inner_rotor_drop_slots/CrossSectInnerRotorDropSlotsPartial.svg
+++ b/mach_cad/model_obj/cross_sects/inner_rotor_drop_slots/CrossSectInnerRotorDropSlotsPartial.svg
@@ -1,0 +1,1661 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   inkscape:export-ydpi="150"
+   inkscape:export-xdpi="150"
+   inkscape:export-filename="C:\Users\nheme\Documents\Research\Bearingless Motor\Bearinless_Parametrization_Rev1_wht_bckgrnd.png"
+   inkscape:version="1.0.1 (3bc2e813f5, 2020-09-07)"
+   sodipodi:docname="CrossSectInnerRotorDropSlotsPartial.svg"
+   id="svg837"
+   version="1.1"
+   viewBox="0 0 103.19714 54.202985"
+   height="54.202984mm"
+   width="103.19714mm">
+  <defs
+     id="defs831">
+    <marker
+       inkscape:stockid="Arrow1Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker11428"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path11426"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker8873"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path8871"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker8863"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mend">
+      <path
+         transform="matrix(-0.4,0,0,-0.4,-4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path8861" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker7321"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path7319"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker7311"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mstart">
+      <path
+         transform="matrix(0.4,0,0,0.4,4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path7309" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker6185"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path6183"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker6175"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mstart">
+      <path
+         transform="matrix(0.4,0,0,0.4,4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path6173" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker3321"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path3319"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker3311"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mstart">
+      <path
+         transform="matrix(0.4,0,0,0.4,4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path3309" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker2565"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path2563"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#ff0000;fill-opacity:1;fill-rule:evenodd;stroke:#ff0000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker2555"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mend">
+      <path
+         transform="matrix(-0.4,0,0,-0.4,-4,0)"
+         style="fill:#ff0000;fill-opacity:1;fill-rule:evenodd;stroke:#ff0000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path2553" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker2545"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path2543"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker2535"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mstart">
+      <path
+         transform="matrix(0.4,0,0,0.4,4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path2533" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker6553"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path6551"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker5313"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mend">
+      <path
+         transform="matrix(-0.4,0,0,-0.4,-4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path5311" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker3363"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path3361"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mstart"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker2957"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path2955"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(0.4,0,0,0.4,4,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mstart"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker4727"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path4725"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(0.4,0,0,0.4,4,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mstart"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker4345"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path4343"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(0.4,0,0,0.4,4,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mstart"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker3969"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path3967"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(0.4,0,0,0.4,4,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mstart"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker3599"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path3597"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(0.4,0,0,0.4,4,0)" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker2905"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow2Send">
+      <path
+         transform="matrix(-0.3,0,0,-0.3,0.69,0)"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         id="path2903" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker3124"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow2Send">
+      <path
+         transform="matrix(-0.3,0,0,-0.3,0.69,0)"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         id="path3122" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow2Send"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker4852"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path4850"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         transform="matrix(-0.3,0,0,-0.3,0.69,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow2Send"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker3691"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path3689"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         transform="matrix(-0.3,0,0,-0.3,0.69,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Sstart"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker3429"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path3427"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(0.2,0,0,0.2,1.2,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow2Send"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker2019"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path2017"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         transform="matrix(-0.3,0,0,-0.3,0.69,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow2Sstart"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker1781"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path1779"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         transform="matrix(0.3,0,0,0.3,-0.69,0)" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker1488"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mend">
+      <path
+         transform="matrix(-0.4,0,0,-0.4,-4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path1486" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker1244"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mend">
+      <path
+         inkscape:connector-curvature="0"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path1242" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow2Send"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker16235"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path16233"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         transform="matrix(-0.3,0,0,-0.3,0.69,0)" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:stockid="Arrow2Send"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker15733"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path15731"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         transform="matrix(-0.3,0,0,-0.3,0.69,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker15525"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path15523"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker9500"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mend">
+      <path
+         transform="matrix(-0.4,0,0,-0.4,-4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path9498" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker8403"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mstart">
+      <path
+         transform="matrix(0.4,0,0,0.4,4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path8401" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker8209"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mend">
+      <path
+         transform="matrix(-0.4,0,0,-0.4,-4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path8207" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker8061"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mstart">
+      <path
+         transform="matrix(0.4,0,0,0.4,4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path8059" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker7820"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path7818"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mstart"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker7684"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path7682"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(0.4,0,0,0.4,4,0)" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:stockid="Arrow1Mstart"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker6757"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path6755"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(0.4,0,0,0.4,4,0)" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:stockid="Arrow1Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker6627"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path6625"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker6012"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mstart">
+      <path
+         transform="matrix(0.4,0,0,0.4,4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path6010" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker5894"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mend">
+      <path
+         transform="matrix(-0.4,0,0,-0.4,-4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path5892" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:stockid="Arrow1Mstart"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker5567"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path5565"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(0.4,0,0,0.4,4,0)" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:stockid="Arrow1Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker5461"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path5459"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:stockid="Arrow1Mstart"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker5080"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path5078"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(0.4,0,0,0.4,4,0)" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker4986"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mend">
+      <path
+         transform="matrix(-0.4,0,0,-0.4,-4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path4984" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker4450"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow2Send">
+      <path
+         transform="matrix(-0.3,0,0,-0.3,0.69,0)"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         id="path4448" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker4374"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path4372"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:stockid="Arrow1Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker4128"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path4126"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker3864"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mend">
+      <path
+         transform="matrix(-0.4,0,0,-0.4,-4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path3862" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="Arrow1Mstart"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mstart">
+      <path
+         transform="matrix(0.4,0,0,0.4,4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path1491" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="Arrow1Sstart"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Sstart">
+      <path
+         transform="matrix(0.2,0,0,0.2,1.2,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path1497" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker1939"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow2Send">
+      <path
+         transform="matrix(-0.3,0,0,-0.3,0.69,0)"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         id="path1937" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="Arrow2Sstart"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow2Sstart">
+      <path
+         transform="matrix(0.3,0,0,0.3,-0.69,0)"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         id="path1515" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="Arrow2Send"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow2Send">
+      <path
+         transform="matrix(-0.3,0,0,-0.3,0.69,0)"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         id="path1518" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="Arrow2Mstart"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow2Mstart">
+      <path
+         transform="scale(0.6)"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         id="path1509" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="Arrow1Mend"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mend">
+      <path
+         transform="matrix(-0.4,0,0,-0.4,-4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path1494" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:stockid="Arrow1Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker4128-8"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path4126-2"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow2Send"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker4852-2"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path4850-0"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         transform="matrix(-0.3,0,0,-0.3,0.69,0)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow2Send"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker4852-2-2"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path4850-0-3"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         transform="matrix(-0.3,0,0,-0.3,0.69,0)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       id="DistanceX"
+       orient="auto"
+       refX="0"
+       refY="0"
+       style="overflow:visible">
+      <path
+         d="M 3,-3 -3,3 M 0,-5 V 5"
+         style="stroke:#000000;stroke-width:0.5"
+         id="path1492" />
+    </marker>
+    <pattern
+       id="Hatch"
+       patternUnits="userSpaceOnUse"
+       width="8"
+       height="8"
+       x="0"
+       y="0">
+      <path
+         d="M8 4 l-4,4"
+         stroke="#000000"
+         stroke-width="0.25"
+         linecap="square"
+         id="path1495" />
+      <path
+         d="M6 2 l-4,4"
+         stroke="#000000"
+         stroke-width="0.25"
+         linecap="square"
+         id="path1497-9" />
+      <path
+         d="M4 0 l-4,4"
+         stroke="#000000"
+         stroke-width="0.25"
+         linecap="square"
+         id="path1499" />
+    </pattern>
+    <marker
+       id="DistanceX-3"
+       orient="auto"
+       refX="0"
+       refY="0"
+       style="overflow:visible">
+      <path
+         d="M 3,-3 -3,3 M 0,-5 V 5"
+         style="stroke:#000000;stroke-width:0.5"
+         id="path1451" />
+    </marker>
+    <pattern
+       id="Hatch-7"
+       patternUnits="userSpaceOnUse"
+       width="8"
+       height="8"
+       x="0"
+       y="0">
+      <path
+         d="M8 4 l-4,4"
+         stroke="#000000"
+         stroke-width="0.25"
+         linecap="square"
+         id="path1454" />
+      <path
+         d="M6 2 l-4,4"
+         stroke="#000000"
+         stroke-width="0.25"
+         linecap="square"
+         id="path1456" />
+      <path
+         d="M4 0 l-4,4"
+         stroke="#000000"
+         stroke-width="0.25"
+         linecap="square"
+         id="path1458" />
+    </pattern>
+    <marker
+       inkscape:stockid="Arrow1Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker6553-9"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path6551-2"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)" />
+    </marker>
+    <marker
+       id="DistanceX-1"
+       orient="auto"
+       refX="0"
+       refY="0"
+       style="overflow:visible">
+      <path
+         d="M 3,-3 -3,3 M 0,-5 V 5"
+         style="stroke:#000000;stroke-width:0.5"
+         id="path1546" />
+    </marker>
+    <pattern
+       id="Hatch-0"
+       patternUnits="userSpaceOnUse"
+       width="8"
+       height="8"
+       x="0"
+       y="0">
+      <path
+         d="M8 4 l-4,4"
+         stroke="#000000"
+         stroke-width="0.25"
+         linecap="square"
+         id="path1549" />
+      <path
+         d="M6 2 l-4,4"
+         stroke="#000000"
+         stroke-width="0.25"
+         linecap="square"
+         id="path1551" />
+      <path
+         d="M4 0 l-4,4"
+         stroke="#000000"
+         stroke-width="0.25"
+         linecap="square"
+         id="path1553" />
+    </pattern>
+    <symbol
+       id="*Model_Space" />
+    <symbol
+       id="*Paper_Space" />
+    <symbol
+       id="*Paper_Space0" />
+    <marker
+       inkscape:collect="always"
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker1387"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mend">
+      <path
+         transform="matrix(-0.4,0,0,-0.4,-4,0)"
+         style="fill:#ff0000;fill-opacity:1;fill-rule:evenodd;stroke:#ff0000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path1385" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker1741"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path1739"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#ff0000;fill-opacity:1;fill-rule:evenodd;stroke:#ff0000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)" />
+    </marker>
+  </defs>
+  <sodipodi:namedview
+     height="281mm"
+     inkscape:document-rotation="0"
+     inkscape:snap-to-guides="true"
+     inkscape:snap-global="true"
+     inkscape:snap-bbox="false"
+     inkscape:object-paths="true"
+     inkscape:snap-intersection-paths="true"
+     inkscape:snap-object-midpoints="true"
+     inkscape:snap-others="true"
+     inkscape:snap-smooth-nodes="true"
+     inkscape:snap-midpoints="true"
+     inkscape:snap-center="true"
+     inkscape:window-maximized="1"
+     inkscape:window-y="-6"
+     inkscape:window-x="-6"
+     inkscape:window-height="650"
+     inkscape:window-width="1280"
+     inkscape:guide-bbox="true"
+     showguides="false"
+     showborder="true"
+     showgrid="false"
+     inkscape:current-layer="layer4"
+     inkscape:document-units="mm"
+     inkscape:cy="74.545854"
+     inkscape:cx="208.90849"
+     inkscape:zoom="1"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     borderopacity="1.0"
+     bordercolor="#666666"
+     pagecolor="#ffffff"
+     id="base" />
+  <metadata
+     id="metadata834">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     style="display:none"
+     inkscape:label="Background"
+     id="layer5"
+     inkscape:groupmode="layer"
+     transform="translate(-267.48665,-48.418102)" />
+  <g
+     style="display:none"
+     id="layer1"
+     inkscape:groupmode="layer"
+     inkscape:label="Total_Motor"
+     transform="translate(-267.48665,-48.418102)">
+    <path
+       inkscape:connector-curvature="0"
+       id="path1388"
+       transform="scale(0.26458333)"
+       d="M 0,650.07812 A 472.4409,472.4409 0 0 0 -472.44141,1122.5195 472.4409,472.4409 0 0 0 0,1594.9609 472.4409,472.4409 0 0 0 472.44141,1122.5195 472.4409,472.4409 0 0 0 0,650.07812 Z m -62.580078,131.7168 c 2.119773,-0.0633 4.238058,0.0941 6.103516,0.6543 2.541358,0.7632 4.943413,2.47682 6.457031,4.65625 1.450551,2.08861 2.260179,4.14371 2.77539,6.56445 v 96.20703 l -32.126953,32.12696 v 25.01171 A 192.85715,192.85715 0 0 1 0,929.66211 192.85715,192.85715 0 0 1 79.371094,946.94922 V 922.00391 L 47.244141,889.87695 v -96.1914 c 0.515003,-2.42755 1.32369,-4.487 2.777343,-6.58008 1.513618,-2.17943 3.915677,-3.89305 6.457032,-4.65625 1.645518,-0.49416 3.491159,-0.65631 5.357422,-0.64844 A 347.10338,347.10338 0 0 1 262.25586,895.70703 c 1.75673,2.4167 3.37685,5.15152 4.01758,7.86524 0.60972,2.58247 0.32595,5.51939 -0.80469,7.91992 -1.08536,2.30442 -2.46502,4.03425 -4.30859,5.69336 l -83.3086,48.09765 -43.88476,-11.75781 -21.66211,12.50586 a 192.85715,192.85715 0 0 1 54.71484,60.06055 192.85715,192.85715 0 0 1 24.71485,77.3809 L 213.33789,1091 l 11.75781,-43.8867 83.31055,-48.09963 c 2.35704,-0.76605 4.54514,-1.093 7.08203,-0.88086 2.64428,0.2211 5.33009,1.4444 7.26172,3.26369 1.49012,1.4034 2.72559,3.2743 3.76172,5.248 a 347.10338,347.10338 0 0 1 20.5918,115.875 347.10338,347.10338 0 0 1 -20.0625,114.8164 c -1.13505,2.3551 -2.53462,4.6543 -4.28907,6.3067 -1.93162,1.8193 -4.61553,3.0425 -7.25976,3.2636 -2.5387,0.2123 -4.72893,-0.1155 -7.08789,-0.8828 l -83.3086,-48.0976 -11.75781,-43.8848 -21.66211,-12.5058 a 192.85715,192.85715 0 0 1 -24.65625,77.414 192.85715,192.85715 0 0 1 -54.65625,60.0938 l 21.60352,12.4726 43.88476,-11.7597 83.30664,48.0976 c 1.84358,1.6591 3.22324,3.3889 4.3086,5.6934 1.13066,2.4005 1.41246,5.3374 0.80273,7.9199 -0.38563,1.6333 -1.14266,3.2715 -2.05273,4.8496 A 347.10338,347.10338 0 0 1 63.15625,1463.209 c -2.309571,0.1107 -4.639833,-0.01 -6.673828,-0.6192 -2.541351,-0.7632 -4.94539,-2.4748 -6.458984,-4.6543 -1.45523,-2.0953 -2.264404,-4.1588 -2.779297,-6.5898 v -96.1836 l 32.126953,-32.1269 v -25.0118 A 192.85715,192.85715 0 0 1 0,1315.377 192.85715,192.85715 0 0 1 -79.371094,1298.0898 v 24.9454 l 32.126953,32.1269 v 96.1914 c -0.514998,2.4276 -1.323687,4.489 -2.777343,6.582 -1.513614,2.1795 -3.915681,3.8911 -6.457032,4.6543 -1.645521,0.4942 -3.491159,0.6564 -5.357422,0.6485 A 347.10338,347.10338 0 0 1 -262.22656,1349.3672 c -1.76655,-2.4252 -3.39721,-5.1736 -4.04102,-7.9004 -0.60972,-2.5825 -0.32791,-5.5194 0.80274,-7.9199 1.08656,-2.307 2.46775,-4.0385 4.31445,-5.6992 l 83.29883,-48.0918 43.88476,11.7597 21.66211,-12.5058 a 192.85715,192.85715 0 0 1 -54.71484,-60.0606 192.85715,192.85715 0 0 1 -24.71485,-77.3808 l -21.60351,12.4726 -11.75781,43.8848 -83.31055,48.0996 c -2.35704,0.766 -4.54513,1.093 -7.08203,0.8808 -2.64427,-0.2211 -5.33009,-1.4443 -7.26172,-3.2636 -1.49012,-1.4035 -2.72559,-3.2744 -3.76172,-5.2481 a 347.10338,347.10338 0 0 1 -20.5918,-115.875 347.10338,347.10338 0 0 1 20.04688,-114.7754 c 1.13845,-2.3696 2.54575,-4.6855 4.31055,-6.3476 1.93163,-1.81929 4.61551,-3.04259 7.25976,-3.26369 2.53416,-0.21191 4.7201,0.11466 7.07422,0.87891 l 83.31641,48.10158 11.75781,43.8867 21.66211,12.5059 a 192.85715,192.85715 0 0 1 24.65625,-77.4141 192.85715,192.85715 0 0 1 54.65625,-60.09571 l -21.60352,-12.4707 -43.88476,11.75781 -83.30664,-48.09765 c -1.84358,-1.65911 -3.22324,-3.38894 -4.3086,-5.69336 -1.13063,-2.40057 -1.41246,-5.33745 -0.80273,-7.91992 0.3858,-1.63403 1.14211,-3.27284 2.05273,-4.85157 A 347.10338,347.10338 0 0 1 -63.158203,781.83008 c 0.193318,-0.009 0.38466,-0.0294 0.578125,-0.0352 z"
+       style="opacity:1;fill:#008000;fill-opacity:1;stroke:#000000;stroke-width:3.77953;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+    <circle
+       r="43.733097"
+       cy="297"
+       cx="0"
+       id="path1390"
+       style="opacity:1;fill:#ff0000;fill-opacity:1;stroke:#000000;stroke-width:1.09333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+  </g>
+  <g
+     style="display:none"
+     inkscape:label="Motor_Cutaway"
+     id="layer2"
+     inkscape:groupmode="layer"
+     transform="translate(-267.48665,-48.418102)" />
+  <g
+     style="display:none"
+     inkscape:label="Annotations_1"
+     id="layer3"
+     inkscape:groupmode="layer"
+     transform="translate(-267.48665,-48.418102)">
+    <path
+       inkscape:connector-curvature="0"
+       id="path5884"
+       d="M -7.5563861,234.90369 V 206.70526"
+       style="fill:none;stroke:#000000;stroke-width:0.259632px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-start:url(#marker6012);marker-end:url(#marker5894)" />
+    <rect
+       y="218.84871"
+       x="-8.3674479"
+       height="2.2158854"
+       width="1.5875"
+       id="rect6524"
+       style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.264583;stroke-miterlimit:4;stroke-dasharray:0.79375, 0.264583;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal" />
+    <path
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       id="path1464"
+       d="M -0.02743323,297.01265 35.30925,221.27907"
+       style="fill:none;stroke:#000000;stroke-width:0.202531;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:0.810125, 0.202531;stroke-dashoffset:0;stroke-opacity:1" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.202531;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:0.810125, 0.202531;stroke-dashoffset:0;stroke-opacity:1"
+       d="M 0,297 -35.336683,221.26642"
+       id="path1466"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cc" />
+    <path
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       id="path1470"
+       d="M -21.000268,250.56454 V 221.26642"
+       style="fill:none;stroke:#000000;stroke-width:0.264583;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:0.79375, 0.264583;stroke-dashoffset:0;stroke-opacity:1" />
+    <path
+       sodipodi:nodetypes="csc"
+       inkscape:connector-curvature="0"
+       id="path1482"
+       d="m -11.797594,270.57892 c 3.5813579,-1.66871 7.5752744,-2.60053 11.78682858,-2.60053 4.23356982,0 8.24722062,0.94159 11.84295942,2.62676"
+       style="opacity:1;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.264583;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-start:url(#Arrow2Sstart);marker-end:url(#Arrow2Send);paint-order:normal" />
+    <g
+       transform="translate(-23.187493,-34.196779)"
+       id="g1919">
+      <rect
+         style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.264583;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal"
+         id="rect1907"
+         width="6.160902"
+         height="5.5858846"
+         x="20.12562"
+         y="299.38223" />
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+         x="20.947077"
+         y="304.3931"
+         id="text1895"><tspan
+           sodipodi:role="line"
+           id="tspan1893"
+           x="20.947077"
+           y="304.3931"
+           style="stroke-width:0.264583">θ<tspan
+   style="font-size:3.52778px"
+   id="tspan1897">t</tspan></tspan></text>
+    </g>
+    <flowRoot
+       transform="scale(0.26458333)"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:24px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none"
+       id="flowRoot1899"
+       xml:space="preserve"><flowRegion
+         id="flowRegion1901"><rect
+           y="1122.5197"
+           x="61.473213"
+           height="49.675323"
+           width="50.91721"
+           id="rect1903" /></flowRegion><flowPara
+         id="flowPara1905" /></flowRoot>
+    <path
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       id="path1934"
+       d="m -29.626283,232.40708 c 2.447086,-1.23671 5.213559,-1.9334 8.142751,-1.9334"
+       style="display:inline;opacity:1;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.236671;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-start:url(#Arrow1Sstart);marker-end:url(#marker1939);paint-order:normal" />
+    <rect
+       y="229.11623"
+       x="-27.407322"
+       height="3.6542518"
+       width="3.6240244"
+       id="rect1927"
+       style="display:inline;opacity:1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.13113;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal" />
+    <text
+       id="text1923"
+       y="232.42699"
+       x="-27.561081"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+       xml:space="preserve"><tspan
+         style="stroke-width:0.264583"
+         y="232.42699"
+         x="-27.561081"
+         id="tspan1921"
+         sodipodi:role="line">α</tspan></text>
+    <path
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       id="path3542"
+       d="m 25.501249,208.12668 8.748058,-30.47166"
+       style="fill:none;stroke:#000000;stroke-width:0.251839px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-start:url(#Arrow1Mstart);marker-end:url(#marker3864)" />
+    <text
+       id="text4090"
+       y="162.72395"
+       x="57.811459"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+       xml:space="preserve"><tspan
+         style="stroke-width:0.264583"
+         y="162.72395"
+         x="57.811459"
+         id="tspan4088"
+         sodipodi:role="line" /></text>
+    <path
+       inkscape:connector-curvature="0"
+       id="path3528"
+       d="M -12.500012,236.16224 V 246.8512"
+       style="display:inline;fill:none;stroke:#000000;stroke-width:0.24847px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-start:url(#marker5567);marker-end:url(#marker5461)" />
+    <text
+       id="text4094"
+       y="173.58723"
+       x="-52.318027"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+       xml:space="preserve"><tspan
+         style="stroke-width:0.264583"
+         y="173.58723"
+         x="-52.318027"
+         id="tspan4092"
+         sodipodi:role="line">D<tspan
+   id="tspan4096"
+   style="font-size:3.52778px">os</tspan></tspan></text>
+    <g
+       transform="translate(-16.559098,-7.3212701)"
+       id="g4116">
+      <rect
+         style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:0.237103;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal"
+         id="rect4104"
+         width="6.6424799"
+         height="5.9479485"
+         x="43.113136"
+         y="197.23814" />
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+         x="43.78854"
+         y="202.14687"
+         id="text4100"><tspan
+           sodipodi:role="line"
+           id="tspan4098"
+           x="43.78854"
+           y="202.14687"
+           style="stroke-width:0.264583">T<tspan
+   style="font-size:3.52778px"
+   id="tspan4102">s</tspan></tspan></text>
+    </g>
+    <path
+       sodipodi:nodetypes="ccc"
+       inkscape:connector-curvature="0"
+       id="path4118"
+       d="m -44.334244,171.98437 h 2.000911 l 4.828646,4.82865"
+       style="fill:none;stroke:#000000;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#marker4128)" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path4364"
+       d="m 15.718783,210.03594 -1.547002,-1.79208"
+       style="fill:none;stroke:#000000;stroke-width:0.191617;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:0.383234, 0.191617;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker4450)" />
+    <text
+       id="text4634"
+       y="212.41602"
+       x="15.941146"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+       xml:space="preserve"><tspan
+         style="stroke-width:0.264583"
+         y="212.41602"
+         x="15.941146"
+         id="tspan4632"
+         sodipodi:role="line">r</tspan></text>
+    <path
+       inkscape:connector-curvature="0"
+       id="path4976"
+       d="M -11.547554,219.80781 H 11.547554"
+       style="fill:none;stroke:#000000;stroke-width:0.254303px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-start:url(#marker5080);marker-end:url(#marker4986)" />
+    <g
+       transform="translate(-43.306146,19.473489)"
+       id="g4116-9">
+      <g
+         transform="translate(0,0.18708867)"
+         id="g5421">
+        <rect
+           y="197.24779"
+           x="42.65506"
+           height="5.928659"
+           width="7.7924948"
+           id="rect4104-4"
+           style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:0.256393;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal" />
+        <text
+           id="text4100-8"
+           y="202.70813"
+           x="42.993412"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+           xml:space="preserve"><tspan
+             style="stroke-width:0.264583"
+             y="202.70813"
+             x="42.993412"
+             id="tspan4098-5"
+             sodipodi:role="line">W<tspan
+   style="font-size:3.52778px"
+   id="tspan5415">t</tspan></tspan></text>
+      </g>
+    </g>
+    <path
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       id="path5449"
+       d="m -12.500012,247.56684 h 9.8872516"
+       style="fill:none;stroke:#000000;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+    <path
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       id="path5451"
+       d="m -12.500012,235.4466 h 9.8872516"
+       style="fill:none;stroke:#000000;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+    <path
+       sodipodi:arc-type="arc"
+       style="display:inline;opacity:1;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.265;stroke-miterlimit:4;stroke-dasharray:0.795, 0.265;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal"
+       id="path5875"
+       sodipodi:type="arc"
+       sodipodi:cx="0"
+       sodipodi:cy="296.99997"
+       sodipodi:rx="91.67807"
+       sodipodi:ry="91.67807"
+       sodipodi:start="4.4466291"
+       sodipodi:end="4.5768786"
+       sodipodi:open="true"
+       d="m -24.078562,208.54042 a 91.67807,91.67807 0 0 1 11.693219,-2.37806" />
+    <path
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       id="path5878"
+       d="m -12.500012,213.23104 v -7.0392"
+       style="fill:none;stroke:#000000;stroke-width:0.264583;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:0.79375, 0.264583;stroke-dashoffset:0;stroke-opacity:1" />
+    <path
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       id="path5882"
+       d="m -12.385343,206.16235 h 9.7725826"
+       style="fill:none;stroke:#000000;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+    <g
+       transform="translate(-53.364328,27.478398)"
+       id="g4116-9-8"
+       style="display:inline">
+      <g
+         transform="translate(0,0.18708867)"
+         id="g5421-1">
+        <rect
+           y="197.24779"
+           x="42.65506"
+           height="5.928659"
+           width="7.7924948"
+           id="rect4104-4-4"
+           style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:0.256393;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal" />
+        <text
+           id="text4100-8-5"
+           y="202.17897"
+           x="43.456432"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+           xml:space="preserve"><tspan
+             style="stroke-width:0.264583"
+             y="202.17897"
+             x="43.456432"
+             id="tspan4098-5-6"
+             sodipodi:role="line"><tspan
+               style="font-size:3.52778px"
+               id="tspan5415-7"><tspan
+   id="tspan6615"
+   style="font-size:6.35px">L</tspan>t</tspan></tspan></text>
+      </g>
+    </g>
+    <g
+       transform="translate(-53.364328,40.708055)"
+       id="g4116-9-8-7"
+       style="display:inline">
+      <g
+         transform="translate(0,0.18708867)"
+         id="g5421-1-5">
+        <rect
+           y="197.24779"
+           x="42.65506"
+           height="5.928659"
+           width="7.7924948"
+           id="rect4104-4-4-1"
+           style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:0.256393;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal" />
+        <text
+           id="text4100-8-5-7"
+           y="202.17897"
+           x="43.456432"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+           xml:space="preserve"><tspan
+             style="stroke-width:0.264583"
+             y="202.17897"
+             x="43.456432"
+             id="tspan4098-5-6-6"
+             sodipodi:role="line"><tspan
+               style="font-size:3.52778px"
+               id="tspan5415-7-7"><tspan
+   id="tspan6580-5"
+   style="font-size:6.35px">L</tspan>tt</tspan></tspan></text>
+      </g>
+    </g>
+    <path
+       sodipodi:nodetypes="ccc"
+       inkscape:connector-curvature="0"
+       id="path4118-8"
+       d="m -28.486583,277.7367 h -2.000911 l -4.828646,-4.82865"
+       style="display:inline;fill:none;stroke:#000000;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#marker4128-8)" />
+    <text
+       id="text4094-6"
+       y="279.95316"
+       x="-28.468546"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+       xml:space="preserve"><tspan
+         style="stroke-width:0.264583"
+         y="279.95316"
+         x="-28.468546"
+         id="tspan4092-2"
+         sodipodi:role="line">D<tspan
+   id="tspan4096-9"
+   style="font-size:3.52778px;stroke-width:0.264583">or</tspan></tspan></text>
+    <path
+       inkscape:transform-center-y="-47.336963"
+       inkscape:transform-center-x="-0.53635573"
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       id="path6617"
+       d="m 0.49341607,252.4546 0.0643483,-5.62927"
+       style="display:inline;fill:none;stroke:#000000;stroke-width:0.204665px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-start:url(#marker6757);marker-end:url(#marker6627)" />
+    <text
+       id="text4100-8-5-7-6"
+       y="251.6891"
+       x="1.700698"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+       xml:space="preserve"><tspan
+         style="stroke-width:0.264583"
+         y="251.6891"
+         x="1.700698"
+         id="tspan4098-5-6-6-5"
+         sodipodi:role="line"><tspan
+           style="font-size:3.52778px"
+           id="tspan5415-7-7-3"><tspan
+   id="tspan6580-5-5"
+   style="font-size:6.35px">L</tspan>g</tspan></tspan></text>
+    <path
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       id="path15507"
+       d="m 21.000268,250.54698 h 8.688366"
+       style="fill:none;stroke:#000000;stroke-width:0.23934px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+    <path
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       id="path15509"
+       d="m 21.000268,243.94686 h 8.688366"
+       style="fill:none;stroke:#000000;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+    <text
+       id="text15513"
+       y="248.73111"
+       x="25.765221"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+       xml:space="preserve"><tspan
+         style="stroke-width:0.264583"
+         y="248.73111"
+         x="25.765221"
+         id="tspan15511"
+         sodipodi:role="line">s</tspan></text>
+    <path
+       inkscape:connector-curvature="0"
+       id="path15515"
+       d="m 27.057699,249.05852 v 0.97042"
+       style="fill:none;stroke:#000000;stroke-width:0.276484px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#marker15733)" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path15945"
+       d="m 27.060298,245.50384 v -1.05237"
+       style="fill:none;stroke:#000000;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#marker16235)" />
+  </g>
+  <g
+     style="display:inline"
+     inkscape:label="Annotations_2"
+     id="layer4"
+     inkscape:groupmode="layer"
+     transform="translate(-267.48665,-48.418102)">
+    <g
+       transform="translate(125.42796,-33.89125)"
+       id="g4116-9-8-2-5"
+       style="display:inline">
+      <g
+         transform="translate(0,0.18708867)"
+         id="g5421-1-7-0">
+        <text
+           id="text4100-8-5-1-8"
+           y="202.24512"
+           x="42.629608"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+           xml:space="preserve"><tspan
+             style="stroke-width:0.264583"
+             y="0"
+             x="0"
+             id="tspan4098-5-6-1-3"
+             sodipodi:role="line"><tspan
+               style="font-size:3.52778px"
+               id="tspan5415-7-3-8"><tspan
+                 id="tspan6615-5-9"
+                 style="font-size:6.35px" /></tspan></tspan></text>
+      </g>
+    </g>
+    <g
+       id="g1623"
+       transform="matrix(2.165656,0,0,2.1897589,268.23154,-2382.5278)"
+       style="stroke-width:0.367364;stroke-miterlimit:4;stroke-dasharray:none">
+      <g
+         inkscape:label="0"
+         id="g1561"
+         style="stroke-width:0.367364;stroke-miterlimit:4;stroke-dasharray:none" />
+      <g
+         inkscape:label="RotorCore"
+         id="g1589"
+         style="stroke-width:0.367364;stroke-miterlimit:4;stroke-dasharray:none">
+        <path
+           d="M 47.124079,1123.4646 H 39.565024"
+           style="fill:none;stroke:#000000;stroke-width:0.367364;stroke-miterlimit:4;stroke-dasharray:none"
+           id="path1563-1" />
+        <path
+           d="m 34.96063,1126.1792 -7.086614,-1.8298"
+           style="fill:none;stroke:#000000;stroke-width:0.367364;stroke-miterlimit:4;stroke-dasharray:none"
+           id="path1565-5" />
+        <path
+           d="m 27.874016,1120.6899 7.086614,-1.8297"
+           style="fill:none;stroke:#000000;stroke-width:0.367364;stroke-miterlimit:4;stroke-dasharray:none"
+           id="path1567-7" />
+        <path
+           d="m 39.565024,1121.5748 h 7.559055"
+           style="fill:none;stroke:#000000;stroke-width:0.367364;stroke-miterlimit:4;stroke-dasharray:none"
+           id="path1569-8" />
+        <path
+           d="M 45.527514,1134.7187 10.95223,1125.4543"
+           style="fill:none;stroke:#000000;stroke-width:0.367364;stroke-miterlimit:4;stroke-dasharray:none"
+           id="path1571-2" />
+        <path
+           d="M 45.527514,1110.3206 10.95223,1119.585"
+           style="fill:none;stroke:#000000;stroke-width:0.367364;stroke-miterlimit:4;stroke-dasharray:none"
+           id="path1573-0" />
+        <path
+           d="m 45.527514,1134.7187 a 47.133551,47.133551 0 0 0 1.596565,-11.2541"
+           style="fill:none;stroke:#000000;stroke-width:0.367364;stroke-miterlimit:4;stroke-dasharray:none"
+           id="path1575-7" />
+        <path
+           d="m 34.96063,1126.1792 a 3.779528,3.779528 0 0 0 4.604394,-2.7146"
+           style="fill:none;stroke:#000000;stroke-width:0.367364;stroke-miterlimit:4;stroke-dasharray:none"
+           id="path1577-1" />
+        <path
+           d="m 26.456693,1122.5197 a 1.889764,1.889764 0 0 0 1.417323,1.8297"
+           style="fill:none;stroke:#000000;stroke-width:0.367364;stroke-miterlimit:4;stroke-dasharray:none"
+           id="path1579-3" />
+        <path
+           d="m 27.874016,1120.6899 a 1.889764,1.889764 0 0 0 -1.417323,1.8298"
+           style="fill:none;stroke:#000000;stroke-width:0.367364;stroke-miterlimit:4;stroke-dasharray:none"
+           id="path1581-9" />
+        <path
+           d="m 39.565024,1121.5748 a 3.779528,3.779528 0 0 0 -4.604394,-2.7146"
+           style="fill:none;stroke:#000000;stroke-width:0.367364;stroke-miterlimit:4;stroke-dasharray:none"
+           id="path1583-8" />
+        <path
+           d="m 47.124079,1121.5748 a 47.133551,47.133551 0 0 0 -1.596565,-11.2542"
+           style="fill:none;stroke:#000000;stroke-width:0.367364;stroke-miterlimit:4;stroke-dasharray:none"
+           id="path1585" />
+        <path
+           d="m 10.95223,1125.4543 a 11.338583,11.338583 0 0 0 0,-5.8693"
+           style="fill:none;stroke:#000000;stroke-width:0.367364;stroke-miterlimit:4;stroke-dasharray:none"
+           id="path1587" />
+      </g>
+    </g>
+    <text
+       xml:space="preserve"
+       style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.23333px;line-height:1.25;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman, Italic';letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+       x="285.64575"
+       y="80.665741"
+       id="text2115"><tspan
+         sodipodi:role="line"
+         id="tspan2113"
+         x="285.64575"
+         y="80.665741"
+         style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman, Italic';stroke-width:0.264583">x</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:10.5833px;line-height:1.25;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman, Italic';letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+       x="267.99515"
+       y="55.468307"
+       id="text2145"><tspan
+         sodipodi:role="line"
+         id="tspan2143"
+         x="267.99515"
+         y="55.468307"
+         style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman, Italic';stroke-width:0.264583">y</tspan></text>
+    <g
+       style="display:inline;stroke:#ff0000"
+       id="g2173"
+       transform="rotate(90,246.08436,321.63426)">
+      <path
+         inkscape:connector-curvature="0"
+         id="path1377"
+         d="M 0,297 V 279.41365"
+         style="fill:none;stroke:#ff0000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#marker1387)" />
+      <path
+         inkscape:transform-center-x="8.793175"
+         style="fill:none;stroke:#ff0000;stroke-width:0.5;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#marker1741)"
+         d="M 0,297 H -17.58635"
+         id="path1737"
+         inkscape:connector-curvature="0" />
+    </g>
+  </g>
+</svg>

--- a/mach_cad/model_obj/cross_sects/inner_rotor_drop_slots/__init__.py
+++ b/mach_cad/model_obj/cross_sects/inner_rotor_drop_slots/__init__.py
@@ -1,0 +1,546 @@
+import numpy as np
+
+from ...dimensions import DimRadian
+from ...dimensions import DimMillimeter
+from ...dimensions.dim_linear import DimLinear
+
+from ..cross_sect_base import CrossSectBase, CrossSectToken
+
+__all__ = ['CrossSectInnerRotorDropSlots', 'CrossSectInnerRotorDropSlotsPartial', 'CrossSectInnerRotorDropSlotsBar']
+
+
+class CrossSectInnerRotorDropSlots(CrossSectBase):
+
+    def __init__(self, **kwargs: any) -> None:
+        '''
+        Intialization function for CrossSectInnerRotorDropSlots class. This function takes in
+        arguments and saves the information passed to private variable to make
+        them read-only
+        Parameters
+        ----------
+        **kwargs : any
+            DESCRIPTION. Keyword arguments provided to the initialization funcntion.
+            The following argument names have to be included in order for the code
+            to execute:  name, dim_l, dim_t, dim_theta, location.
+            
+        Returns
+        -------
+        None
+        '''
+        self._create_attr(kwargs)
+
+        super()._validate_attr()
+        self._validate_attr()
+
+    @property
+    def dim_r_ri(self):
+        return self._dim_r_ri
+
+    @property
+    def dim_d_ri(self):
+        return self._dim_d_ri
+
+    @property
+    def dim_d_rb(self):
+        return self._dim_d_rb
+
+    @property
+    def dim_r_rb1(self):
+        return self._dim_r_rb1
+
+    @property
+    def dim_r_rb2(self):
+        return self._dim_r_rb2
+
+    @property
+    def dim_d_so(self):
+        return self._dim_d_so
+
+    @property
+    def dim_w_so(self):
+        return self._dim_w_so
+
+    @property
+    def Qr(self):
+        return self._Qr
+
+    def draw(self, drawer):
+
+        r_ri = self.dim_r_ri
+        d_ri = self.dim_d_ri
+        d_rb = self.dim_d_rb
+        r_rb1 = self.dim_r_rb1
+        r_rb2 = self.dim_r_rb2
+        d_so = self.dim_d_so
+        w_so = self.dim_w_so
+        Qr = self.Qr
+
+        alpha_u = DimRadian(2 * np.pi / Qr)
+        r1 = r_ri + d_ri + r_rb2 + d_rb + DimMillimeter(np.sqrt(r_rb1 ** 2 - (w_so / 2) ** 2)) + d_so
+        r2 = w_so / 2
+        r_ro = DimMillimeter(np.sqrt(r1 ** 2 + r2 ** 2))
+
+        x1 = r_ro * np.cos(alpha_u / 2)
+        y1 = - r_ro * np.sin(alpha_u / 2)
+
+        x2 = DimMillimeter(np.sqrt(r_ro ** 2 - (w_so / 2) ** 2))
+        y2 = - w_so / 2
+
+        x3 = x2 - d_so
+        y3 = y2
+
+        Rc2 = r_ri + d_ri + r_rb2
+        Rc1 = Rc2 + d_rb
+
+        alpha_slope = np.arcsin((r_rb1 - r_rb2) / d_rb)
+
+        x4 = Rc1 - r_rb1 * np.sin(alpha_slope)
+        y4 = - r_rb1 * np.cos(alpha_slope)
+
+        x5 = Rc2 - r_rb2 * np.sin(alpha_slope)
+        y5 = - r_rb2 * np.cos(alpha_slope)
+
+        x6 = r_ri + d_ri
+        y6 = DimMillimeter(0)
+
+        x7 = x5
+        y7 = - y5
+
+        x8 = x4
+        y8 = - y4
+
+        x9 = x3
+        y9 = - y3
+
+        x10 = x2
+        y10 = - y2
+
+        x11 = x1
+        y11 = - y1
+
+        center_rotor_bar1 = [Rc1, DimMillimeter(0)]
+        center_rotor_bar2 = [Rc2, DimMillimeter(0)]
+
+        x_arr = [x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, center_rotor_bar1[0], center_rotor_bar2[0]]
+        y_arr = [y1, y2, y3, y4, y5, y6, y7, y8, y9, y10, y11, center_rotor_bar1[1], center_rotor_bar2[1]]
+
+        arc1 = []
+        arc2 = []
+        arc3 = []
+        arc4 = []
+        arc5 = []
+        arc6 = []
+        arc7 = []
+        arc8 = []
+        seg1 = []
+        seg2 = []
+        seg3 = []
+        seg4 = []
+
+        # transpose list
+        coords = [x_arr, y_arr]
+        coords = list(zip(*coords))
+        coords = [list(sublist) for sublist in coords]
+
+        for i in range(0, Qr):
+            p = self.location.transform_coords(coords, alpha_u * i)
+
+            arc1.append(drawer.draw_arc(self.location.anchor_xy, p[0], p[1]))
+            seg1.append(drawer.draw_line(p[1], p[2]))
+            arc2.append(drawer.draw_arc(p[11], p[3], p[2]))
+            seg2.append(drawer.draw_line(p[3], p[4]))
+            arc3.append(drawer.draw_arc(p[12], p[5], p[4]))
+            arc4.append(drawer.draw_arc(p[12], p[6], p[5]))
+            seg3.append(drawer.draw_line(p[6], p[7]))
+            arc5.append(drawer.draw_arc(p[11], p[8], p[7]))
+            seg4.append(drawer.draw_line(p[8], p[9]))
+            arc6.append(drawer.draw_arc(self.location.anchor_xy, p[9], p[10]))
+
+        arc7.append(drawer.draw_arc(self.location.anchor_xy,
+            [r_ri, DimMillimeter(0)], [- r_ri, DimMillimeter(0)]))
+        arc8.append(drawer.draw_arc(self.location.anchor_xy,
+            [- r_ri, DimMillimeter(0)], [r_ri, DimMillimeter(0)]))
+
+        rad = (r_ri + x6) / 2
+        inner_coord = self.location.transform_coords([[rad, 0]])
+        segments = [arc1, seg1, arc2, seg2, arc3, arc4, seg3, arc5, seg4, arc6, arc7, arc8]
+        segs = [x for segment in segments for x in segment]
+        cs_token = CrossSectToken(inner_coord[0], segs)
+        return cs_token
+
+    def _validate_attr(self):
+
+        if isinstance(self._dim_r_ri, DimLinear):
+            pass
+        else:
+            raise TypeError("dim_r_ri not of type DimLinear")
+
+        if isinstance(self._dim_d_ri, DimLinear):
+            pass
+        else:
+            raise TypeError("dim_d_ri not of type DimLinear")
+
+        if isinstance(self._dim_d_rb, DimLinear):
+            pass
+        else:
+            raise TypeError("dim_d_rb not of type DimLinear")
+
+        if isinstance(self._dim_r_rb1, DimLinear):
+            pass
+        else:
+            raise TypeError("dim_r_rb1 not of type DimLinear")
+
+        if isinstance(self._dim_r_rb2, DimLinear):
+            pass
+        else:
+            raise TypeError("dim_r_rb2 not of type DimLinear")
+
+        if isinstance(self._dim_d_so, DimLinear):
+            pass
+        else:
+            raise TypeError("dim_d_so not of type DimLinear")
+
+        if isinstance(self._dim_w_so, DimLinear):
+            pass
+        else:
+            raise TypeError("dim_w_so not of type DimLinear")
+
+        if isinstance(self._Qr, int):
+            pass
+        else:
+            raise TypeError("Qr not of type int")
+
+
+class CrossSectInnerRotorDropSlotsPartial(CrossSectBase):
+
+    def __init__(self, **kwargs: any) -> None:
+        '''
+        Intialization function for CrossSectInnerRotorDropSlotsPartial class. This function takes in
+        arguments and saves the information passed to private variable to make
+        them read-only
+        Parameters
+        ----------
+        **kwargs : any
+            DESCRIPTION. Keyword arguments provided to the initialization funcntion.
+            The following argument names have to be included in order for the code
+            to execute:  name, dim_l, dim_t, dim_theta, location.
+            
+        Returns
+        -------
+        None
+        '''
+        self._create_attr(kwargs)
+
+        super()._validate_attr()
+        self._validate_attr()
+
+    @property
+    def dim_r_ri(self):
+        return self._dim_r_ri
+
+    @property
+    def dim_d_ri(self):
+        return self._dim_d_ri
+
+    @property
+    def dim_d_rb(self):
+        return self._dim_d_rb
+
+    @property
+    def dim_r_rb1(self):
+        return self._dim_r_rb1
+
+    @property
+    def dim_r_rb2(self):
+        return self._dim_r_rb2
+
+    @property
+    def dim_d_so(self):
+        return self._dim_d_so
+
+    @property
+    def dim_w_so(self):
+        return self._dim_w_so
+
+    @property
+    def Qr(self):
+        return self._Qr
+
+    def draw(self, drawer):
+
+        r_ri = self.dim_r_ri
+        d_ri = self.dim_d_ri
+        d_rb = self.dim_d_rb
+        r_rb1 = self.dim_r_rb1
+        r_rb2 = self.dim_r_rb2
+        d_so = self.dim_d_so
+        w_so = self.dim_w_so
+        Qr = self.Qr
+
+        alpha_u = DimRadian(2 * np.pi / Qr)
+        r1 = r_ri + d_ri + r_rb2 + d_rb + DimMillimeter(np.sqrt(r_rb1 ** 2 - (w_so / 2) ** 2)) + d_so
+        r2 = w_so / 2
+        r_ro = DimMillimeter(np.sqrt(r1 ** 2 + r2 ** 2))
+
+        x1 = r_ro * np.cos(alpha_u / 2)
+        y1 = - r_ro * np.sin(alpha_u / 2)
+
+        x2 = DimMillimeter(np.sqrt(r_ro ** 2 - (w_so / 2) ** 2))
+        y2 = - w_so / 2
+
+        x3 = x2 - d_so
+        y3 = y2
+
+        Rc2 = r_ri + d_ri + r_rb2
+        Rc1 = Rc2 + d_rb
+
+        alpha_slope = np.arcsin((r_rb1 - r_rb2) / d_rb)
+
+        x4 = Rc1 - r_rb1 * np.sin(alpha_slope)
+        y4 = - r_rb1 * np.cos(alpha_slope)
+
+        x5 = Rc2 - r_rb2 * np.sin(alpha_slope)
+        y5 = - r_rb2 * np.cos(alpha_slope)
+
+        x6 = r_ri + d_ri
+        y6 = DimMillimeter(0)
+
+        x7 = x5
+        y7 = - y5
+
+        x8 = x4
+        y8 = - y4
+
+        x9 = x3
+        y9 = - y3
+
+        x10 = x2
+        y10 = - y2
+
+        x11 = x1
+        y11 = - y1
+
+        center_rotor_bar1 = [Rc1, DimMillimeter(0)]
+        center_rotor_bar2 = [Rc2, DimMillimeter(0)]
+
+        x_arr = [x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, center_rotor_bar1[0], center_rotor_bar2[0]]
+        y_arr = [y1, y2, y3, y4, y5, y6, y7, y8, y9, y10, y11, center_rotor_bar1[1], center_rotor_bar2[1]]
+
+        arc1 = []
+        arc2 = []
+        arc3 = []
+        arc4 = []
+        arc5 = []
+        arc6 = []
+        arc7 = []
+        seg1 = []
+        seg2 = []
+        seg3 = []
+        seg4 = []
+        seg5 = []
+        seg6 = []
+
+        # transpose list
+        coords = [x_arr, y_arr]
+        coords = list(zip(*coords))
+        coords = [list(sublist) for sublist in coords]
+
+        for i in range(0, 1):
+            p = self.location.transform_coords(coords, alpha_u * i)
+
+            arc1.append(drawer.draw_arc(self.location.anchor_xy, p[0], p[1]))
+            seg1.append(drawer.draw_line(p[1], p[2]))
+            arc2.append(drawer.draw_arc(p[11], p[3], p[2]))
+            seg2.append(drawer.draw_line(p[3], p[4]))
+            arc3.append(drawer.draw_arc(p[12], p[5], p[4]))
+            arc4.append(drawer.draw_arc(p[12], p[6], p[5]))
+            seg3.append(drawer.draw_line(p[6], p[7]))
+            arc5.append(drawer.draw_arc(p[11], p[8], p[7]))
+            seg4.append(drawer.draw_line(p[8], p[9]))
+            arc6.append(drawer.draw_arc(self.location.anchor_xy, p[9], p[10]))
+
+        x12 = r_ri * np.cos(alpha_u / 2)
+        y12 = - r_ri * np.sin(alpha_u / 2)
+        x13 = x12
+        y13 = - y12
+        arc7.append(drawer.draw_arc(self.location.anchor_xy,
+            [x12, y12], [x13, y13]))
+        seg5.append(drawer.draw_line(p[0], [x12, y12]))
+        seg6.append(drawer.draw_line(p[10], [x13, y13]))
+
+        rad = (r_ri + x6) / 2
+        inner_coord = self.location.transform_coords([[rad, 0]])
+        segments = [
+            arc1, seg1, arc2, seg2, arc3, arc4, seg3, arc5, seg4, 
+            arc6, arc7, seg5, seg6]
+        segs = [x for segment in segments for x in segment]
+        cs_token = CrossSectToken(inner_coord[0], segs)
+        return cs_token
+
+    def _validate_attr(self):
+
+        if isinstance(self._dim_r_ri, DimLinear):
+            pass
+        else:
+            raise TypeError("dim_r_ri not of type DimLinear")
+
+        if isinstance(self._dim_d_ri, DimLinear):
+            pass
+        else:
+            raise TypeError("dim_d_ri not of type DimLinear")
+
+        if isinstance(self._dim_d_rb, DimLinear):
+            pass
+        else:
+            raise TypeError("dim_d_rb not of type DimLinear")
+
+        if isinstance(self._dim_r_rb1, DimLinear):
+            pass
+        else:
+            raise TypeError("dim_r_rb1 not of type DimLinear")
+
+        if isinstance(self._dim_r_rb2, DimLinear):
+            pass
+        else:
+            raise TypeError("dim_r_rb2 not of type DimLinear")
+
+        if isinstance(self._dim_d_so, DimLinear):
+            pass
+        else:
+            raise TypeError("dim_d_so not of type DimLinear")
+
+        if isinstance(self._dim_w_so, DimLinear):
+            pass
+        else:
+            raise TypeError("dim_w_so not of type DimLinear")
+
+        if isinstance(self._Qr, int):
+            pass
+        else:
+            raise TypeError("Qr not of type int")
+
+
+class CrossSectInnerRotorDropSlotsBar(CrossSectBase):
+
+    def __init__(self, **kwargs: any) -> None:
+        '''
+        Intialization function for RoundBar class. This function takes in
+        arguments and saves the information passed to private variable to make
+        them read-only
+        Parameters
+        ----------
+        **kwargs : any
+            DESCRIPTION. Keyword arguments provided to the initialization funcntion.
+            The following argument names have to be included in order for the code
+            to execute: name, dim_t, dim_r_o, location. 
+            
+        Returns
+        -------
+        None
+        '''
+        self._create_attr(kwargs)
+
+        super()._validate_attr()
+        self._validate_attr()
+
+    @property
+    def rotor_core(self):
+        return self._rotor_core
+
+    def draw(self, drawer):
+
+        r_ri = self.rotor_core.dim_r_ri
+        d_ri = self.rotor_core.dim_d_ri
+        d_rb = self.rotor_core.dim_d_rb
+        r_rb1 = self.rotor_core.dim_r_rb1
+        r_rb2 = self.rotor_core.dim_r_rb2
+        d_so = self.rotor_core.dim_d_so
+        w_so = self.rotor_core.dim_w_so
+        Qr = self.rotor_core.Qr
+
+        alpha_u = DimRadian(2 * np.pi / Qr)
+        r1 = r_ri + d_ri + r_rb2 + d_rb + DimMillimeter(np.sqrt(r_rb1 ** 2 - (w_so / 2) ** 2)) + d_so
+        r2 = w_so / 2
+        r_ro = DimMillimeter(np.sqrt(r1 ** 2 + r2 ** 2))
+
+        x1 = r_ro * np.cos(alpha_u / 2)
+        y1 = - r_ro * np.sin(alpha_u / 2)
+
+        x2 = DimMillimeter(np.sqrt(r_ro ** 2 - (w_so / 2) ** 2))
+        y2 = - w_so / 2
+
+        x3 = x2 - d_so
+        y3 = y2
+
+        Rc2 = r_ri + d_ri + r_rb2
+        Rc1 = Rc2 + d_rb
+
+        alpha_slope = np.arcsin((r_rb1 - r_rb2) / d_rb)
+
+        x4 = Rc1 - r_rb1 * np.sin(alpha_slope)
+        y4 = - r_rb1 * np.cos(alpha_slope)
+
+        x5 = Rc2 - r_rb2 * np.sin(alpha_slope)
+        y5 = - r_rb2 * np.cos(alpha_slope)
+
+        x6 = r_ri + d_ri
+        y6 = DimMillimeter(0)
+
+        x7 = x5
+        y7 = - y5
+
+        x8 = x4
+        y8 = - y4
+
+        x9 = x3
+        y9 = - y3
+
+        x10 = x2
+        y10 = - y2
+
+        x11 = x1
+        y11 = - y1
+
+        x12 = Rc1 + r_rb1
+        y12 = DimMillimeter(0)
+
+        center_rotor_bar1 = [Rc1, DimMillimeter(0)]
+        center_rotor_bar2 = [Rc2, DimMillimeter(0)]
+
+        x_arr = [x12, x4, x5, x6, x7, x8, center_rotor_bar1[0], center_rotor_bar2[0]]
+        y_arr = [y12, y4, y5, y6, y7, y8, center_rotor_bar1[1], center_rotor_bar2[1]]
+
+        arc1 = []
+        seg1 = []
+        arc2 = []
+        arc3 = []
+        seg2 = []
+        arc4 = []
+
+        # transpose list
+        coords = [x_arr, y_arr]
+        coords = list(zip(*coords))
+        coords = [list(sublist) for sublist in coords]
+
+        p = self.location.transform_coords(coords, 0)
+
+        arc1.append(drawer.draw_arc(p[6], p[1], p[0]))
+        seg1.append(drawer.draw_line(p[1], p[2]))
+        arc1.append(drawer.draw_arc(p[7], p[3], p[2]))
+        arc3.append(drawer.draw_arc(p[7], p[4], p[3]))
+        seg2.append(drawer.draw_line(p[4], p[5]))
+        arc4.append(drawer.draw_arc(p[6], p[0], p[5]))
+
+        inner_coord = self.location.transform_coords([center_rotor_bar1])
+        segments = [arc1, seg1, arc2, arc3, seg2, arc4]
+        segs = [x for segment in segments for x in segment]
+        cs_token = CrossSectToken(inner_coord[0], segs)
+
+        return cs_token
+
+    def _validate_attr(self):
+
+        if isinstance(self.rotor_core, CrossSectInnerRotorDropSlots):
+            pass
+        else:
+            raise TypeError("rotor_core not of type CrossSectInnerRotorDropSlots")

--- a/mach_cad/model_obj/cross_sects/inner_rotor_round_slots/CrossSectInnerRotorRoundSlots.svg
+++ b/mach_cad/model_obj/cross_sects/inner_rotor_round_slots/CrossSectInnerRotorRoundSlots.svg
@@ -1,0 +1,1624 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   inkscape:export-ydpi="150"
+   inkscape:export-xdpi="150"
+   inkscape:export-filename="C:\Users\nheme\Documents\Research\Bearingless Motor\Bearinless_Parametrization_Rev1_wht_bckgrnd.png"
+   inkscape:version="1.0.1 (3bc2e813f5, 2020-09-07)"
+   sodipodi:docname="CrossSectInnerRotorRoundSlots.svg"
+   id="svg837"
+   version="1.1"
+   viewBox="0 0 171 145"
+   height="145mm"
+   width="171mm">
+  <defs
+     id="defs831">
+    <marker
+       inkscape:stockid="Arrow1Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker9019"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path9017"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker9009"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mstart">
+      <path
+         transform="matrix(0.4,0,0,0.4,4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path9007" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker8201"
+       style="overflow:visible"
+       inkscape:isstock="true"
+       inkscape:collect="always">
+      <path
+         id="path8199"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker8191"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mstart"
+       inkscape:collect="always">
+      <path
+         transform="matrix(0.4,0,0,0.4,4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path8189" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker7163"
+       style="overflow:visible"
+       inkscape:isstock="true"
+       inkscape:collect="always">
+      <path
+         id="path7161"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker7153"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mstart"
+       inkscape:collect="always">
+      <path
+         transform="matrix(0.4,0,0,0.4,4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path7151" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker6553"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path6551"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker5969"
+       style="overflow:visible"
+       inkscape:isstock="true"
+       inkscape:collect="always">
+      <path
+         id="path5967"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker5313"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mend">
+      <path
+         transform="matrix(-0.4,0,0,-0.4,-4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path5311" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker4395"
+       style="overflow:visible"
+       inkscape:isstock="true"
+       inkscape:collect="always">
+      <path
+         id="path4393"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker4385"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mend"
+       inkscape:collect="always">
+      <path
+         transform="matrix(-0.4,0,0,-0.4,-4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path4383" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker3363"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path3361"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mstart"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker2957"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path2955"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(0.4,0,0,0.4,4,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mstart"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker4727"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path4725"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(0.4,0,0,0.4,4,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mstart"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker4345"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path4343"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(0.4,0,0,0.4,4,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mstart"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker3969"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path3967"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(0.4,0,0,0.4,4,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mstart"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker3599"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path3597"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(0.4,0,0,0.4,4,0)" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker2905"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow2Send">
+      <path
+         transform="matrix(-0.3,0,0,-0.3,0.69,0)"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         id="path2903" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker3124"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow2Send">
+      <path
+         transform="matrix(-0.3,0,0,-0.3,0.69,0)"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         id="path3122" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker1741"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path1739"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#ff0000;fill-opacity:1;fill-rule:evenodd;stroke:#ff0000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker1387"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mend">
+      <path
+         transform="matrix(-0.4,0,0,-0.4,-4,0)"
+         style="fill:#ff0000;fill-opacity:1;fill-rule:evenodd;stroke:#ff0000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path1385" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow2Send"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker4852"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path4850"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         transform="matrix(-0.3,0,0,-0.3,0.69,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow2Send"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker3691"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path3689"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         transform="matrix(-0.3,0,0,-0.3,0.69,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Sstart"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker3429"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path3427"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(0.2,0,0,0.2,1.2,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow2Send"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker2019"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path2017"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         transform="matrix(-0.3,0,0,-0.3,0.69,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow2Sstart"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker1781"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path1779"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         transform="matrix(0.3,0,0,0.3,-0.69,0)" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker1488"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mend">
+      <path
+         transform="matrix(-0.4,0,0,-0.4,-4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path1486" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker1244"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mend">
+      <path
+         inkscape:connector-curvature="0"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path1242" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow2Send"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker16235"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path16233"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         transform="matrix(-0.3,0,0,-0.3,0.69,0)" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:stockid="Arrow2Send"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker15733"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path15731"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         transform="matrix(-0.3,0,0,-0.3,0.69,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker15525"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path15523"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker9500"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mend">
+      <path
+         transform="matrix(-0.4,0,0,-0.4,-4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path9498" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker8403"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mstart">
+      <path
+         transform="matrix(0.4,0,0,0.4,4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path8401" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker8209"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mend">
+      <path
+         transform="matrix(-0.4,0,0,-0.4,-4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path8207" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker8061"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mstart">
+      <path
+         transform="matrix(0.4,0,0,0.4,4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path8059" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker7820"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path7818"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mstart"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker7684"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path7682"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(0.4,0,0,0.4,4,0)" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:stockid="Arrow1Mstart"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker6757"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path6755"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(0.4,0,0,0.4,4,0)" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:stockid="Arrow1Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker6627"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path6625"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker6012"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mstart">
+      <path
+         transform="matrix(0.4,0,0,0.4,4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path6010" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker5894"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mend">
+      <path
+         transform="matrix(-0.4,0,0,-0.4,-4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path5892" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:stockid="Arrow1Mstart"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker5567"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path5565"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(0.4,0,0,0.4,4,0)" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:stockid="Arrow1Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker5461"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path5459"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:stockid="Arrow1Mstart"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker5080"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path5078"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(0.4,0,0,0.4,4,0)" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker4986"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mend">
+      <path
+         transform="matrix(-0.4,0,0,-0.4,-4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path4984" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker4450"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow2Send">
+      <path
+         transform="matrix(-0.3,0,0,-0.3,0.69,0)"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         id="path4448" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker4374"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path4372"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:stockid="Arrow1Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker4128"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path4126"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker3864"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mend">
+      <path
+         transform="matrix(-0.4,0,0,-0.4,-4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path3862" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="Arrow1Mstart"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mstart">
+      <path
+         transform="matrix(0.4,0,0,0.4,4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path1491" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="Arrow1Sstart"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Sstart">
+      <path
+         transform="matrix(0.2,0,0,0.2,1.2,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path1497" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker1939"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow2Send">
+      <path
+         transform="matrix(-0.3,0,0,-0.3,0.69,0)"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         id="path1937" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="Arrow2Sstart"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow2Sstart">
+      <path
+         transform="matrix(0.3,0,0,0.3,-0.69,0)"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         id="path1515" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="Arrow2Send"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow2Send">
+      <path
+         transform="matrix(-0.3,0,0,-0.3,0.69,0)"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         id="path1518" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="Arrow2Mstart"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow2Mstart">
+      <path
+         transform="scale(0.6)"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         id="path1509" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="Arrow1Mend"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mend">
+      <path
+         transform="matrix(-0.4,0,0,-0.4,-4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path1494" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:stockid="Arrow1Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker4128-8"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path4126-2"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow2Send"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker4852-2"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path4850-0"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         transform="matrix(-0.3,0,0,-0.3,0.69,0)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow2Send"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker4852-2-2"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path4850-0-3"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         transform="matrix(-0.3,0,0,-0.3,0.69,0)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       id="DistanceX"
+       orient="auto"
+       refX="0"
+       refY="0"
+       style="overflow:visible">
+      <path
+         d="M 3,-3 -3,3 M 0,-5 V 5"
+         style="stroke:#000000;stroke-width:0.5"
+         id="path1492" />
+    </marker>
+    <pattern
+       id="Hatch"
+       patternUnits="userSpaceOnUse"
+       width="8"
+       height="8"
+       x="0"
+       y="0">
+      <path
+         d="M8 4 l-4,4"
+         stroke="#000000"
+         stroke-width="0.25"
+         linecap="square"
+         id="path1495" />
+      <path
+         d="M6 2 l-4,4"
+         stroke="#000000"
+         stroke-width="0.25"
+         linecap="square"
+         id="path1497-9" />
+      <path
+         d="M4 0 l-4,4"
+         stroke="#000000"
+         stroke-width="0.25"
+         linecap="square"
+         id="path1499" />
+    </pattern>
+  </defs>
+  <sodipodi:namedview
+     height="281mm"
+     inkscape:document-rotation="0"
+     inkscape:snap-to-guides="true"
+     inkscape:snap-global="true"
+     inkscape:snap-bbox="false"
+     inkscape:object-paths="true"
+     inkscape:snap-intersection-paths="true"
+     inkscape:snap-object-midpoints="true"
+     inkscape:snap-others="true"
+     inkscape:snap-smooth-nodes="true"
+     inkscape:snap-midpoints="true"
+     inkscape:snap-center="true"
+     inkscape:window-maximized="1"
+     inkscape:window-y="-6"
+     inkscape:window-x="-6"
+     inkscape:window-height="658"
+     inkscape:window-width="1280"
+     inkscape:guide-bbox="true"
+     showguides="false"
+     showborder="true"
+     showgrid="false"
+     inkscape:current-layer="layer4"
+     inkscape:document-units="mm"
+     inkscape:cy="308.78873"
+     inkscape:cx="411.86652"
+     inkscape:zoom="0.7071068"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     borderopacity="1.0"
+     bordercolor="#666666"
+     pagecolor="#ffffff"
+     id="base" />
+  <metadata
+     id="metadata834">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     style="display:none"
+     inkscape:label="Background"
+     id="layer5"
+     inkscape:groupmode="layer" />
+  <g
+     style="display:none"
+     id="layer1"
+     inkscape:groupmode="layer"
+     inkscape:label="Total_Motor">
+    <path
+       inkscape:connector-curvature="0"
+       id="path1388"
+       transform="scale(0.26458333)"
+       d="M 0,650.07812 A 472.4409,472.4409 0 0 0 -472.44141,1122.5195 472.4409,472.4409 0 0 0 0,1594.9609 472.4409,472.4409 0 0 0 472.44141,1122.5195 472.4409,472.4409 0 0 0 0,650.07812 Z m -62.580078,131.7168 c 2.119773,-0.0633 4.238058,0.0941 6.103516,0.6543 2.541358,0.7632 4.943413,2.47682 6.457031,4.65625 1.450551,2.08861 2.260179,4.14371 2.77539,6.56445 v 96.20703 l -32.126953,32.12696 v 25.01171 A 192.85715,192.85715 0 0 1 0,929.66211 192.85715,192.85715 0 0 1 79.371094,946.94922 V 922.00391 L 47.244141,889.87695 v -96.1914 c 0.515003,-2.42755 1.32369,-4.487 2.777343,-6.58008 1.513618,-2.17943 3.915677,-3.89305 6.457032,-4.65625 1.645518,-0.49416 3.491159,-0.65631 5.357422,-0.64844 A 347.10338,347.10338 0 0 1 262.25586,895.70703 c 1.75673,2.4167 3.37685,5.15152 4.01758,7.86524 0.60972,2.58247 0.32595,5.51939 -0.80469,7.91992 -1.08536,2.30442 -2.46502,4.03425 -4.30859,5.69336 l -83.3086,48.09765 -43.88476,-11.75781 -21.66211,12.50586 a 192.85715,192.85715 0 0 1 54.71484,60.06055 192.85715,192.85715 0 0 1 24.71485,77.3809 L 213.33789,1091 l 11.75781,-43.8867 83.31055,-48.09963 c 2.35704,-0.76605 4.54514,-1.093 7.08203,-0.88086 2.64428,0.2211 5.33009,1.4444 7.26172,3.26369 1.49012,1.4034 2.72559,3.2743 3.76172,5.248 a 347.10338,347.10338 0 0 1 20.5918,115.875 347.10338,347.10338 0 0 1 -20.0625,114.8164 c -1.13505,2.3551 -2.53462,4.6543 -4.28907,6.3067 -1.93162,1.8193 -4.61553,3.0425 -7.25976,3.2636 -2.5387,0.2123 -4.72893,-0.1155 -7.08789,-0.8828 l -83.3086,-48.0976 -11.75781,-43.8848 -21.66211,-12.5058 a 192.85715,192.85715 0 0 1 -24.65625,77.414 192.85715,192.85715 0 0 1 -54.65625,60.0938 l 21.60352,12.4726 43.88476,-11.7597 83.30664,48.0976 c 1.84358,1.6591 3.22324,3.3889 4.3086,5.6934 1.13066,2.4005 1.41246,5.3374 0.80273,7.9199 -0.38563,1.6333 -1.14266,3.2715 -2.05273,4.8496 A 347.10338,347.10338 0 0 1 63.15625,1463.209 c -2.309571,0.1107 -4.639833,-0.01 -6.673828,-0.6192 -2.541351,-0.7632 -4.94539,-2.4748 -6.458984,-4.6543 -1.45523,-2.0953 -2.264404,-4.1588 -2.779297,-6.5898 v -96.1836 l 32.126953,-32.1269 v -25.0118 A 192.85715,192.85715 0 0 1 0,1315.377 192.85715,192.85715 0 0 1 -79.371094,1298.0898 v 24.9454 l 32.126953,32.1269 v 96.1914 c -0.514998,2.4276 -1.323687,4.489 -2.777343,6.582 -1.513614,2.1795 -3.915681,3.8911 -6.457032,4.6543 -1.645521,0.4942 -3.491159,0.6564 -5.357422,0.6485 A 347.10338,347.10338 0 0 1 -262.22656,1349.3672 c -1.76655,-2.4252 -3.39721,-5.1736 -4.04102,-7.9004 -0.60972,-2.5825 -0.32791,-5.5194 0.80274,-7.9199 1.08656,-2.307 2.46775,-4.0385 4.31445,-5.6992 l 83.29883,-48.0918 43.88476,11.7597 21.66211,-12.5058 a 192.85715,192.85715 0 0 1 -54.71484,-60.0606 192.85715,192.85715 0 0 1 -24.71485,-77.3808 l -21.60351,12.4726 -11.75781,43.8848 -83.31055,48.0996 c -2.35704,0.766 -4.54513,1.093 -7.08203,0.8808 -2.64427,-0.2211 -5.33009,-1.4443 -7.26172,-3.2636 -1.49012,-1.4035 -2.72559,-3.2744 -3.76172,-5.2481 a 347.10338,347.10338 0 0 1 -20.5918,-115.875 347.10338,347.10338 0 0 1 20.04688,-114.7754 c 1.13845,-2.3696 2.54575,-4.6855 4.31055,-6.3476 1.93163,-1.81929 4.61551,-3.04259 7.25976,-3.26369 2.53416,-0.21191 4.7201,0.11466 7.07422,0.87891 l 83.31641,48.10158 11.75781,43.8867 21.66211,12.5059 a 192.85715,192.85715 0 0 1 24.65625,-77.4141 192.85715,192.85715 0 0 1 54.65625,-60.09571 l -21.60352,-12.4707 -43.88476,11.75781 -83.30664,-48.09765 c -1.84358,-1.65911 -3.22324,-3.38894 -4.3086,-5.69336 -1.13063,-2.40057 -1.41246,-5.33745 -0.80273,-7.91992 0.3858,-1.63403 1.14211,-3.27284 2.05273,-4.85157 A 347.10338,347.10338 0 0 1 -63.158203,781.83008 c 0.193318,-0.009 0.38466,-0.0294 0.578125,-0.0352 z"
+       style="opacity:1;fill:#008000;fill-opacity:1;stroke:#000000;stroke-width:3.77953;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+    <circle
+       r="43.733097"
+       cy="297"
+       cx="0"
+       id="path1390"
+       style="opacity:1;fill:#ff0000;fill-opacity:1;stroke:#000000;stroke-width:1.09333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+  </g>
+  <g
+     style="display:none"
+     inkscape:label="Motor_Cutaway"
+     id="layer2"
+     inkscape:groupmode="layer" />
+  <g
+     style="display:none"
+     inkscape:label="Annotations_1"
+     id="layer3"
+     inkscape:groupmode="layer">
+    <path
+       inkscape:connector-curvature="0"
+       id="path5884"
+       d="M -7.5563861,234.90369 V 206.70526"
+       style="fill:none;stroke:#000000;stroke-width:0.259632px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-start:url(#marker6012);marker-end:url(#marker5894)" />
+    <rect
+       y="218.84871"
+       x="-8.3674479"
+       height="2.2158854"
+       width="1.5875"
+       id="rect6524"
+       style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.264583;stroke-miterlimit:4;stroke-dasharray:0.79375, 0.264583;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal" />
+    <path
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       id="path1464"
+       d="M -0.02743323,297.01265 35.30925,221.27907"
+       style="fill:none;stroke:#000000;stroke-width:0.202531;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:0.810125, 0.202531;stroke-dashoffset:0;stroke-opacity:1" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.202531;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:0.810125, 0.202531;stroke-dashoffset:0;stroke-opacity:1"
+       d="M 0,297 -35.336683,221.26642"
+       id="path1466"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cc" />
+    <path
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       id="path1470"
+       d="M -21.000268,250.56454 V 221.26642"
+       style="fill:none;stroke:#000000;stroke-width:0.264583;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:0.79375, 0.264583;stroke-dashoffset:0;stroke-opacity:1" />
+    <path
+       sodipodi:nodetypes="csc"
+       inkscape:connector-curvature="0"
+       id="path1482"
+       d="m -11.797594,270.57892 c 3.5813579,-1.66871 7.5752744,-2.60053 11.78682858,-2.60053 4.23356982,0 8.24722062,0.94159 11.84295942,2.62676"
+       style="opacity:1;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.264583;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-start:url(#Arrow2Sstart);marker-end:url(#Arrow2Send);paint-order:normal" />
+    <g
+       transform="translate(-23.187493,-34.196779)"
+       id="g1919">
+      <rect
+         style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.264583;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal"
+         id="rect1907"
+         width="6.160902"
+         height="5.5858846"
+         x="20.12562"
+         y="299.38223" />
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+         x="20.947077"
+         y="304.3931"
+         id="text1895"><tspan
+           sodipodi:role="line"
+           id="tspan1893"
+           x="20.947077"
+           y="304.3931"
+           style="stroke-width:0.264583">θ<tspan
+   style="font-size:3.52778px"
+   id="tspan1897">t</tspan></tspan></text>
+    </g>
+    <flowRoot
+       transform="scale(0.26458333)"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:24px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none"
+       id="flowRoot1899"
+       xml:space="preserve"><flowRegion
+         id="flowRegion1901"><rect
+           y="1122.5197"
+           x="61.473213"
+           height="49.675323"
+           width="50.91721"
+           id="rect1903" /></flowRegion><flowPara
+         id="flowPara1905" /></flowRoot>
+    <path
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       id="path1934"
+       d="m -29.626283,232.40708 c 2.447086,-1.23671 5.213559,-1.9334 8.142751,-1.9334"
+       style="display:inline;opacity:1;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.236671;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-start:url(#Arrow1Sstart);marker-end:url(#marker1939);paint-order:normal" />
+    <rect
+       y="229.11623"
+       x="-27.407322"
+       height="3.6542518"
+       width="3.6240244"
+       id="rect1927"
+       style="display:inline;opacity:1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.13113;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal" />
+    <text
+       id="text1923"
+       y="232.42699"
+       x="-27.561081"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+       xml:space="preserve"><tspan
+         style="stroke-width:0.264583"
+         y="232.42699"
+         x="-27.561081"
+         id="tspan1921"
+         sodipodi:role="line">α</tspan></text>
+    <path
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       id="path3542"
+       d="m 25.501249,208.12668 8.748058,-30.47166"
+       style="fill:none;stroke:#000000;stroke-width:0.251839px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-start:url(#Arrow1Mstart);marker-end:url(#marker3864)" />
+    <text
+       id="text4090"
+       y="162.72395"
+       x="57.811459"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+       xml:space="preserve"><tspan
+         style="stroke-width:0.264583"
+         y="162.72395"
+         x="57.811459"
+         id="tspan4088"
+         sodipodi:role="line" /></text>
+    <path
+       inkscape:connector-curvature="0"
+       id="path3528"
+       d="M -12.500012,236.16224 V 246.8512"
+       style="display:inline;fill:none;stroke:#000000;stroke-width:0.24847px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-start:url(#marker5567);marker-end:url(#marker5461)" />
+    <text
+       id="text4094"
+       y="173.58723"
+       x="-52.318027"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+       xml:space="preserve"><tspan
+         style="stroke-width:0.264583"
+         y="173.58723"
+         x="-52.318027"
+         id="tspan4092"
+         sodipodi:role="line">D<tspan
+   id="tspan4096"
+   style="font-size:3.52778px">os</tspan></tspan></text>
+    <g
+       transform="translate(-16.559098,-7.3212701)"
+       id="g4116">
+      <rect
+         style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:0.237103;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal"
+         id="rect4104"
+         width="6.6424799"
+         height="5.9479485"
+         x="43.113136"
+         y="197.23814" />
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+         x="43.78854"
+         y="202.14687"
+         id="text4100"><tspan
+           sodipodi:role="line"
+           id="tspan4098"
+           x="43.78854"
+           y="202.14687"
+           style="stroke-width:0.264583">T<tspan
+   style="font-size:3.52778px"
+   id="tspan4102">s</tspan></tspan></text>
+    </g>
+    <path
+       sodipodi:nodetypes="ccc"
+       inkscape:connector-curvature="0"
+       id="path4118"
+       d="m -44.334244,171.98437 h 2.000911 l 4.828646,4.82865"
+       style="fill:none;stroke:#000000;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#marker4128)" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path4364"
+       d="m 15.718783,210.03594 -1.547002,-1.79208"
+       style="fill:none;stroke:#000000;stroke-width:0.191617;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:0.383234, 0.191617;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker4450)" />
+    <text
+       id="text4634"
+       y="212.41602"
+       x="15.941146"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+       xml:space="preserve"><tspan
+         style="stroke-width:0.264583"
+         y="212.41602"
+         x="15.941146"
+         id="tspan4632"
+         sodipodi:role="line">r</tspan></text>
+    <path
+       inkscape:connector-curvature="0"
+       id="path4976"
+       d="M -11.547554,219.80781 H 11.547554"
+       style="fill:none;stroke:#000000;stroke-width:0.254303px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-start:url(#marker5080);marker-end:url(#marker4986)" />
+    <g
+       transform="translate(-43.306146,19.473489)"
+       id="g4116-9">
+      <g
+         transform="translate(0,0.18708867)"
+         id="g5421">
+        <rect
+           y="197.24779"
+           x="42.65506"
+           height="5.928659"
+           width="7.7924948"
+           id="rect4104-4"
+           style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:0.256393;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal" />
+        <text
+           id="text4100-8"
+           y="202.70813"
+           x="42.993412"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+           xml:space="preserve"><tspan
+             style="stroke-width:0.264583"
+             y="202.70813"
+             x="42.993412"
+             id="tspan4098-5"
+             sodipodi:role="line">W<tspan
+   style="font-size:3.52778px"
+   id="tspan5415">t</tspan></tspan></text>
+      </g>
+    </g>
+    <path
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       id="path5449"
+       d="m -12.500012,247.56684 h 9.8872516"
+       style="fill:none;stroke:#000000;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+    <path
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       id="path5451"
+       d="m -12.500012,235.4466 h 9.8872516"
+       style="fill:none;stroke:#000000;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+    <path
+       sodipodi:arc-type="arc"
+       style="display:inline;opacity:1;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.265;stroke-miterlimit:4;stroke-dasharray:0.795, 0.265;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal"
+       id="path5875"
+       sodipodi:type="arc"
+       sodipodi:cx="0"
+       sodipodi:cy="296.99997"
+       sodipodi:rx="91.67807"
+       sodipodi:ry="91.67807"
+       sodipodi:start="4.4466291"
+       sodipodi:end="4.5768786"
+       sodipodi:open="true"
+       d="m -24.078562,208.54042 a 91.67807,91.67807 0 0 1 11.693219,-2.37806" />
+    <path
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       id="path5878"
+       d="m -12.500012,213.23104 v -7.0392"
+       style="fill:none;stroke:#000000;stroke-width:0.264583;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:0.79375, 0.264583;stroke-dashoffset:0;stroke-opacity:1" />
+    <path
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       id="path5882"
+       d="m -12.385343,206.16235 h 9.7725826"
+       style="fill:none;stroke:#000000;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+    <g
+       transform="translate(-53.364328,27.478398)"
+       id="g4116-9-8"
+       style="display:inline">
+      <g
+         transform="translate(0,0.18708867)"
+         id="g5421-1">
+        <rect
+           y="197.24779"
+           x="42.65506"
+           height="5.928659"
+           width="7.7924948"
+           id="rect4104-4-4"
+           style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:0.256393;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal" />
+        <text
+           id="text4100-8-5"
+           y="202.17897"
+           x="43.456432"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+           xml:space="preserve"><tspan
+             style="stroke-width:0.264583"
+             y="202.17897"
+             x="43.456432"
+             id="tspan4098-5-6"
+             sodipodi:role="line"><tspan
+               style="font-size:3.52778px"
+               id="tspan5415-7"><tspan
+   id="tspan6615"
+   style="font-size:6.35px">L</tspan>t</tspan></tspan></text>
+      </g>
+    </g>
+    <g
+       transform="translate(-53.364328,40.708055)"
+       id="g4116-9-8-7"
+       style="display:inline">
+      <g
+         transform="translate(0,0.18708867)"
+         id="g5421-1-5">
+        <rect
+           y="197.24779"
+           x="42.65506"
+           height="5.928659"
+           width="7.7924948"
+           id="rect4104-4-4-1"
+           style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:0.256393;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal" />
+        <text
+           id="text4100-8-5-7"
+           y="202.17897"
+           x="43.456432"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+           xml:space="preserve"><tspan
+             style="stroke-width:0.264583"
+             y="202.17897"
+             x="43.456432"
+             id="tspan4098-5-6-6"
+             sodipodi:role="line"><tspan
+               style="font-size:3.52778px"
+               id="tspan5415-7-7"><tspan
+   id="tspan6580-5"
+   style="font-size:6.35px">L</tspan>tt</tspan></tspan></text>
+      </g>
+    </g>
+    <path
+       sodipodi:nodetypes="ccc"
+       inkscape:connector-curvature="0"
+       id="path4118-8"
+       d="m -28.486583,277.7367 h -2.000911 l -4.828646,-4.82865"
+       style="display:inline;fill:none;stroke:#000000;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#marker4128-8)" />
+    <text
+       id="text4094-6"
+       y="279.95316"
+       x="-28.468546"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+       xml:space="preserve"><tspan
+         style="stroke-width:0.264583"
+         y="279.95316"
+         x="-28.468546"
+         id="tspan4092-2"
+         sodipodi:role="line">D<tspan
+   id="tspan4096-9"
+   style="font-size:3.52778px;stroke-width:0.264583">or</tspan></tspan></text>
+    <path
+       inkscape:transform-center-y="-47.336963"
+       inkscape:transform-center-x="-0.53635573"
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       id="path6617"
+       d="m 0.49341607,252.4546 0.0643483,-5.62927"
+       style="display:inline;fill:none;stroke:#000000;stroke-width:0.204665px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-start:url(#marker6757);marker-end:url(#marker6627)" />
+    <text
+       id="text4100-8-5-7-6"
+       y="251.6891"
+       x="1.700698"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+       xml:space="preserve"><tspan
+         style="stroke-width:0.264583"
+         y="251.6891"
+         x="1.700698"
+         id="tspan4098-5-6-6-5"
+         sodipodi:role="line"><tspan
+           style="font-size:3.52778px"
+           id="tspan5415-7-7-3"><tspan
+   id="tspan6580-5-5"
+   style="font-size:6.35px">L</tspan>g</tspan></tspan></text>
+    <path
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       id="path15507"
+       d="m 21.000268,250.54698 h 8.688366"
+       style="fill:none;stroke:#000000;stroke-width:0.23934px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+    <path
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       id="path15509"
+       d="m 21.000268,243.94686 h 8.688366"
+       style="fill:none;stroke:#000000;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+    <text
+       id="text15513"
+       y="248.73111"
+       x="25.765221"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+       xml:space="preserve"><tspan
+         style="stroke-width:0.264583"
+         y="248.73111"
+         x="25.765221"
+         id="tspan15511"
+         sodipodi:role="line">s</tspan></text>
+    <path
+       inkscape:connector-curvature="0"
+       id="path15515"
+       d="m 27.057699,249.05852 v 0.97042"
+       style="fill:none;stroke:#000000;stroke-width:0.276484px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#marker15733)" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path15945"
+       d="m 27.060298,245.50384 v -1.05237"
+       style="fill:none;stroke:#000000;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#marker16235)" />
+  </g>
+  <g
+     style="display:inline"
+     inkscape:label="Annotations_2"
+     id="layer4"
+     inkscape:groupmode="layer">
+    <g
+       transform="translate(125.42796,-33.89125)"
+       id="g4116-9-8-2-5"
+       style="display:inline">
+      <g
+         transform="translate(0,0.18708867)"
+         id="g5421-1-7-0">
+        <text
+           id="text4100-8-5-1-8"
+           y="202.24512"
+           x="42.629608"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+           xml:space="preserve"><tspan
+             style="stroke-width:0.264583"
+             y="0"
+             x="0"
+             id="tspan4098-5-6-1-3"
+             sodipodi:role="line"><tspan
+               style="font-size:3.52778px"
+               id="tspan5415-7-3-8"><tspan
+                 id="tspan6615-5-9"
+                 style="font-size:6.35px" /></tspan></tspan></text>
+      </g>
+    </g>
+    <g
+       id="g4181"
+       transform="translate(100.69956,-36.985927)"
+       style="stroke-width:0.8;stroke-miterlimit:4;stroke-dasharray:none">
+      <text
+         xml:space="preserve"
+         style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.23333px;line-height:1.25;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman, Italic';letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.8;stroke-miterlimit:4;stroke-dasharray:none"
+         x="-61.300587"
+         y="137.48808"
+         id="text2115"><tspan
+           sodipodi:role="line"
+           id="tspan2113"
+           x="-61.300587"
+           y="137.48808"
+           style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman, Italic';stroke-width:0.8;stroke-miterlimit:4;stroke-dasharray:none">x</tspan></text>
+      <text
+         xml:space="preserve"
+         style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:10.5833px;line-height:1.25;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman, Italic';letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.8;stroke-miterlimit:4;stroke-dasharray:none"
+         x="-81.795479"
+         y="117.64843"
+         id="text2145"><tspan
+           sodipodi:role="line"
+           id="tspan2143"
+           x="-81.795479"
+           y="117.64843"
+           style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman, Italic';stroke-width:0.8;stroke-miterlimit:4;stroke-dasharray:none">y</tspan></text>
+      <path
+         inkscape:connector-curvature="0"
+         id="path1377"
+         d="m -76.955365,132.96748 h 17.58635"
+         style="fill:none;stroke:#ff0000;stroke-width:0.8;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#marker1387)" />
+      <path
+         inkscape:transform-center-x="8.793175"
+         style="fill:none;stroke:#ff0000;stroke-width:0.8;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#marker1741)"
+         d="M -76.955365,132.96748 V 115.38113"
+         id="path1737"
+         inkscape:connector-curvature="0" />
+    </g>
+    <path
+       d="M 118.30486,99.609723 H 103.74628"
+       style="fill:none;stroke:#000000;stroke-width:0.8;stroke-miterlimit:4;stroke-dasharray:none"
+       id="path1576" />
+    <path
+       d="m 103.74628,92.330524 h 14.55858"
+       style="fill:none;stroke:#000000;stroke-width:0.8;stroke-miterlimit:4;stroke-dasharray:none"
+       id="path1578" />
+    <path
+       d="M 74.176541,15.898137 66.897275,28.506173"
+       style="fill:none;stroke:#000000;stroke-width:0.8;stroke-miterlimit:4;stroke-dasharray:none"
+       id="path1580" />
+    <path
+       d="M 60.593221,24.866625 67.872506,12.258411"
+       style="fill:none;stroke:#000000;stroke-width:0.8;stroke-miterlimit:4;stroke-dasharray:none"
+       id="path1582" />
+    <path
+       d="M 105.69679,143.28549 A 94.630689,94.630689 0 0 0 118.30486,99.609723"
+       style="fill:none;stroke:#000000;stroke-width:0.8;stroke-miterlimit:4;stroke-dasharray:none"
+       id="path1648" />
+    <path
+       d="m 75.091414,95.970234 a 14.558567,14.558567 0 0 0 28.654866,3.639489"
+       style="fill:none;stroke:#000000;stroke-width:0.8;stroke-miterlimit:4;stroke-dasharray:none"
+       id="path1650" />
+    <path
+       d="m 103.74628,92.330524 a 14.558567,14.558567 0 0 0 -28.654866,3.63971"
+       style="fill:none;stroke:#000000;stroke-width:0.8;stroke-miterlimit:4;stroke-dasharray:none"
+       id="path1652" />
+    <path
+       d="M 118.30486,92.330524 A 94.630689,94.630689 0 0 0 105.69679,48.654972"
+       style="fill:none;stroke:#000000;stroke-width:0.8;stroke-miterlimit:4;stroke-dasharray:none"
+       id="path1654" />
+    <path
+       d="M 105.69679,48.654972 A 94.630689,94.630689 0 0 0 74.176541,15.898137"
+       style="fill:none;stroke:#000000;stroke-width:0.8;stroke-miterlimit:4;stroke-dasharray:none"
+       id="path1656" />
+    <path
+       d="M 49.417845,52.294468 A 14.90431,14.90431 0 0 0 66.897275,28.506173"
+       style="fill:none;stroke:#000000;stroke-width:0.8;stroke-miterlimit:4;stroke-dasharray:none"
+       id="path1658" />
+    <path
+       d="M 60.593221,24.866625 A 14.904283,14.904283 0 0 0 49.417845,52.294468"
+       style="fill:none;stroke:#000000;stroke-width:0.8;stroke-miterlimit:4;stroke-dasharray:none"
+       id="path1660" />
+    <path
+       d="M 67.872506,12.258411 A 94.630689,94.630689 0 0 0 23.74418,1.3395019"
+       style="fill:none;stroke:#000000;stroke-width:0.8;stroke-miterlimit:4;stroke-dasharray:none"
+       id="path1662" />
+    <path
+       d="m 45.58207,95.970234 a 21.837882,21.837882 0 0 0 -43.6757601,0"
+       style="fill:none;stroke:#000000;stroke-width:0.8;stroke-miterlimit:4;stroke-dasharray:none"
+       id="path1696" />
+    <path
+       d="m 1.9063099,95.970234 a 21.837882,21.837882 0 0 0 43.6757601,0"
+       style="fill:none;stroke:#000000;stroke-width:0.8;stroke-miterlimit:4;stroke-dasharray:none"
+       id="path1698" />
+    <path
+       style="fill:#000000;stroke:#000000;stroke-width:0.4;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#marker4395)"
+       d="m 112.00083,85.526988 v 6.284436"
+       id="path4379"
+       inkscape:connector-curvature="0" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path4381"
+       d="m 112.00083,105.80366 v -5.66477"
+       style="fill:#000000;stroke:#000000;stroke-width:0.4;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#marker4385)" />
+    <text
+       xml:space="preserve"
+       style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;line-height:1.25;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman, Italic';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#999999;fill-opacity:1;stroke:none;stroke-width:0.264583"
+       x="104.53635"
+       y="108.5205"
+       id="text4959"><tspan
+         sodipodi:role="line"
+         id="tspan4957"
+         x="104.53635"
+         y="108.5205"
+         style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman,  Italic';fill:#000000;stroke-width:0.264583">w<tspan
+   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:65%;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman, ';baseline-shift:sub;fill:#000000"
+   id="tspan4955">so</tspan></tspan></text>
+    <path
+       style="fill:#000000;stroke:#000000;stroke-width:0.4;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#marker5969)"
+       d="m 96.84322,94.206864 6.28219,-0.16849"
+       id="path5965"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 103.74561,95.15556 6.7e-4,-2.825036"
+       style="fill:none;stroke:#000000;stroke-width:0.2;stroke-miterlimit:4;stroke-dasharray:none"
+       id="path6533" />
+    <path
+       d="m 118.31514,95.22572 6.7e-4,-2.825036"
+       style="fill:none;stroke:#000000;stroke-width:0.2;stroke-miterlimit:4;stroke-dasharray:none"
+       id="path6541" />
+    <path
+       style="fill:#000000;stroke:#000000;stroke-width:0.4;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#marker6553)"
+       d="m 125.12309,94.206864 -6.28219,-0.16849"
+       id="path6549"
+       inkscape:connector-curvature="0" />
+    <text
+       xml:space="preserve"
+       style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;line-height:1.25;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman, Italic';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#999999;fill-opacity:1;stroke:none;stroke-width:0.264583"
+       x="122.49686"
+       y="92.430855"
+       id="text7129"><tspan
+         sodipodi:role="line"
+         id="tspan7127"
+         x="122.49686"
+         y="92.430855"
+         style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman,  Italic';fill:#000000;stroke-width:0.264583">d<tspan
+   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:65%;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman, ';baseline-shift:sub;fill:#000000"
+   id="tspan7125">so</tspan></tspan></text>
+    <path
+       id="path7149"
+       d="M 80.801693,85.102428 89.12028,95.11876"
+       style="fill:none;stroke:#000000;stroke-width:0.4;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-start:url(#marker7153);marker-end:url(#marker7163)" />
+    <text
+       xml:space="preserve"
+       style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;line-height:1.25;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman, Italic';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#999999;fill-opacity:1;stroke:none;stroke-width:0.264583"
+       x="85.202789"
+       y="89.66452"
+       id="text8173"><tspan
+         sodipodi:role="line"
+         id="tspan8171"
+         x="85.202789"
+         y="89.66452"
+         style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman,  Italic';fill:#000000;stroke-width:0.264583">r<tspan
+   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:65%;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman, ';baseline-shift:sub;fill:#000000"
+   id="tspan8169">rb</tspan></tspan></text>
+    <path
+       id="path8187"
+       d="M 10.14308,79.712568 23.21502,95.452377"
+       style="fill:none;stroke:#000000;stroke-width:0.4;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-start:url(#marker8191);marker-end:url(#marker8201)" />
+    <text
+       xml:space="preserve"
+       style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;line-height:1.25;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman, Italic';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#999999;fill-opacity:1;stroke:none;stroke-width:0.264583"
+       x="11.022134"
+       y="90.319344"
+       id="text8991"><tspan
+         sodipodi:role="line"
+         id="tspan8989"
+         x="11.022134"
+         y="90.319344"
+         style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman,  Italic';fill:#000000;stroke-width:0.264583">r<tspan
+   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:65%;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman, ';baseline-shift:sub;fill:#000000"
+   id="tspan8987"
+   dy="0 0">ri</tspan></tspan></text>
+    <path
+       id="path9005"
+       d="m 74.378915,95.972639 -28.296455,0.0065"
+       style="fill:none;stroke:#000000;stroke-width:0.4;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-start:url(#marker9009);marker-end:url(#marker9019)" />
+    <text
+       xml:space="preserve"
+       style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;line-height:1.25;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman, Italic';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#999999;fill-opacity:1;stroke:none;stroke-width:0.264583"
+       x="57.900005"
+       y="93.740318"
+       id="text9973"><tspan
+         sodipodi:role="line"
+         id="tspan9971"
+         x="57.900005"
+         y="93.740318"
+         style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman,  Italic';fill:#000000;stroke-width:0.264583">d<tspan
+   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:65%;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman, ';baseline-shift:sub;fill:#000000"
+   id="tspan9969">ri</tspan></tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-size:6.35px;line-height:0.95;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math';display:inline;stroke-width:0.264583"
+       x="117.14384"
+       y="138.7039"
+       id="text1453"><tspan
+         sodipodi:role="line"
+         id="tspan1451"
+         x="117.14384"
+         y="138.7039"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman, ';stroke-width:0.264583"><tspan
+   style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman, Italic';stroke-width:0.264583"
+   id="tspan1455">Q<tspan
+   style="font-style:normal;font-size:65%;baseline-shift:sub"
+   id="tspan1571">r</tspan></tspan> = number of slots</tspan></text>
+  </g>
+</svg>

--- a/mach_cad/model_obj/cross_sects/inner_rotor_round_slots/CrossSectInnerRotorRoundSlotsBar.svg
+++ b/mach_cad/model_obj/cross_sects/inner_rotor_round_slots/CrossSectInnerRotorRoundSlotsBar.svg
@@ -1,0 +1,1406 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   inkscape:export-ydpi="150"
+   inkscape:export-xdpi="150"
+   inkscape:export-filename="C:\Users\nheme\Documents\Research\Bearingless Motor\Bearinless_Parametrization_Rev1_wht_bckgrnd.png"
+   inkscape:version="1.0.1 (3bc2e813f5, 2020-09-07)"
+   sodipodi:docname="CrossSectInnerRotorRoundSlotsBar.svg"
+   id="svg837"
+   version="1.1"
+   viewBox="0 0 130 145"
+   height="145mm"
+   width="130mm">
+  <defs
+     id="defs831">
+    <marker
+       inkscape:stockid="Arrow1Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker9019"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path9017"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker9009"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mstart">
+      <path
+         transform="matrix(0.4,0,0,0.4,4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path9007" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker6553"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path6551"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker5313"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mend">
+      <path
+         transform="matrix(-0.4,0,0,-0.4,-4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path5311" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker3363"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path3361"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mstart"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker2957"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path2955"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(0.4,0,0,0.4,4,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mstart"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker4727"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path4725"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(0.4,0,0,0.4,4,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mstart"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker4345"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path4343"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(0.4,0,0,0.4,4,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mstart"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker3969"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path3967"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(0.4,0,0,0.4,4,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mstart"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker3599"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path3597"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(0.4,0,0,0.4,4,0)" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker2905"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow2Send">
+      <path
+         transform="matrix(-0.3,0,0,-0.3,0.69,0)"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         id="path2903" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker3124"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow2Send">
+      <path
+         transform="matrix(-0.3,0,0,-0.3,0.69,0)"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         id="path3122" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker1741"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path1739"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#ff0000;fill-opacity:1;fill-rule:evenodd;stroke:#ff0000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker1387"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mend">
+      <path
+         transform="matrix(-0.4,0,0,-0.4,-4,0)"
+         style="fill:#ff0000;fill-opacity:1;fill-rule:evenodd;stroke:#ff0000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path1385" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow2Send"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker4852"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path4850"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         transform="matrix(-0.3,0,0,-0.3,0.69,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow2Send"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker3691"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path3689"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         transform="matrix(-0.3,0,0,-0.3,0.69,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Sstart"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker3429"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path3427"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(0.2,0,0,0.2,1.2,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow2Send"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker2019"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path2017"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         transform="matrix(-0.3,0,0,-0.3,0.69,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow2Sstart"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker1781"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path1779"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         transform="matrix(0.3,0,0,0.3,-0.69,0)" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker1488"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mend">
+      <path
+         transform="matrix(-0.4,0,0,-0.4,-4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path1486" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker1244"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mend">
+      <path
+         inkscape:connector-curvature="0"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path1242" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow2Send"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker16235"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path16233"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         transform="matrix(-0.3,0,0,-0.3,0.69,0)" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:stockid="Arrow2Send"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker15733"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path15731"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         transform="matrix(-0.3,0,0,-0.3,0.69,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker15525"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path15523"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker9500"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mend">
+      <path
+         transform="matrix(-0.4,0,0,-0.4,-4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path9498" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker8403"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mstart">
+      <path
+         transform="matrix(0.4,0,0,0.4,4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path8401" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker8209"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mend">
+      <path
+         transform="matrix(-0.4,0,0,-0.4,-4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path8207" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker8061"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mstart">
+      <path
+         transform="matrix(0.4,0,0,0.4,4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path8059" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker7820"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path7818"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mstart"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker7684"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path7682"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(0.4,0,0,0.4,4,0)" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:stockid="Arrow1Mstart"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker6757"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path6755"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(0.4,0,0,0.4,4,0)" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:stockid="Arrow1Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker6627"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path6625"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker6012"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mstart">
+      <path
+         transform="matrix(0.4,0,0,0.4,4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path6010" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker5894"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mend">
+      <path
+         transform="matrix(-0.4,0,0,-0.4,-4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path5892" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:stockid="Arrow1Mstart"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker5567"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path5565"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(0.4,0,0,0.4,4,0)" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:stockid="Arrow1Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker5461"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path5459"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:stockid="Arrow1Mstart"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker5080"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path5078"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(0.4,0,0,0.4,4,0)" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker4986"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mend">
+      <path
+         transform="matrix(-0.4,0,0,-0.4,-4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path4984" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker4450"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow2Send">
+      <path
+         transform="matrix(-0.3,0,0,-0.3,0.69,0)"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         id="path4448" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker4374"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path4372"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:stockid="Arrow1Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker4128"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path4126"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker3864"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mend">
+      <path
+         transform="matrix(-0.4,0,0,-0.4,-4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path3862" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="Arrow1Mstart"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mstart">
+      <path
+         transform="matrix(0.4,0,0,0.4,4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path1491" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="Arrow1Sstart"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Sstart">
+      <path
+         transform="matrix(0.2,0,0,0.2,1.2,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path1497" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker1939"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow2Send">
+      <path
+         transform="matrix(-0.3,0,0,-0.3,0.69,0)"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         id="path1937" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="Arrow2Sstart"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow2Sstart">
+      <path
+         transform="matrix(0.3,0,0,0.3,-0.69,0)"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         id="path1515" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="Arrow2Send"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow2Send">
+      <path
+         transform="matrix(-0.3,0,0,-0.3,0.69,0)"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         id="path1518" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="Arrow2Mstart"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow2Mstart">
+      <path
+         transform="scale(0.6)"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         id="path1509" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="Arrow1Mend"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mend">
+      <path
+         transform="matrix(-0.4,0,0,-0.4,-4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path1494" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:stockid="Arrow1Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker4128-8"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path4126-2"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow2Send"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker4852-2"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path4850-0"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         transform="matrix(-0.3,0,0,-0.3,0.69,0)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow2Send"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker4852-2-2"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path4850-0-3"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         transform="matrix(-0.3,0,0,-0.3,0.69,0)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       id="DistanceX"
+       orient="auto"
+       refX="0"
+       refY="0"
+       style="overflow:visible">
+      <path
+         d="M 3,-3 -3,3 M 0,-5 V 5"
+         style="stroke:#000000;stroke-width:0.5"
+         id="path1492" />
+    </marker>
+    <pattern
+       id="Hatch"
+       patternUnits="userSpaceOnUse"
+       width="8"
+       height="8"
+       x="0"
+       y="0">
+      <path
+         d="M8 4 l-4,4"
+         stroke="#000000"
+         stroke-width="0.25"
+         linecap="square"
+         id="path1495" />
+      <path
+         d="M6 2 l-4,4"
+         stroke="#000000"
+         stroke-width="0.25"
+         linecap="square"
+         id="path1497-9" />
+      <path
+         d="M4 0 l-4,4"
+         stroke="#000000"
+         stroke-width="0.25"
+         linecap="square"
+         id="path1499" />
+    </pattern>
+  </defs>
+  <sodipodi:namedview
+     height="281mm"
+     inkscape:document-rotation="0"
+     inkscape:snap-to-guides="true"
+     inkscape:snap-global="true"
+     inkscape:snap-bbox="false"
+     inkscape:object-paths="true"
+     inkscape:snap-intersection-paths="true"
+     inkscape:snap-object-midpoints="true"
+     inkscape:snap-others="true"
+     inkscape:snap-smooth-nodes="true"
+     inkscape:snap-midpoints="true"
+     inkscape:snap-center="true"
+     inkscape:window-maximized="1"
+     inkscape:window-y="-8"
+     inkscape:window-x="-8"
+     inkscape:window-height="1017"
+     inkscape:window-width="1920"
+     inkscape:guide-bbox="true"
+     showguides="false"
+     showborder="true"
+     showgrid="false"
+     inkscape:current-layer="layer4"
+     inkscape:document-units="mm"
+     inkscape:cy="301.70028"
+     inkscape:cx="470.37026"
+     inkscape:zoom="1"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     borderopacity="1.0"
+     bordercolor="#666666"
+     pagecolor="#ffffff"
+     id="base" />
+  <metadata
+     id="metadata834">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     style="display:none"
+     inkscape:label="Background"
+     id="layer5"
+     inkscape:groupmode="layer" />
+  <g
+     style="display:none"
+     id="layer1"
+     inkscape:groupmode="layer"
+     inkscape:label="Total_Motor">
+    <path
+       inkscape:connector-curvature="0"
+       id="path1388"
+       transform="scale(0.26458333)"
+       d="M 0,650.07812 A 472.4409,472.4409 0 0 0 -472.44141,1122.5195 472.4409,472.4409 0 0 0 0,1594.9609 472.4409,472.4409 0 0 0 472.44141,1122.5195 472.4409,472.4409 0 0 0 0,650.07812 Z m -62.580078,131.7168 c 2.119773,-0.0633 4.238058,0.0941 6.103516,0.6543 2.541358,0.7632 4.943413,2.47682 6.457031,4.65625 1.450551,2.08861 2.260179,4.14371 2.77539,6.56445 v 96.20703 l -32.126953,32.12696 v 25.01171 A 192.85715,192.85715 0 0 1 0,929.66211 192.85715,192.85715 0 0 1 79.371094,946.94922 V 922.00391 L 47.244141,889.87695 v -96.1914 c 0.515003,-2.42755 1.32369,-4.487 2.777343,-6.58008 1.513618,-2.17943 3.915677,-3.89305 6.457032,-4.65625 1.645518,-0.49416 3.491159,-0.65631 5.357422,-0.64844 A 347.10338,347.10338 0 0 1 262.25586,895.70703 c 1.75673,2.4167 3.37685,5.15152 4.01758,7.86524 0.60972,2.58247 0.32595,5.51939 -0.80469,7.91992 -1.08536,2.30442 -2.46502,4.03425 -4.30859,5.69336 l -83.3086,48.09765 -43.88476,-11.75781 -21.66211,12.50586 a 192.85715,192.85715 0 0 1 54.71484,60.06055 192.85715,192.85715 0 0 1 24.71485,77.3809 L 213.33789,1091 l 11.75781,-43.8867 83.31055,-48.09963 c 2.35704,-0.76605 4.54514,-1.093 7.08203,-0.88086 2.64428,0.2211 5.33009,1.4444 7.26172,3.26369 1.49012,1.4034 2.72559,3.2743 3.76172,5.248 a 347.10338,347.10338 0 0 1 20.5918,115.875 347.10338,347.10338 0 0 1 -20.0625,114.8164 c -1.13505,2.3551 -2.53462,4.6543 -4.28907,6.3067 -1.93162,1.8193 -4.61553,3.0425 -7.25976,3.2636 -2.5387,0.2123 -4.72893,-0.1155 -7.08789,-0.8828 l -83.3086,-48.0976 -11.75781,-43.8848 -21.66211,-12.5058 a 192.85715,192.85715 0 0 1 -24.65625,77.414 192.85715,192.85715 0 0 1 -54.65625,60.0938 l 21.60352,12.4726 43.88476,-11.7597 83.30664,48.0976 c 1.84358,1.6591 3.22324,3.3889 4.3086,5.6934 1.13066,2.4005 1.41246,5.3374 0.80273,7.9199 -0.38563,1.6333 -1.14266,3.2715 -2.05273,4.8496 A 347.10338,347.10338 0 0 1 63.15625,1463.209 c -2.309571,0.1107 -4.639833,-0.01 -6.673828,-0.6192 -2.541351,-0.7632 -4.94539,-2.4748 -6.458984,-4.6543 -1.45523,-2.0953 -2.264404,-4.1588 -2.779297,-6.5898 v -96.1836 l 32.126953,-32.1269 v -25.0118 A 192.85715,192.85715 0 0 1 0,1315.377 192.85715,192.85715 0 0 1 -79.371094,1298.0898 v 24.9454 l 32.126953,32.1269 v 96.1914 c -0.514998,2.4276 -1.323687,4.489 -2.777343,6.582 -1.513614,2.1795 -3.915681,3.8911 -6.457032,4.6543 -1.645521,0.4942 -3.491159,0.6564 -5.357422,0.6485 A 347.10338,347.10338 0 0 1 -262.22656,1349.3672 c -1.76655,-2.4252 -3.39721,-5.1736 -4.04102,-7.9004 -0.60972,-2.5825 -0.32791,-5.5194 0.80274,-7.9199 1.08656,-2.307 2.46775,-4.0385 4.31445,-5.6992 l 83.29883,-48.0918 43.88476,11.7597 21.66211,-12.5058 a 192.85715,192.85715 0 0 1 -54.71484,-60.0606 192.85715,192.85715 0 0 1 -24.71485,-77.3808 l -21.60351,12.4726 -11.75781,43.8848 -83.31055,48.0996 c -2.35704,0.766 -4.54513,1.093 -7.08203,0.8808 -2.64427,-0.2211 -5.33009,-1.4443 -7.26172,-3.2636 -1.49012,-1.4035 -2.72559,-3.2744 -3.76172,-5.2481 a 347.10338,347.10338 0 0 1 -20.5918,-115.875 347.10338,347.10338 0 0 1 20.04688,-114.7754 c 1.13845,-2.3696 2.54575,-4.6855 4.31055,-6.3476 1.93163,-1.81929 4.61551,-3.04259 7.25976,-3.26369 2.53416,-0.21191 4.7201,0.11466 7.07422,0.87891 l 83.31641,48.10158 11.75781,43.8867 21.66211,12.5059 a 192.85715,192.85715 0 0 1 24.65625,-77.4141 192.85715,192.85715 0 0 1 54.65625,-60.09571 l -21.60352,-12.4707 -43.88476,11.75781 -83.30664,-48.09765 c -1.84358,-1.65911 -3.22324,-3.38894 -4.3086,-5.69336 -1.13063,-2.40057 -1.41246,-5.33745 -0.80273,-7.91992 0.3858,-1.63403 1.14211,-3.27284 2.05273,-4.85157 A 347.10338,347.10338 0 0 1 -63.158203,781.83008 c 0.193318,-0.009 0.38466,-0.0294 0.578125,-0.0352 z"
+       style="opacity:1;fill:#008000;fill-opacity:1;stroke:#000000;stroke-width:3.77953;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+    <circle
+       r="43.733097"
+       cy="297"
+       cx="0"
+       id="path1390"
+       style="opacity:1;fill:#ff0000;fill-opacity:1;stroke:#000000;stroke-width:1.09333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+  </g>
+  <g
+     style="display:none"
+     inkscape:label="Motor_Cutaway"
+     id="layer2"
+     inkscape:groupmode="layer" />
+  <g
+     style="display:none"
+     inkscape:label="Annotations_1"
+     id="layer3"
+     inkscape:groupmode="layer">
+    <path
+       inkscape:connector-curvature="0"
+       id="path5884"
+       d="M -7.5563861,234.90369 V 206.70526"
+       style="fill:none;stroke:#000000;stroke-width:0.259632px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-start:url(#marker6012);marker-end:url(#marker5894)" />
+    <rect
+       y="218.84871"
+       x="-8.3674479"
+       height="2.2158854"
+       width="1.5875"
+       id="rect6524"
+       style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.264583;stroke-miterlimit:4;stroke-dasharray:0.79375, 0.264583;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal" />
+    <path
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       id="path1464"
+       d="M -0.02743323,297.01265 35.30925,221.27907"
+       style="fill:none;stroke:#000000;stroke-width:0.202531;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:0.810125, 0.202531;stroke-dashoffset:0;stroke-opacity:1" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.202531;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:0.810125, 0.202531;stroke-dashoffset:0;stroke-opacity:1"
+       d="M 0,297 -35.336683,221.26642"
+       id="path1466"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cc" />
+    <path
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       id="path1470"
+       d="M -21.000268,250.56454 V 221.26642"
+       style="fill:none;stroke:#000000;stroke-width:0.264583;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:0.79375, 0.264583;stroke-dashoffset:0;stroke-opacity:1" />
+    <path
+       sodipodi:nodetypes="csc"
+       inkscape:connector-curvature="0"
+       id="path1482"
+       d="m -11.797594,270.57892 c 3.5813579,-1.66871 7.5752744,-2.60053 11.78682858,-2.60053 4.23356982,0 8.24722062,0.94159 11.84295942,2.62676"
+       style="opacity:1;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.264583;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-start:url(#Arrow2Sstart);marker-end:url(#Arrow2Send);paint-order:normal" />
+    <g
+       transform="translate(-23.187493,-34.196779)"
+       id="g1919">
+      <rect
+         style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.264583;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal"
+         id="rect1907"
+         width="6.160902"
+         height="5.5858846"
+         x="20.12562"
+         y="299.38223" />
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+         x="20.947077"
+         y="304.3931"
+         id="text1895"><tspan
+           sodipodi:role="line"
+           id="tspan1893"
+           x="20.947077"
+           y="304.3931"
+           style="stroke-width:0.264583">θ<tspan
+   style="font-size:3.52778px"
+   id="tspan1897">t</tspan></tspan></text>
+    </g>
+    <flowRoot
+       transform="scale(0.26458333)"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:24px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none"
+       id="flowRoot1899"
+       xml:space="preserve"><flowRegion
+         id="flowRegion1901"><rect
+           y="1122.5197"
+           x="61.473213"
+           height="49.675323"
+           width="50.91721"
+           id="rect1903" /></flowRegion><flowPara
+         id="flowPara1905" /></flowRoot>
+    <path
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       id="path1934"
+       d="m -29.626283,232.40708 c 2.447086,-1.23671 5.213559,-1.9334 8.142751,-1.9334"
+       style="display:inline;opacity:1;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.236671;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-start:url(#Arrow1Sstart);marker-end:url(#marker1939);paint-order:normal" />
+    <rect
+       y="229.11623"
+       x="-27.407322"
+       height="3.6542518"
+       width="3.6240244"
+       id="rect1927"
+       style="display:inline;opacity:1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.13113;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal" />
+    <text
+       id="text1923"
+       y="232.42699"
+       x="-27.561081"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+       xml:space="preserve"><tspan
+         style="stroke-width:0.264583"
+         y="232.42699"
+         x="-27.561081"
+         id="tspan1921"
+         sodipodi:role="line">α</tspan></text>
+    <path
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       id="path3542"
+       d="m 25.501249,208.12668 8.748058,-30.47166"
+       style="fill:none;stroke:#000000;stroke-width:0.251839px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-start:url(#Arrow1Mstart);marker-end:url(#marker3864)" />
+    <text
+       id="text4090"
+       y="162.72395"
+       x="57.811459"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+       xml:space="preserve"><tspan
+         style="stroke-width:0.264583"
+         y="162.72395"
+         x="57.811459"
+         id="tspan4088"
+         sodipodi:role="line" /></text>
+    <path
+       inkscape:connector-curvature="0"
+       id="path3528"
+       d="M -12.500012,236.16224 V 246.8512"
+       style="display:inline;fill:none;stroke:#000000;stroke-width:0.24847px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-start:url(#marker5567);marker-end:url(#marker5461)" />
+    <text
+       id="text4094"
+       y="173.58723"
+       x="-52.318027"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+       xml:space="preserve"><tspan
+         style="stroke-width:0.264583"
+         y="173.58723"
+         x="-52.318027"
+         id="tspan4092"
+         sodipodi:role="line">D<tspan
+   id="tspan4096"
+   style="font-size:3.52778px">os</tspan></tspan></text>
+    <g
+       transform="translate(-16.559098,-7.3212701)"
+       id="g4116">
+      <rect
+         style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:0.237103;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal"
+         id="rect4104"
+         width="6.6424799"
+         height="5.9479485"
+         x="43.113136"
+         y="197.23814" />
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+         x="43.78854"
+         y="202.14687"
+         id="text4100"><tspan
+           sodipodi:role="line"
+           id="tspan4098"
+           x="43.78854"
+           y="202.14687"
+           style="stroke-width:0.264583">T<tspan
+   style="font-size:3.52778px"
+   id="tspan4102">s</tspan></tspan></text>
+    </g>
+    <path
+       sodipodi:nodetypes="ccc"
+       inkscape:connector-curvature="0"
+       id="path4118"
+       d="m -44.334244,171.98437 h 2.000911 l 4.828646,4.82865"
+       style="fill:none;stroke:#000000;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#marker4128)" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path4364"
+       d="m 15.718783,210.03594 -1.547002,-1.79208"
+       style="fill:none;stroke:#000000;stroke-width:0.191617;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:0.383234, 0.191617;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker4450)" />
+    <text
+       id="text4634"
+       y="212.41602"
+       x="15.941146"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+       xml:space="preserve"><tspan
+         style="stroke-width:0.264583"
+         y="212.41602"
+         x="15.941146"
+         id="tspan4632"
+         sodipodi:role="line">r</tspan></text>
+    <path
+       inkscape:connector-curvature="0"
+       id="path4976"
+       d="M -11.547554,219.80781 H 11.547554"
+       style="fill:none;stroke:#000000;stroke-width:0.254303px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-start:url(#marker5080);marker-end:url(#marker4986)" />
+    <g
+       transform="translate(-43.306146,19.473489)"
+       id="g4116-9">
+      <g
+         transform="translate(0,0.18708867)"
+         id="g5421">
+        <rect
+           y="197.24779"
+           x="42.65506"
+           height="5.928659"
+           width="7.7924948"
+           id="rect4104-4"
+           style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:0.256393;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal" />
+        <text
+           id="text4100-8"
+           y="202.70813"
+           x="42.993412"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+           xml:space="preserve"><tspan
+             style="stroke-width:0.264583"
+             y="202.70813"
+             x="42.993412"
+             id="tspan4098-5"
+             sodipodi:role="line">W<tspan
+   style="font-size:3.52778px"
+   id="tspan5415">t</tspan></tspan></text>
+      </g>
+    </g>
+    <path
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       id="path5449"
+       d="m -12.500012,247.56684 h 9.8872516"
+       style="fill:none;stroke:#000000;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+    <path
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       id="path5451"
+       d="m -12.500012,235.4466 h 9.8872516"
+       style="fill:none;stroke:#000000;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+    <path
+       sodipodi:arc-type="arc"
+       style="display:inline;opacity:1;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.265;stroke-miterlimit:4;stroke-dasharray:0.795, 0.265;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal"
+       id="path5875"
+       sodipodi:type="arc"
+       sodipodi:cx="0"
+       sodipodi:cy="296.99997"
+       sodipodi:rx="91.67807"
+       sodipodi:ry="91.67807"
+       sodipodi:start="4.4466291"
+       sodipodi:end="4.5768786"
+       sodipodi:open="true"
+       d="m -24.078562,208.54042 a 91.67807,91.67807 0 0 1 11.693219,-2.37806" />
+    <path
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       id="path5878"
+       d="m -12.500012,213.23104 v -7.0392"
+       style="fill:none;stroke:#000000;stroke-width:0.264583;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:0.79375, 0.264583;stroke-dashoffset:0;stroke-opacity:1" />
+    <path
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       id="path5882"
+       d="m -12.385343,206.16235 h 9.7725826"
+       style="fill:none;stroke:#000000;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+    <g
+       transform="translate(-53.364328,27.478398)"
+       id="g4116-9-8"
+       style="display:inline">
+      <g
+         transform="translate(0,0.18708867)"
+         id="g5421-1">
+        <rect
+           y="197.24779"
+           x="42.65506"
+           height="5.928659"
+           width="7.7924948"
+           id="rect4104-4-4"
+           style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:0.256393;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal" />
+        <text
+           id="text4100-8-5"
+           y="202.17897"
+           x="43.456432"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+           xml:space="preserve"><tspan
+             style="stroke-width:0.264583"
+             y="202.17897"
+             x="43.456432"
+             id="tspan4098-5-6"
+             sodipodi:role="line"><tspan
+               style="font-size:3.52778px"
+               id="tspan5415-7"><tspan
+   id="tspan6615"
+   style="font-size:6.35px">L</tspan>t</tspan></tspan></text>
+      </g>
+    </g>
+    <g
+       transform="translate(-53.364328,40.708055)"
+       id="g4116-9-8-7"
+       style="display:inline">
+      <g
+         transform="translate(0,0.18708867)"
+         id="g5421-1-5">
+        <rect
+           y="197.24779"
+           x="42.65506"
+           height="5.928659"
+           width="7.7924948"
+           id="rect4104-4-4-1"
+           style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:0.256393;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal" />
+        <text
+           id="text4100-8-5-7"
+           y="202.17897"
+           x="43.456432"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+           xml:space="preserve"><tspan
+             style="stroke-width:0.264583"
+             y="202.17897"
+             x="43.456432"
+             id="tspan4098-5-6-6"
+             sodipodi:role="line"><tspan
+               style="font-size:3.52778px"
+               id="tspan5415-7-7"><tspan
+   id="tspan6580-5"
+   style="font-size:6.35px">L</tspan>tt</tspan></tspan></text>
+      </g>
+    </g>
+    <path
+       sodipodi:nodetypes="ccc"
+       inkscape:connector-curvature="0"
+       id="path4118-8"
+       d="m -28.486583,277.7367 h -2.000911 l -4.828646,-4.82865"
+       style="display:inline;fill:none;stroke:#000000;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#marker4128-8)" />
+    <text
+       id="text4094-6"
+       y="279.95316"
+       x="-28.468546"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+       xml:space="preserve"><tspan
+         style="stroke-width:0.264583"
+         y="279.95316"
+         x="-28.468546"
+         id="tspan4092-2"
+         sodipodi:role="line">D<tspan
+   id="tspan4096-9"
+   style="font-size:3.52778px;stroke-width:0.264583">or</tspan></tspan></text>
+    <path
+       inkscape:transform-center-y="-47.336963"
+       inkscape:transform-center-x="-0.53635573"
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       id="path6617"
+       d="m 0.49341607,252.4546 0.0643483,-5.62927"
+       style="display:inline;fill:none;stroke:#000000;stroke-width:0.204665px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-start:url(#marker6757);marker-end:url(#marker6627)" />
+    <text
+       id="text4100-8-5-7-6"
+       y="251.6891"
+       x="1.700698"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+       xml:space="preserve"><tspan
+         style="stroke-width:0.264583"
+         y="251.6891"
+         x="1.700698"
+         id="tspan4098-5-6-6-5"
+         sodipodi:role="line"><tspan
+           style="font-size:3.52778px"
+           id="tspan5415-7-7-3"><tspan
+   id="tspan6580-5-5"
+   style="font-size:6.35px">L</tspan>g</tspan></tspan></text>
+    <path
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       id="path15507"
+       d="m 21.000268,250.54698 h 8.688366"
+       style="fill:none;stroke:#000000;stroke-width:0.23934px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+    <path
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       id="path15509"
+       d="m 21.000268,243.94686 h 8.688366"
+       style="fill:none;stroke:#000000;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+    <text
+       id="text15513"
+       y="248.73111"
+       x="25.765221"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+       xml:space="preserve"><tspan
+         style="stroke-width:0.264583"
+         y="248.73111"
+         x="25.765221"
+         id="tspan15511"
+         sodipodi:role="line">s</tspan></text>
+    <path
+       inkscape:connector-curvature="0"
+       id="path15515"
+       d="m 27.057699,249.05852 v 0.97042"
+       style="fill:none;stroke:#000000;stroke-width:0.276484px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#marker15733)" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path15945"
+       d="m 27.060298,245.50384 v -1.05237"
+       style="fill:none;stroke:#000000;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#marker16235)" />
+  </g>
+  <g
+     style="display:inline"
+     inkscape:label="Annotations_2"
+     id="layer4"
+     inkscape:groupmode="layer">
+    <g
+       transform="translate(125.42796,-33.89125)"
+       id="g4116-9-8-2-5"
+       style="display:inline">
+      <g
+         transform="translate(0,0.18708867)"
+         id="g5421-1-7-0">
+        <text
+           id="text4100-8-5-1-8"
+           y="202.24512"
+           x="42.629608"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+           xml:space="preserve"><tspan
+             style="stroke-width:0.264583"
+             y="0"
+             x="0"
+             id="tspan4098-5-6-1-3"
+             sodipodi:role="line"><tspan
+               style="font-size:3.52778px"
+               id="tspan5415-7-3-8"><tspan
+                 id="tspan6615-5-9"
+                 style="font-size:6.35px" /></tspan></tspan></text>
+      </g>
+    </g>
+    <g
+       id="g4181"
+       transform="translate(103.34541,-36.985927)"
+       style="stroke-width:0.8;stroke-miterlimit:4;stroke-dasharray:none">
+      <text
+         xml:space="preserve"
+         style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.23333px;line-height:1.25;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman, Italic';letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.8;stroke-miterlimit:4;stroke-dasharray:none"
+         x="-61.300587"
+         y="137.48808"
+         id="text2115"><tspan
+           sodipodi:role="line"
+           id="tspan2113"
+           x="-61.300587"
+           y="137.48808"
+           style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman, Italic';stroke-width:0.8;stroke-miterlimit:4;stroke-dasharray:none">x</tspan></text>
+      <text
+         xml:space="preserve"
+         style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:10.5833px;line-height:1.25;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman, Italic';letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.8;stroke-miterlimit:4;stroke-dasharray:none"
+         x="-81.795479"
+         y="117.64843"
+         id="text2145"><tspan
+           sodipodi:role="line"
+           id="tspan2143"
+           x="-81.795479"
+           y="117.64843"
+           style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman, Italic';stroke-width:0.8;stroke-miterlimit:4;stroke-dasharray:none">y</tspan></text>
+      <path
+         inkscape:connector-curvature="0"
+         id="path1377"
+         d="m -76.955365,132.96748 h 17.58635"
+         style="fill:none;stroke:#ff0000;stroke-width:0.8;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#marker1387)" />
+      <path
+         inkscape:transform-center-x="8.793175"
+         style="fill:none;stroke:#ff0000;stroke-width:0.8;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#marker1741)"
+         d="M -76.955365,132.96748 V 115.38113"
+         id="path1737"
+         inkscape:connector-curvature="0" />
+    </g>
+    <path
+       d="M 120.82297,99.667433 H 106.19219"
+       style="display:inline;fill:none;stroke:#b3b3b3;stroke-width:0.7;stroke-miterlimit:4;stroke-dasharray:none"
+       id="path1685" />
+    <path
+       d="m 106.19219,92.369564 h 14.63078"
+       style="display:inline;fill:none;stroke:#b3b3b3;stroke-width:0.7;stroke-miterlimit:4;stroke-dasharray:none"
+       id="path1687" />
+    <path
+       d="m 76.672861,16.081823 -7.31539,12.640402"
+       style="display:inline;fill:none;stroke:#b3b3b3;stroke-width:0.7;stroke-miterlimit:4;stroke-dasharray:none"
+       id="path1689" />
+    <path
+       d="m 63.022101,25.07318 7.31541,-12.640403"
+       style="display:inline;fill:none;stroke:#b3b3b3;stroke-width:0.7;stroke-miterlimit:4;stroke-dasharray:none"
+       id="path1691" />
+    <path
+       d="M 108.20545,143.25877 A 94.706327,94.48029 0 0 0 120.82297,99.667433"
+       style="display:inline;fill:none;stroke:#b3b3b3;stroke-width:0.7;stroke-miterlimit:4;stroke-dasharray:none"
+       id="path1709" />
+    <path
+       d="m 77.395181,96.018633 a 14.630807,14.595888 0 0 0 28.797009,3.6488"
+       style="display:inline;fill:none;stroke:#000000;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none"
+       id="path1711" />
+    <path
+       d="M 106.19219,92.369564 A 14.630807,14.595888 0 0 0 77.395181,96.018633"
+       style="display:inline;fill:none;stroke:#000000;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none"
+       id="path1713" />
+    <path
+       d="M 120.82297,92.369564 A 94.706327,94.48029 0 0 0 108.20545,48.778434"
+       style="display:inline;fill:none;stroke:#b3b3b3;stroke-width:0.7;stroke-miterlimit:4;stroke-dasharray:none"
+       id="path1715" />
+    <path
+       d="M 108.20545,48.778434 A 94.706327,94.48029 0 0 0 76.672861,16.081823"
+       style="display:inline;fill:none;stroke:#b3b3b3;stroke-width:0.7;stroke-miterlimit:4;stroke-dasharray:none"
+       id="path1717" />
+    <path
+       d="M 51.791281,51.777089 A 14.630807,14.595888 0 0 0 69.357471,28.722225"
+       style="display:inline;fill:none;stroke:#b3b3b3;stroke-width:0.7;stroke-miterlimit:4;stroke-dasharray:none"
+       id="path1719" />
+    <path
+       d="M 63.022101,25.07318 A 14.630807,14.595888 0 0 0 51.791281,51.777089"
+       style="display:inline;fill:none;stroke:#b3b3b3;stroke-width:0.7;stroke-miterlimit:4;stroke-dasharray:none"
+       id="path1721" />
+    <path
+       d="M 70.337511,12.432777 A 94.706327,94.48029 0 0 0 26.187361,1.5384119"
+       style="display:inline;fill:none;stroke:#b3b3b3;stroke-width:0.7;stroke-miterlimit:4;stroke-dasharray:none"
+       id="path1723" />
+    <path
+       d="m 48.133591,96.018633 a 21.946225,21.893847 0 0 0 -43.8924467,0"
+       style="display:inline;fill:none;stroke:#b3b3b3;stroke-width:0.7;stroke-miterlimit:4;stroke-dasharray:none"
+       id="path1757" />
+    <path
+       d="m 4.2411443,96.018633 a 21.946225,21.893847 0 0 0 43.8924467,0"
+       style="display:inline;fill:none;stroke:#b3b3b3;stroke-width:0.7;stroke-miterlimit:4;stroke-dasharray:none"
+       id="path1759" />
+    <path
+       d="m 106.65677,96.018633 a 14.630807,14.595888 0 0 0 -0.46452,-3.649069"
+       style="display:inline;fill:none;stroke:#000000;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none"
+       id="path1761" />
+    <path
+       d="m 106.19219,99.667433 a 14.630807,14.595888 0 0 0 0.46451,-3.648799"
+       style="display:inline;fill:none;stroke:#000000;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none"
+       id="path1763" />
+  </g>
+</svg>

--- a/mach_cad/model_obj/cross_sects/inner_rotor_round_slots/CrossSectInnerRotorRoundSlotsPartial.svg
+++ b/mach_cad/model_obj/cross_sects/inner_rotor_round_slots/CrossSectInnerRotorRoundSlotsPartial.svg
@@ -1,0 +1,1454 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   inkscape:export-ydpi="150"
+   inkscape:export-xdpi="150"
+   inkscape:export-filename="C:\Users\nheme\Documents\Research\Bearingless Motor\Bearinless_Parametrization_Rev1_wht_bckgrnd.png"
+   inkscape:version="1.0.1 (3bc2e813f5, 2020-09-07)"
+   sodipodi:docname="CrossSectInnerRotorRoundSlotsPartial.svg"
+   id="svg837"
+   version="1.1"
+   viewBox="0 0 167.93766 95.954292"
+   height="95.954292mm"
+   width="167.93765mm">
+  <defs
+     id="defs831">
+    <marker
+       inkscape:stockid="Arrow1Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker9019"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path9017"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker9009"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mstart">
+      <path
+         transform="matrix(0.4,0,0,0.4,4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path9007" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker6553"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path6551"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker5313"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mend">
+      <path
+         transform="matrix(-0.4,0,0,-0.4,-4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path5311" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker3363"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path3361"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mstart"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker2957"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path2955"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(0.4,0,0,0.4,4,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mstart"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker4727"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path4725"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(0.4,0,0,0.4,4,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mstart"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker4345"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path4343"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(0.4,0,0,0.4,4,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mstart"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker3969"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path3967"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(0.4,0,0,0.4,4,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mstart"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker3599"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path3597"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(0.4,0,0,0.4,4,0)" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker2905"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow2Send">
+      <path
+         transform="matrix(-0.3,0,0,-0.3,0.69,0)"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         id="path2903" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker3124"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow2Send">
+      <path
+         transform="matrix(-0.3,0,0,-0.3,0.69,0)"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         id="path3122" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker1741"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path1739"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#ff0000;fill-opacity:1;fill-rule:evenodd;stroke:#ff0000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow2Send"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker4852"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path4850"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         transform="matrix(-0.3,0,0,-0.3,0.69,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow2Send"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker3691"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path3689"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         transform="matrix(-0.3,0,0,-0.3,0.69,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Sstart"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker3429"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path3427"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(0.2,0,0,0.2,1.2,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow2Send"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker2019"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path2017"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         transform="matrix(-0.3,0,0,-0.3,0.69,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow2Sstart"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker1781"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path1779"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         transform="matrix(0.3,0,0,0.3,-0.69,0)" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker1488"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mend">
+      <path
+         transform="matrix(-0.4,0,0,-0.4,-4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path1486" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker1244"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mend">
+      <path
+         inkscape:connector-curvature="0"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path1242" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow2Send"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker16235"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path16233"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         transform="matrix(-0.3,0,0,-0.3,0.69,0)" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:stockid="Arrow2Send"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker15733"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path15731"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         transform="matrix(-0.3,0,0,-0.3,0.69,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker15525"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path15523"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker9500"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mend">
+      <path
+         transform="matrix(-0.4,0,0,-0.4,-4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path9498" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker8403"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mstart">
+      <path
+         transform="matrix(0.4,0,0,0.4,4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path8401" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker8209"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mend">
+      <path
+         transform="matrix(-0.4,0,0,-0.4,-4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path8207" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker8061"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mstart">
+      <path
+         transform="matrix(0.4,0,0,0.4,4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path8059" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker7820"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path7818"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mstart"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker7684"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path7682"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(0.4,0,0,0.4,4,0)" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:stockid="Arrow1Mstart"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker6757"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path6755"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(0.4,0,0,0.4,4,0)" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:stockid="Arrow1Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker6627"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path6625"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker6012"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mstart">
+      <path
+         transform="matrix(0.4,0,0,0.4,4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path6010" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker5894"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mend">
+      <path
+         transform="matrix(-0.4,0,0,-0.4,-4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path5892" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:stockid="Arrow1Mstart"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker5567"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path5565"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(0.4,0,0,0.4,4,0)" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:stockid="Arrow1Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker5461"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path5459"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:stockid="Arrow1Mstart"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker5080"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path5078"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(0.4,0,0,0.4,4,0)" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker4986"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mend">
+      <path
+         transform="matrix(-0.4,0,0,-0.4,-4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path4984" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker4450"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow2Send">
+      <path
+         transform="matrix(-0.3,0,0,-0.3,0.69,0)"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         id="path4448" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker4374"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path4372"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:stockid="Arrow1Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker4128"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path4126"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker3864"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mend">
+      <path
+         transform="matrix(-0.4,0,0,-0.4,-4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path3862" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="Arrow1Mstart"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mstart">
+      <path
+         transform="matrix(0.4,0,0,0.4,4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path1491" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="Arrow1Sstart"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Sstart">
+      <path
+         transform="matrix(0.2,0,0,0.2,1.2,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path1497" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker1939"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow2Send">
+      <path
+         transform="matrix(-0.3,0,0,-0.3,0.69,0)"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         id="path1937" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="Arrow2Sstart"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow2Sstart">
+      <path
+         transform="matrix(0.3,0,0,0.3,-0.69,0)"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         id="path1515" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="Arrow2Send"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow2Send">
+      <path
+         transform="matrix(-0.3,0,0,-0.3,0.69,0)"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         id="path1518" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="Arrow2Mstart"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow2Mstart">
+      <path
+         transform="scale(0.6)"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         id="path1509" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="Arrow1Mend"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mend">
+      <path
+         transform="matrix(-0.4,0,0,-0.4,-4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path1494" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:stockid="Arrow1Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker4128-8"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path4126-2"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow2Send"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker4852-2"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path4850-0"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         transform="matrix(-0.3,0,0,-0.3,0.69,0)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow2Send"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker4852-2-2"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path4850-0-3"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         transform="matrix(-0.3,0,0,-0.3,0.69,0)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       id="DistanceX"
+       orient="auto"
+       refX="0"
+       refY="0"
+       style="overflow:visible">
+      <path
+         d="M 3,-3 -3,3 M 0,-5 V 5"
+         style="stroke:#000000;stroke-width:0.5"
+         id="path1492" />
+    </marker>
+    <pattern
+       id="Hatch"
+       patternUnits="userSpaceOnUse"
+       width="8"
+       height="8"
+       x="0"
+       y="0">
+      <path
+         d="M8 4 l-4,4"
+         stroke="#000000"
+         stroke-width="0.25"
+         linecap="square"
+         id="path1495" />
+      <path
+         d="M6 2 l-4,4"
+         stroke="#000000"
+         stroke-width="0.25"
+         linecap="square"
+         id="path1497-9" />
+      <path
+         d="M4 0 l-4,4"
+         stroke="#000000"
+         stroke-width="0.25"
+         linecap="square"
+         id="path1499" />
+    </pattern>
+    <marker
+       id="DistanceX-6"
+       orient="auto"
+       refX="0"
+       refY="0"
+       style="overflow:visible">
+      <path
+         d="M 3,-3 -3,3 M 0,-5 V 5"
+         style="stroke:#000000;stroke-width:0.5"
+         id="path1451" />
+    </marker>
+    <pattern
+       id="Hatch-8"
+       patternUnits="userSpaceOnUse"
+       width="8"
+       height="8"
+       x="0"
+       y="0">
+      <path
+         d="M8 4 l-4,4"
+         stroke="#000000"
+         stroke-width="0.25"
+         linecap="square"
+         id="path1454" />
+      <path
+         d="M6 2 l-4,4"
+         stroke="#000000"
+         stroke-width="0.25"
+         linecap="square"
+         id="path1456" />
+      <path
+         d="M4 0 l-4,4"
+         stroke="#000000"
+         stroke-width="0.25"
+         linecap="square"
+         id="path1458" />
+    </pattern>
+    <symbol
+       id="*Model_Space" />
+    <symbol
+       id="*Paper_Space" />
+    <symbol
+       id="*Paper_Space0" />
+    <marker
+       inkscape:collect="always"
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker1387"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mend">
+      <path
+         transform="matrix(-0.4,0,0,-0.4,-4,0)"
+         style="fill:#ff0000;fill-opacity:1;fill-rule:evenodd;stroke:#ff0000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path1385" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker1741-6"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path1739-6"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#ff0000;fill-opacity:1;fill-rule:evenodd;stroke:#ff0000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)" />
+    </marker>
+  </defs>
+  <sodipodi:namedview
+     height="281mm"
+     inkscape:document-rotation="0"
+     inkscape:snap-to-guides="true"
+     inkscape:snap-global="true"
+     inkscape:snap-bbox="false"
+     inkscape:object-paths="true"
+     inkscape:snap-intersection-paths="true"
+     inkscape:snap-object-midpoints="true"
+     inkscape:snap-others="true"
+     inkscape:snap-smooth-nodes="true"
+     inkscape:snap-midpoints="true"
+     inkscape:snap-center="true"
+     inkscape:window-maximized="1"
+     inkscape:window-y="-6"
+     inkscape:window-x="-6"
+     inkscape:window-height="650"
+     inkscape:window-width="1280"
+     inkscape:guide-bbox="true"
+     showguides="false"
+     showborder="true"
+     showgrid="false"
+     inkscape:current-layer="layer4"
+     inkscape:document-units="mm"
+     inkscape:cy="232.66905"
+     inkscape:cx="105.11333"
+     inkscape:zoom="0.50000001"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     borderopacity="1.0"
+     bordercolor="#666666"
+     pagecolor="#ffffff"
+     id="base" />
+  <metadata
+     id="metadata834">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     style="display:none"
+     inkscape:label="Background"
+     id="layer5"
+     inkscape:groupmode="layer"
+     transform="translate(-170.23219,-28.204918)" />
+  <g
+     style="display:none"
+     id="layer1"
+     inkscape:groupmode="layer"
+     inkscape:label="Total_Motor"
+     transform="translate(-170.23219,-28.204918)">
+    <path
+       inkscape:connector-curvature="0"
+       id="path1388"
+       transform="scale(0.26458333)"
+       d="M 0,650.07812 A 472.4409,472.4409 0 0 0 -472.44141,1122.5195 472.4409,472.4409 0 0 0 0,1594.9609 472.4409,472.4409 0 0 0 472.44141,1122.5195 472.4409,472.4409 0 0 0 0,650.07812 Z m -62.580078,131.7168 c 2.119773,-0.0633 4.238058,0.0941 6.103516,0.6543 2.541358,0.7632 4.943413,2.47682 6.457031,4.65625 1.450551,2.08861 2.260179,4.14371 2.77539,6.56445 v 96.20703 l -32.126953,32.12696 v 25.01171 A 192.85715,192.85715 0 0 1 0,929.66211 192.85715,192.85715 0 0 1 79.371094,946.94922 V 922.00391 L 47.244141,889.87695 v -96.1914 c 0.515003,-2.42755 1.32369,-4.487 2.777343,-6.58008 1.513618,-2.17943 3.915677,-3.89305 6.457032,-4.65625 1.645518,-0.49416 3.491159,-0.65631 5.357422,-0.64844 A 347.10338,347.10338 0 0 1 262.25586,895.70703 c 1.75673,2.4167 3.37685,5.15152 4.01758,7.86524 0.60972,2.58247 0.32595,5.51939 -0.80469,7.91992 -1.08536,2.30442 -2.46502,4.03425 -4.30859,5.69336 l -83.3086,48.09765 -43.88476,-11.75781 -21.66211,12.50586 a 192.85715,192.85715 0 0 1 54.71484,60.06055 192.85715,192.85715 0 0 1 24.71485,77.3809 L 213.33789,1091 l 11.75781,-43.8867 83.31055,-48.09963 c 2.35704,-0.76605 4.54514,-1.093 7.08203,-0.88086 2.64428,0.2211 5.33009,1.4444 7.26172,3.26369 1.49012,1.4034 2.72559,3.2743 3.76172,5.248 a 347.10338,347.10338 0 0 1 20.5918,115.875 347.10338,347.10338 0 0 1 -20.0625,114.8164 c -1.13505,2.3551 -2.53462,4.6543 -4.28907,6.3067 -1.93162,1.8193 -4.61553,3.0425 -7.25976,3.2636 -2.5387,0.2123 -4.72893,-0.1155 -7.08789,-0.8828 l -83.3086,-48.0976 -11.75781,-43.8848 -21.66211,-12.5058 a 192.85715,192.85715 0 0 1 -24.65625,77.414 192.85715,192.85715 0 0 1 -54.65625,60.0938 l 21.60352,12.4726 43.88476,-11.7597 83.30664,48.0976 c 1.84358,1.6591 3.22324,3.3889 4.3086,5.6934 1.13066,2.4005 1.41246,5.3374 0.80273,7.9199 -0.38563,1.6333 -1.14266,3.2715 -2.05273,4.8496 A 347.10338,347.10338 0 0 1 63.15625,1463.209 c -2.309571,0.1107 -4.639833,-0.01 -6.673828,-0.6192 -2.541351,-0.7632 -4.94539,-2.4748 -6.458984,-4.6543 -1.45523,-2.0953 -2.264404,-4.1588 -2.779297,-6.5898 v -96.1836 l 32.126953,-32.1269 v -25.0118 A 192.85715,192.85715 0 0 1 0,1315.377 192.85715,192.85715 0 0 1 -79.371094,1298.0898 v 24.9454 l 32.126953,32.1269 v 96.1914 c -0.514998,2.4276 -1.323687,4.489 -2.777343,6.582 -1.513614,2.1795 -3.915681,3.8911 -6.457032,4.6543 -1.645521,0.4942 -3.491159,0.6564 -5.357422,0.6485 A 347.10338,347.10338 0 0 1 -262.22656,1349.3672 c -1.76655,-2.4252 -3.39721,-5.1736 -4.04102,-7.9004 -0.60972,-2.5825 -0.32791,-5.5194 0.80274,-7.9199 1.08656,-2.307 2.46775,-4.0385 4.31445,-5.6992 l 83.29883,-48.0918 43.88476,11.7597 21.66211,-12.5058 a 192.85715,192.85715 0 0 1 -54.71484,-60.0606 192.85715,192.85715 0 0 1 -24.71485,-77.3808 l -21.60351,12.4726 -11.75781,43.8848 -83.31055,48.0996 c -2.35704,0.766 -4.54513,1.093 -7.08203,0.8808 -2.64427,-0.2211 -5.33009,-1.4443 -7.26172,-3.2636 -1.49012,-1.4035 -2.72559,-3.2744 -3.76172,-5.2481 a 347.10338,347.10338 0 0 1 -20.5918,-115.875 347.10338,347.10338 0 0 1 20.04688,-114.7754 c 1.13845,-2.3696 2.54575,-4.6855 4.31055,-6.3476 1.93163,-1.81929 4.61551,-3.04259 7.25976,-3.26369 2.53416,-0.21191 4.7201,0.11466 7.07422,0.87891 l 83.31641,48.10158 11.75781,43.8867 21.66211,12.5059 a 192.85715,192.85715 0 0 1 24.65625,-77.4141 192.85715,192.85715 0 0 1 54.65625,-60.09571 l -21.60352,-12.4707 -43.88476,11.75781 -83.30664,-48.09765 c -1.84358,-1.65911 -3.22324,-3.38894 -4.3086,-5.69336 -1.13063,-2.40057 -1.41246,-5.33745 -0.80273,-7.91992 0.3858,-1.63403 1.14211,-3.27284 2.05273,-4.85157 A 347.10338,347.10338 0 0 1 -63.158203,781.83008 c 0.193318,-0.009 0.38466,-0.0294 0.578125,-0.0352 z"
+       style="opacity:1;fill:#008000;fill-opacity:1;stroke:#000000;stroke-width:3.77953;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+    <circle
+       r="43.733097"
+       cy="297"
+       cx="0"
+       id="path1390"
+       style="opacity:1;fill:#ff0000;fill-opacity:1;stroke:#000000;stroke-width:1.09333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+  </g>
+  <g
+     style="display:none"
+     inkscape:label="Motor_Cutaway"
+     id="layer2"
+     inkscape:groupmode="layer"
+     transform="translate(-170.23219,-28.204918)" />
+  <g
+     style="display:none"
+     inkscape:label="Annotations_1"
+     id="layer3"
+     inkscape:groupmode="layer"
+     transform="translate(-170.23219,-28.204918)">
+    <path
+       inkscape:connector-curvature="0"
+       id="path5884"
+       d="M -7.5563861,234.90369 V 206.70526"
+       style="fill:none;stroke:#000000;stroke-width:0.259632px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-start:url(#marker6012);marker-end:url(#marker5894)" />
+    <rect
+       y="218.84871"
+       x="-8.3674479"
+       height="2.2158854"
+       width="1.5875"
+       id="rect6524"
+       style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.264583;stroke-miterlimit:4;stroke-dasharray:0.79375, 0.264583;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal" />
+    <path
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       id="path1464"
+       d="M -0.02743323,297.01265 35.30925,221.27907"
+       style="fill:none;stroke:#000000;stroke-width:0.202531;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:0.810125, 0.202531;stroke-dashoffset:0;stroke-opacity:1" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.202531;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:0.810125, 0.202531;stroke-dashoffset:0;stroke-opacity:1"
+       d="M 0,297 -35.336683,221.26642"
+       id="path1466"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cc" />
+    <path
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       id="path1470"
+       d="M -21.000268,250.56454 V 221.26642"
+       style="fill:none;stroke:#000000;stroke-width:0.264583;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:0.79375, 0.264583;stroke-dashoffset:0;stroke-opacity:1" />
+    <path
+       sodipodi:nodetypes="csc"
+       inkscape:connector-curvature="0"
+       id="path1482"
+       d="m -11.797594,270.57892 c 3.5813579,-1.66871 7.5752744,-2.60053 11.78682858,-2.60053 4.23356982,0 8.24722062,0.94159 11.84295942,2.62676"
+       style="opacity:1;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.264583;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-start:url(#Arrow2Sstart);marker-end:url(#Arrow2Send);paint-order:normal" />
+    <g
+       transform="translate(-23.187493,-34.196779)"
+       id="g1919">
+      <rect
+         style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.264583;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal"
+         id="rect1907"
+         width="6.160902"
+         height="5.5858846"
+         x="20.12562"
+         y="299.38223" />
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+         x="20.947077"
+         y="304.3931"
+         id="text1895"><tspan
+           sodipodi:role="line"
+           id="tspan1893"
+           x="20.947077"
+           y="304.3931"
+           style="stroke-width:0.264583">θ<tspan
+   style="font-size:3.52778px"
+   id="tspan1897">t</tspan></tspan></text>
+    </g>
+    <flowRoot
+       transform="scale(0.26458333)"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:24px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none"
+       id="flowRoot1899"
+       xml:space="preserve"><flowRegion
+         id="flowRegion1901"><rect
+           y="1122.5197"
+           x="61.473213"
+           height="49.675323"
+           width="50.91721"
+           id="rect1903" /></flowRegion><flowPara
+         id="flowPara1905" /></flowRoot>
+    <path
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       id="path1934"
+       d="m -29.626283,232.40708 c 2.447086,-1.23671 5.213559,-1.9334 8.142751,-1.9334"
+       style="display:inline;opacity:1;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.236671;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-start:url(#Arrow1Sstart);marker-end:url(#marker1939);paint-order:normal" />
+    <rect
+       y="229.11623"
+       x="-27.407322"
+       height="3.6542518"
+       width="3.6240244"
+       id="rect1927"
+       style="display:inline;opacity:1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.13113;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal" />
+    <text
+       id="text1923"
+       y="232.42699"
+       x="-27.561081"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+       xml:space="preserve"><tspan
+         style="stroke-width:0.264583"
+         y="232.42699"
+         x="-27.561081"
+         id="tspan1921"
+         sodipodi:role="line">α</tspan></text>
+    <path
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       id="path3542"
+       d="m 25.501249,208.12668 8.748058,-30.47166"
+       style="fill:none;stroke:#000000;stroke-width:0.251839px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-start:url(#Arrow1Mstart);marker-end:url(#marker3864)" />
+    <text
+       id="text4090"
+       y="162.72395"
+       x="57.811459"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+       xml:space="preserve"><tspan
+         style="stroke-width:0.264583"
+         y="162.72395"
+         x="57.811459"
+         id="tspan4088"
+         sodipodi:role="line" /></text>
+    <path
+       inkscape:connector-curvature="0"
+       id="path3528"
+       d="M -12.500012,236.16224 V 246.8512"
+       style="display:inline;fill:none;stroke:#000000;stroke-width:0.24847px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-start:url(#marker5567);marker-end:url(#marker5461)" />
+    <text
+       id="text4094"
+       y="173.58723"
+       x="-52.318027"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+       xml:space="preserve"><tspan
+         style="stroke-width:0.264583"
+         y="173.58723"
+         x="-52.318027"
+         id="tspan4092"
+         sodipodi:role="line">D<tspan
+   id="tspan4096"
+   style="font-size:3.52778px">os</tspan></tspan></text>
+    <g
+       transform="translate(-16.559098,-7.3212701)"
+       id="g4116">
+      <rect
+         style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:0.237103;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal"
+         id="rect4104"
+         width="6.6424799"
+         height="5.9479485"
+         x="43.113136"
+         y="197.23814" />
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+         x="43.78854"
+         y="202.14687"
+         id="text4100"><tspan
+           sodipodi:role="line"
+           id="tspan4098"
+           x="43.78854"
+           y="202.14687"
+           style="stroke-width:0.264583">T<tspan
+   style="font-size:3.52778px"
+   id="tspan4102">s</tspan></tspan></text>
+    </g>
+    <path
+       sodipodi:nodetypes="ccc"
+       inkscape:connector-curvature="0"
+       id="path4118"
+       d="m -44.334244,171.98437 h 2.000911 l 4.828646,4.82865"
+       style="fill:none;stroke:#000000;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#marker4128)" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path4364"
+       d="m 15.718783,210.03594 -1.547002,-1.79208"
+       style="fill:none;stroke:#000000;stroke-width:0.191617;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:0.383234, 0.191617;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker4450)" />
+    <text
+       id="text4634"
+       y="212.41602"
+       x="15.941146"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+       xml:space="preserve"><tspan
+         style="stroke-width:0.264583"
+         y="212.41602"
+         x="15.941146"
+         id="tspan4632"
+         sodipodi:role="line">r</tspan></text>
+    <path
+       inkscape:connector-curvature="0"
+       id="path4976"
+       d="M -11.547554,219.80781 H 11.547554"
+       style="fill:none;stroke:#000000;stroke-width:0.254303px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-start:url(#marker5080);marker-end:url(#marker4986)" />
+    <g
+       transform="translate(-43.306146,19.473489)"
+       id="g4116-9">
+      <g
+         transform="translate(0,0.18708867)"
+         id="g5421">
+        <rect
+           y="197.24779"
+           x="42.65506"
+           height="5.928659"
+           width="7.7924948"
+           id="rect4104-4"
+           style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:0.256393;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal" />
+        <text
+           id="text4100-8"
+           y="202.70813"
+           x="42.993412"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+           xml:space="preserve"><tspan
+             style="stroke-width:0.264583"
+             y="202.70813"
+             x="42.993412"
+             id="tspan4098-5"
+             sodipodi:role="line">W<tspan
+   style="font-size:3.52778px"
+   id="tspan5415">t</tspan></tspan></text>
+      </g>
+    </g>
+    <path
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       id="path5449"
+       d="m -12.500012,247.56684 h 9.8872516"
+       style="fill:none;stroke:#000000;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+    <path
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       id="path5451"
+       d="m -12.500012,235.4466 h 9.8872516"
+       style="fill:none;stroke:#000000;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+    <path
+       sodipodi:arc-type="arc"
+       style="display:inline;opacity:1;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.265;stroke-miterlimit:4;stroke-dasharray:0.795, 0.265;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal"
+       id="path5875"
+       sodipodi:type="arc"
+       sodipodi:cx="0"
+       sodipodi:cy="296.99997"
+       sodipodi:rx="91.67807"
+       sodipodi:ry="91.67807"
+       sodipodi:start="4.4466291"
+       sodipodi:end="4.5768786"
+       sodipodi:open="true"
+       d="m -24.078562,208.54042 a 91.67807,91.67807 0 0 1 11.693219,-2.37806" />
+    <path
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       id="path5878"
+       d="m -12.500012,213.23104 v -7.0392"
+       style="fill:none;stroke:#000000;stroke-width:0.264583;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:0.79375, 0.264583;stroke-dashoffset:0;stroke-opacity:1" />
+    <path
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       id="path5882"
+       d="m -12.385343,206.16235 h 9.7725826"
+       style="fill:none;stroke:#000000;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+    <g
+       transform="translate(-53.364328,27.478398)"
+       id="g4116-9-8"
+       style="display:inline">
+      <g
+         transform="translate(0,0.18708867)"
+         id="g5421-1">
+        <rect
+           y="197.24779"
+           x="42.65506"
+           height="5.928659"
+           width="7.7924948"
+           id="rect4104-4-4"
+           style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:0.256393;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal" />
+        <text
+           id="text4100-8-5"
+           y="202.17897"
+           x="43.456432"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+           xml:space="preserve"><tspan
+             style="stroke-width:0.264583"
+             y="202.17897"
+             x="43.456432"
+             id="tspan4098-5-6"
+             sodipodi:role="line"><tspan
+               style="font-size:3.52778px"
+               id="tspan5415-7"><tspan
+   id="tspan6615"
+   style="font-size:6.35px">L</tspan>t</tspan></tspan></text>
+      </g>
+    </g>
+    <g
+       transform="translate(-53.364328,40.708055)"
+       id="g4116-9-8-7"
+       style="display:inline">
+      <g
+         transform="translate(0,0.18708867)"
+         id="g5421-1-5">
+        <rect
+           y="197.24779"
+           x="42.65506"
+           height="5.928659"
+           width="7.7924948"
+           id="rect4104-4-4-1"
+           style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:0.256393;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal" />
+        <text
+           id="text4100-8-5-7"
+           y="202.17897"
+           x="43.456432"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+           xml:space="preserve"><tspan
+             style="stroke-width:0.264583"
+             y="202.17897"
+             x="43.456432"
+             id="tspan4098-5-6-6"
+             sodipodi:role="line"><tspan
+               style="font-size:3.52778px"
+               id="tspan5415-7-7"><tspan
+   id="tspan6580-5"
+   style="font-size:6.35px">L</tspan>tt</tspan></tspan></text>
+      </g>
+    </g>
+    <path
+       sodipodi:nodetypes="ccc"
+       inkscape:connector-curvature="0"
+       id="path4118-8"
+       d="m -28.486583,277.7367 h -2.000911 l -4.828646,-4.82865"
+       style="display:inline;fill:none;stroke:#000000;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#marker4128-8)" />
+    <text
+       id="text4094-6"
+       y="279.95316"
+       x="-28.468546"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+       xml:space="preserve"><tspan
+         style="stroke-width:0.264583"
+         y="279.95316"
+         x="-28.468546"
+         id="tspan4092-2"
+         sodipodi:role="line">D<tspan
+   id="tspan4096-9"
+   style="font-size:3.52778px;stroke-width:0.264583">or</tspan></tspan></text>
+    <path
+       inkscape:transform-center-y="-47.336963"
+       inkscape:transform-center-x="-0.53635573"
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       id="path6617"
+       d="m 0.49341607,252.4546 0.0643483,-5.62927"
+       style="display:inline;fill:none;stroke:#000000;stroke-width:0.204665px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-start:url(#marker6757);marker-end:url(#marker6627)" />
+    <text
+       id="text4100-8-5-7-6"
+       y="251.6891"
+       x="1.700698"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+       xml:space="preserve"><tspan
+         style="stroke-width:0.264583"
+         y="251.6891"
+         x="1.700698"
+         id="tspan4098-5-6-6-5"
+         sodipodi:role="line"><tspan
+           style="font-size:3.52778px"
+           id="tspan5415-7-7-3"><tspan
+   id="tspan6580-5-5"
+   style="font-size:6.35px">L</tspan>g</tspan></tspan></text>
+    <path
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       id="path15507"
+       d="m 21.000268,250.54698 h 8.688366"
+       style="fill:none;stroke:#000000;stroke-width:0.23934px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+    <path
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       id="path15509"
+       d="m 21.000268,243.94686 h 8.688366"
+       style="fill:none;stroke:#000000;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+    <text
+       id="text15513"
+       y="248.73111"
+       x="25.765221"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+       xml:space="preserve"><tspan
+         style="stroke-width:0.264583"
+         y="248.73111"
+         x="25.765221"
+         id="tspan15511"
+         sodipodi:role="line">s</tspan></text>
+    <path
+       inkscape:connector-curvature="0"
+       id="path15515"
+       d="m 27.057699,249.05852 v 0.97042"
+       style="fill:none;stroke:#000000;stroke-width:0.276484px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#marker15733)" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path15945"
+       d="m 27.060298,245.50384 v -1.05237"
+       style="fill:none;stroke:#000000;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#marker16235)" />
+  </g>
+  <g
+     style="display:inline"
+     inkscape:label="Annotations_2"
+     id="layer4"
+     inkscape:groupmode="layer"
+     transform="translate(-170.23219,-28.204918)">
+    <g
+       transform="translate(125.42796,-33.89125)"
+       id="g4116-9-8-2-5"
+       style="display:inline">
+      <g
+         transform="translate(0,0.18708867)"
+         id="g5421-1-7-0">
+        <text
+           id="text4100-8-5-1-8"
+           y="202.24512"
+           x="42.629608"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+           xml:space="preserve"><tspan
+             style="stroke-width:0.264583"
+             y="0"
+             x="0"
+             id="tspan4098-5-6-1-3"
+             sodipodi:role="line"><tspan
+               style="font-size:3.52778px"
+               id="tspan5415-7-3-8"><tspan
+                 id="tspan6615-5-9"
+                 style="font-size:6.35px" /></tspan></tspan></text>
+      </g>
+    </g>
+    <g
+       id="g1516"
+       transform="matrix(4.4344327,0,0,4.4344327,153.94148,-4901.556)"
+       style="stroke-width:0.180406;stroke-miterlimit:4;stroke-dasharray:none">
+      <g
+         inkscape:label="0"
+         id="g1466"
+         style="stroke-width:0.180406;stroke-miterlimit:4;stroke-dasharray:none" />
+      <g
+         inkscape:label="RotorCore"
+         id="g1486"
+         style="stroke-width:0.180406;stroke-miterlimit:4;stroke-dasharray:none">
+        <path
+           d="M 41.454787,1123.4646 H 33.895732"
+           style="fill:none;stroke:#000000;stroke-width:0.180406;stroke-miterlimit:4;stroke-dasharray:none"
+           id="path1468" />
+        <path
+           d="m 33.895732,1121.5748 h 7.559055"
+           style="fill:none;stroke:#000000;stroke-width:0.180406;stroke-miterlimit:4;stroke-dasharray:none"
+           id="path1470-2" />
+        <path
+           d="m 40.05265,1133.2518 -29.10042,-7.7975"
+           style="fill:none;stroke:#000000;stroke-width:0.180406;stroke-miterlimit:4;stroke-dasharray:none"
+           id="path1472" />
+        <path
+           d="m 40.05265,1111.7876 -29.10042,7.7974"
+           style="fill:none;stroke:#000000;stroke-width:0.180406;stroke-miterlimit:4;stroke-dasharray:none"
+           id="path1474" />
+        <path
+           d="m 40.05265,1133.2518 a 41.465554,41.465554 0 0 0 1.402137,-9.7872"
+           style="fill:none;stroke:#000000;stroke-width:0.180406;stroke-miterlimit:4;stroke-dasharray:none"
+           id="path1476" />
+        <path
+           d="m 26.456693,1122.5197 a 3.779528,3.779528 0 0 0 7.439039,0.9449"
+           style="fill:none;stroke:#000000;stroke-width:0.180406;stroke-miterlimit:4;stroke-dasharray:none"
+           id="path1478" />
+        <path
+           d="m 33.895732,1121.5748 a 3.779528,3.779528 0 0 0 -7.439039,0.9449"
+           style="fill:none;stroke:#000000;stroke-width:0.180406;stroke-miterlimit:4;stroke-dasharray:none"
+           id="path1480" />
+        <path
+           d="m 41.454787,1121.5748 a 41.465554,41.465554 0 0 0 -1.402137,-9.7872"
+           style="fill:none;stroke:#000000;stroke-width:0.180406;stroke-miterlimit:4;stroke-dasharray:none"
+           id="path1482-6" />
+        <path
+           d="m 10.95223,1125.4543 a 11.338583,11.338583 0 0 0 0,-5.8693"
+           style="fill:none;stroke:#000000;stroke-width:0.180406;stroke-miterlimit:4;stroke-dasharray:none"
+           id="path1484" />
+      </g>
+    </g>
+    <text
+       xml:space="preserve"
+       style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:5.81731px;line-height:1.25;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman, Italic';letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264582"
+       x="197.66267"
+       y="82.313828"
+       id="text2115"><tspan
+         sodipodi:role="line"
+         id="tspan2113"
+         x="197.66267"
+         y="82.313828"
+         style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:8.72599px;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman, Italic';stroke-width:0.264582">x</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:14.5432px;line-height:1.25;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman, Italic';letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264582"
+       x="170.93095"
+       y="48.678284"
+       id="text2145"><tspan
+         sodipodi:role="line"
+         id="tspan2143"
+         x="170.93095"
+         y="48.678284"
+         style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:8.72599px;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman, Italic';stroke-width:0.264582">y</tspan></text>
+    <g
+       style="display:inline;stroke:#ff0000;stroke-width:0.727712"
+       id="g2173"
+       transform="matrix(0,1.3741689,-1.3741689,0,582.80173,76.273698)">
+      <path
+         inkscape:connector-curvature="0"
+         id="path1377"
+         d="M 0,297 V 279.41365"
+         style="fill:none;stroke:#ff0000;stroke-width:0.363856;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#marker1387)" />
+      <path
+         inkscape:transform-center-x="8.793175"
+         style="fill:none;stroke:#ff0000;stroke-width:0.363856;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#marker1741-6)"
+         d="M 0,297 H -17.58635"
+         id="path1737"
+         inkscape:connector-curvature="0" />
+    </g>
+  </g>
+</svg>

--- a/mach_cad/model_obj/cross_sects/inner_rotor_round_slots/__init__.py
+++ b/mach_cad/model_obj/cross_sects/inner_rotor_round_slots/__init__.py
@@ -1,0 +1,402 @@
+import numpy as np
+
+from ...dimensions import DimRadian
+from ...dimensions import DimMillimeter
+from ...dimensions.dim_linear import DimLinear
+
+from ..cross_sect_base import CrossSectBase, CrossSectToken
+
+__all__ = ['CrossSectInnerRotorRoundSlots', 'CrossSectInnerRotorRoundSlotsPartial', 'CrossSectInnerRotorRoundSlotsBar']
+
+
+class CrossSectInnerRotorRoundSlots(CrossSectBase):
+
+    def __init__(self, **kwargs: any) -> None:
+        '''
+        Intialization function for CrossSectInnerRotorRoundSlots class. This function takes in
+        arguments and saves the information passed to private variable to make
+        them read-only
+        Parameters
+        ----------
+        **kwargs : any
+            DESCRIPTION. Keyword arguments provided to the initialization funcntion.
+            The following argument names have to be included in order for the code
+            to execute:  name, dim_l, dim_t, dim_theta, location.
+            
+        Returns
+        -------
+        None
+        '''
+        self._create_attr(kwargs)
+
+        super()._validate_attr()
+        self._validate_attr()
+
+    @property
+    def dim_r_ri(self):
+        return self._dim_r_ri
+
+    @property
+    def dim_d_ri(self):
+        return self._dim_d_ri
+
+    @property
+    def dim_r_rb(self):
+        return self._dim_r_rb
+
+    @property
+    def dim_d_so(self):
+        return self._dim_d_so
+
+    @property
+    def dim_w_so(self):
+        return self._dim_w_so
+
+    @property
+    def Qr(self):
+        return self._Qr
+
+    def draw(self, drawer):
+
+        r_ri = self.dim_r_ri
+        d_ri = self.dim_d_ri
+        r_rb = self.dim_r_rb
+        d_so = self.dim_d_so
+        w_so = self.dim_w_so
+        Qr = self.Qr
+
+        alpha_u = DimRadian(2 * np.pi / Qr)
+        r1 = r_ri + d_ri + r_rb + DimMillimeter(np.sqrt(r_rb ** 2 - (w_so / 2) ** 2)) + d_so
+        r2 = w_so / 2
+        r_ro = DimMillimeter(np.sqrt(r1 ** 2 + r2 ** 2))
+
+        x1 = r_ro * np.cos(alpha_u / 2)
+        y1 = - r_ro * np.sin(alpha_u / 2)
+
+        x2 = DimMillimeter(np.sqrt(r_ro ** 2 - (w_so / 2) ** 2))
+        y2 = - w_so / 2
+
+        x3 = x2 - d_so
+        y3 = y2
+
+        x4 = r_ri + d_ri
+        y4 = DimMillimeter(0)
+
+        x5 = x3
+        y5 = - y3
+
+        x6 = x2
+        y6 = - y2
+
+        x7 = x1
+        y7 = - y1
+
+        center_rotor_bar = [(x4 + r_rb), DimMillimeter(0)]
+
+        x_arr = [x1, x2, x3, x4, x5, x6, x7, center_rotor_bar[0]]
+        y_arr = [y1, y2, y3, y4, y5, y6, y7, center_rotor_bar[1]]
+
+        arc1 = []
+        arc2 = []
+        arc3 = []
+        arc4 = []
+        arc5 = []
+        arc6 = []
+        seg1 = []
+        seg2 = []
+
+        # transpose list
+        coords = [x_arr, y_arr]
+        coords = list(zip(*coords))
+        coords = [list(sublist) for sublist in coords]
+
+        for i in range(0, Qr):
+            p = self.location.transform_coords(coords, alpha_u * i)
+
+            arc1.append(drawer.draw_arc(self.location.anchor_xy, p[0], p[1]))
+            seg1.append(drawer.draw_line(p[1], p[2]))
+            arc2.append(drawer.draw_arc(p[7], p[3], p[2]))
+            arc3.append(drawer.draw_arc(p[7], p[4], p[3]))
+            seg2.append(drawer.draw_line(p[4], p[5]))
+            arc4.append(drawer.draw_arc(self.location.anchor_xy, p[5], p[6]))
+
+        arc5.append(drawer.draw_arc(self.location.anchor_xy,
+            [r_ri, DimMillimeter(0)], [- r_ri, DimMillimeter(0)]))
+        arc6.append(drawer.draw_arc(self.location.anchor_xy,
+            [- r_ri, DimMillimeter(0)], [r_ri, DimMillimeter(0)]))
+
+        rad = (r_ri + x4) / 2
+        inner_coord = self.location.transform_coords([[rad, 0]])
+        segments = [arc1, seg1, arc2, arc3, seg2, arc4, arc5, arc6]
+        segs = [x for segment in segments for x in segment]
+        cs_token = CrossSectToken(inner_coord[0], segs)
+        return cs_token
+
+    def _validate_attr(self):
+
+        if isinstance(self._dim_r_ri, DimLinear):
+            pass
+        else:
+            raise TypeError("dim_r_ri not of type DimLinear")
+
+        if isinstance(self._dim_d_ri, DimLinear):
+            pass
+        else:
+            raise TypeError("dim_d_ri not of type DimLinear")
+
+        if isinstance(self._dim_r_rb, DimLinear):
+            pass
+        else:
+            raise TypeError("dim_r_rb not of type DimLinear")
+
+        if isinstance(self._dim_d_so, DimLinear):
+            pass
+        else:
+            raise TypeError("dim_d_so not of type DimLinear")
+
+        if isinstance(self._dim_w_so, DimLinear):
+            pass
+        else:
+            raise TypeError("dim_w_so not of type DimLinear")
+
+        if isinstance(self._Qr, int):
+            pass
+        else:
+            raise TypeError("Qr not of type int")
+
+class CrossSectInnerRotorRoundSlotsPartial(CrossSectBase):
+
+    def __init__(self, **kwargs: any) -> None:
+        '''
+        Intialization function for CrossSectInnerRotorRoundSlotsPartial class. This function takes in
+        arguments and saves the information passed to private variable to make
+        them read-only
+        Parameters
+        ----------
+        **kwargs : any
+            DESCRIPTION. Keyword arguments provided to the initialization funcntion.
+            The following argument names have to be included in order for the code
+            to execute:  name, dim_l, dim_t, dim_theta, location.
+            
+        Returns
+        -------
+        None
+        '''
+        self._create_attr(kwargs)
+
+        super()._validate_attr()
+        self._validate_attr()
+
+    @property
+    def dim_r_ri(self):
+        return self._dim_r_ri
+
+    @property
+    def dim_d_ri(self):
+        return self._dim_d_ri
+
+    @property
+    def dim_r_rb(self):
+        return self._dim_r_rb
+
+    @property
+    def dim_d_so(self):
+        return self._dim_d_so
+
+    @property
+    def dim_w_so(self):
+        return self._dim_w_so
+
+    @property
+    def Qr(self):
+        return self._Qr
+
+    def draw(self, drawer):
+
+        r_ri = self.dim_r_ri
+        d_ri = self.dim_d_ri
+        r_rb = self.dim_r_rb
+        d_so = self.dim_d_so
+        w_so = self.dim_w_so
+        Qr = self.Qr
+
+        alpha_u = DimRadian(2 * np.pi / Qr)
+        r1 = r_ri + d_ri + r_rb + DimMillimeter(np.sqrt(r_rb ** 2 - (w_so / 2) ** 2)) + d_so
+        r2 = w_so / 2
+        r_ro = DimMillimeter(np.sqrt(r1 ** 2 + r2 ** 2))
+
+        x1 = r_ro * np.cos(alpha_u / 2)
+        y1 = - r_ro * np.sin(alpha_u / 2)
+
+        x2 = DimMillimeter(np.sqrt(r_ro ** 2 - (w_so / 2) ** 2))
+        y2 = - w_so / 2
+
+        x3 = x2 - d_so
+        y3 = y2
+
+        x4 = r_ri + d_ri
+        y4 = DimMillimeter(0)
+
+        x5 = x3
+        y5 = - y3
+
+        x6 = x2
+        y6 = - y2
+
+        x7 = x1
+        y7 = - y1
+
+        center_rotor_bar = [(x4 + r_rb), DimMillimeter(0)]
+
+        x_arr = [x1, x2, x3, x4, x5, x6, x7, center_rotor_bar[0]]
+        y_arr = [y1, y2, y3, y4, y5, y6, y7, center_rotor_bar[1]]
+
+        arc1 = []
+        arc2 = []
+        arc3 = []
+        arc4 = []
+        arc5 = []
+        seg1 = []
+        seg2 = []
+        seg3 = []
+        seg4 = []
+
+        # transpose list
+        coords = [x_arr, y_arr]
+        coords = list(zip(*coords))
+        coords = [list(sublist) for sublist in coords]
+
+        for i in range(0, 1):
+            p = self.location.transform_coords(coords, alpha_u * i)
+
+            arc1.append(drawer.draw_arc(self.location.anchor_xy, p[0], p[1]))
+            seg1.append(drawer.draw_line(p[1], p[2]))
+            arc2.append(drawer.draw_arc(p[7], p[3], p[2]))
+            arc3.append(drawer.draw_arc(p[7], p[4], p[3]))
+            seg2.append(drawer.draw_line(p[4], p[5]))
+            arc4.append(drawer.draw_arc(self.location.anchor_xy, p[5], p[6]))
+
+        x8 = r_ri * np.cos(alpha_u / 2)
+        y8 = - r_ri * np.sin(alpha_u / 2)
+        x9 = x8
+        y9 = - y8
+        arc5.append(drawer.draw_arc(self.location.anchor_xy,
+            [x8, y8], [x9, y9]))
+        seg3.append(drawer.draw_line(p[0], [x8, y8]))
+        seg4.append(drawer.draw_line(p[6], [x9, y9]))
+
+        rad = (r_ri + x4) / 2
+        inner_coord = self.location.transform_coords([[rad, 0]])
+        segments = [arc1, seg1, arc2, arc3, seg2, arc4, arc5, seg3, seg4]
+        segs = [x for segment in segments for x in segment]
+        cs_token = CrossSectToken(inner_coord[0], segs)
+        return cs_token
+
+    def _validate_attr(self):
+
+        if isinstance(self._dim_r_ri, DimLinear):
+            pass
+        else:
+            raise TypeError("dim_r_ri not of type DimLinear")
+
+        if isinstance(self._dim_d_ri, DimLinear):
+            pass
+        else:
+            raise TypeError("dim_d_ri not of type DimLinear")
+
+        if isinstance(self._dim_r_rb, DimLinear):
+            pass
+        else:
+            raise TypeError("dim_r_rb not of type DimLinear")
+
+        if isinstance(self._dim_d_so, DimLinear):
+            pass
+        else:
+            raise TypeError("dim_d_so not of type DimLinear")
+
+        if isinstance(self._dim_w_so, DimLinear):
+            pass
+        else:
+            raise TypeError("dim_w_so not of type DimLinear")
+
+        if isinstance(self._Qr, int):
+            pass
+        else:
+            raise TypeError("Qr not of type int")
+
+class CrossSectInnerRotorRoundSlotsBar(CrossSectBase):
+
+    def __init__(self, **kwargs: any) -> None:
+        '''
+        Intialization function for RoundBar class. This function takes in
+        arguments and saves the information passed to private variable to make
+        them read-only
+        Parameters
+        ----------
+        **kwargs : any
+            DESCRIPTION. Keyword arguments provided to the initialization funcntion.
+            The following argument names have to be included in order for the code
+            to execute: name, dim_t, dim_r_o, location. 
+            
+        Returns
+        -------
+        None
+        '''
+        self._create_attr(kwargs)
+
+        super()._validate_attr()
+        self._validate_attr()
+
+    @property
+    def rotor_core(self):
+        return self._rotor_core
+
+    def draw(self, drawer):
+
+        r_ri = self.rotor_core.dim_r_ri
+        d_ri = self.rotor_core.dim_d_ri
+        r_rb = self.rotor_core.dim_r_rb
+        d_so = self.rotor_core.dim_d_so
+        w_so = self.rotor_core.dim_w_so
+        Qr = self.rotor_core.Qr
+
+        alpha_u = DimRadian(2 * np.pi / Qr)
+        r_b = r_ri + d_ri + r_rb
+
+        x1 = r_b + r_rb
+        y1 = DimMillimeter(0)
+
+        x2 = r_b - r_rb
+        y2 = DimMillimeter(0)
+
+        center_rotor_bar = [r_b, DimMillimeter(0)]
+
+        x_arr = [x1, x2, center_rotor_bar[0]]
+        y_arr = [y1, y2, center_rotor_bar[1]]
+
+        arc1 = []
+        arc2 = []
+
+        # transpose list
+        coords = [x_arr, y_arr]
+        coords = list(zip(*coords))
+        coords = [list(sublist) for sublist in coords]
+
+        p = self.location.transform_coords(coords, 0)
+
+        arc1.append(drawer.draw_arc(p[2], p[0], p[1]))
+        arc1.append(drawer.draw_arc(p[2], p[1], p[0]))
+
+        inner_coord = self.location.transform_coords([center_rotor_bar])
+        segments = [arc1, arc2]
+        segs = [x for segment in segments for x in segment]
+        cs_token = CrossSectToken(inner_coord[0], segs)
+
+        return cs_token
+
+    def _validate_attr(self):
+
+        if (isinstance(self.rotor_core, CrossSectInnerRotorRoundSlots)) or (isinstance(self.rotor_core, CrossSectInnerRotorRoundSlotsPartial)):
+            pass
+        else:
+            raise TypeError("rotor_core not of type CrossSectInnerRotorRoundSlots")

--- a/mach_cad/model_obj/cross_sects/inner_rotor_round_slots_double_cage/CrossSectInnerRotorRoundSlotsDoubleCage.svg
+++ b/mach_cad/model_obj/cross_sects/inner_rotor_round_slots_double_cage/CrossSectInnerRotorRoundSlotsDoubleCage.svg
@@ -1,0 +1,1780 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   inkscape:export-ydpi="150"
+   inkscape:export-xdpi="150"
+   inkscape:export-filename="C:\Users\nheme\Documents\Research\Bearingless Motor\Bearinless_Parametrization_Rev1_wht_bckgrnd.png"
+   inkscape:version="1.0.1 (3bc2e813f5, 2020-09-07)"
+   sodipodi:docname="CrossSectInnerRotorRoundSlotsDoubleCage.svg"
+   id="svg837"
+   version="1.1"
+   viewBox="0 0 183.0022 143.62968"
+   height="143.62968mm"
+   width="183.0022mm">
+  <defs
+     id="defs831">
+    <marker
+       inkscape:stockid="Arrow1Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker4217"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path4215"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker4207"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mstart">
+      <path
+         transform="matrix(0.4,0,0,0.4,4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path4205" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker3483"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path3481"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker3473"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mstart">
+      <path
+         transform="matrix(0.4,0,0,0.4,4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path3471" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker2589"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path2587"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#ff0000;fill-opacity:1;fill-rule:evenodd;stroke:#ff0000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker2579"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mend">
+      <path
+         transform="matrix(-0.4,0,0,-0.4,-4,0)"
+         style="fill:#ff0000;fill-opacity:1;fill-rule:evenodd;stroke:#ff0000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path2577" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker2569"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path2567"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker2559"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mstart">
+      <path
+         transform="matrix(0.4,0,0,0.4,4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path2557" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker9019"
+       style="overflow:visible"
+       inkscape:isstock="true"
+       inkscape:collect="always">
+      <path
+         id="path9017"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker9009"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mstart"
+       inkscape:collect="always">
+      <path
+         transform="matrix(0.4,0,0,0.4,4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path9007" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker7163"
+       style="overflow:visible"
+       inkscape:isstock="true"
+       inkscape:collect="always">
+      <path
+         id="path7161"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker7153"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mstart"
+       inkscape:collect="always">
+      <path
+         transform="matrix(0.4,0,0,0.4,4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path7151" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker6553"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path6551"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker5969"
+       style="overflow:visible"
+       inkscape:isstock="true"
+       inkscape:collect="always">
+      <path
+         id="path5967"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker5313"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mend">
+      <path
+         transform="matrix(-0.4,0,0,-0.4,-4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path5311" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker4395"
+       style="overflow:visible"
+       inkscape:isstock="true"
+       inkscape:collect="always">
+      <path
+         id="path4393"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker4385"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mend"
+       inkscape:collect="always">
+      <path
+         transform="matrix(-0.4,0,0,-0.4,-4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path4383" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker3363"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path3361"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mstart"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker2957"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path2955"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(0.4,0,0,0.4,4,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mstart"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker4727"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path4725"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(0.4,0,0,0.4,4,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mstart"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker4345"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path4343"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(0.4,0,0,0.4,4,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mstart"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker3969"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path3967"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(0.4,0,0,0.4,4,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mstart"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker3599"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path3597"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(0.4,0,0,0.4,4,0)" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker2905"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow2Send">
+      <path
+         transform="matrix(-0.3,0,0,-0.3,0.69,0)"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         id="path2903" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker3124"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow2Send">
+      <path
+         transform="matrix(-0.3,0,0,-0.3,0.69,0)"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         id="path3122" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow2Send"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker4852"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path4850"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         transform="matrix(-0.3,0,0,-0.3,0.69,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow2Send"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker3691"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path3689"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         transform="matrix(-0.3,0,0,-0.3,0.69,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Sstart"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker3429"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path3427"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(0.2,0,0,0.2,1.2,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow2Send"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker2019"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path2017"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         transform="matrix(-0.3,0,0,-0.3,0.69,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow2Sstart"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker1781"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path1779"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         transform="matrix(0.3,0,0,0.3,-0.69,0)" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker1488"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mend">
+      <path
+         transform="matrix(-0.4,0,0,-0.4,-4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path1486" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker1244"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mend">
+      <path
+         inkscape:connector-curvature="0"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path1242" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow2Send"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker16235"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path16233"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         transform="matrix(-0.3,0,0,-0.3,0.69,0)" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:stockid="Arrow2Send"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker15733"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path15731"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         transform="matrix(-0.3,0,0,-0.3,0.69,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker15525"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path15523"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker9500"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mend">
+      <path
+         transform="matrix(-0.4,0,0,-0.4,-4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path9498" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker8403"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mstart">
+      <path
+         transform="matrix(0.4,0,0,0.4,4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path8401" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker8209"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mend">
+      <path
+         transform="matrix(-0.4,0,0,-0.4,-4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path8207" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker8061"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mstart">
+      <path
+         transform="matrix(0.4,0,0,0.4,4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path8059" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker7820"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path7818"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mstart"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker7684"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path7682"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(0.4,0,0,0.4,4,0)" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:stockid="Arrow1Mstart"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker6757"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path6755"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(0.4,0,0,0.4,4,0)" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:stockid="Arrow1Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker6627"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path6625"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker6012"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mstart">
+      <path
+         transform="matrix(0.4,0,0,0.4,4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path6010" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker5894"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mend">
+      <path
+         transform="matrix(-0.4,0,0,-0.4,-4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path5892" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:stockid="Arrow1Mstart"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker5567"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path5565"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(0.4,0,0,0.4,4,0)" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:stockid="Arrow1Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker5461"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path5459"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:stockid="Arrow1Mstart"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker5080"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path5078"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(0.4,0,0,0.4,4,0)" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker4986"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mend">
+      <path
+         transform="matrix(-0.4,0,0,-0.4,-4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path4984" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker4450"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow2Send">
+      <path
+         transform="matrix(-0.3,0,0,-0.3,0.69,0)"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         id="path4448" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker4374"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path4372"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:stockid="Arrow1Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker4128"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path4126"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker3864"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mend">
+      <path
+         transform="matrix(-0.4,0,0,-0.4,-4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path3862" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="Arrow1Mstart"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mstart">
+      <path
+         transform="matrix(0.4,0,0,0.4,4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path1491" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="Arrow1Sstart"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Sstart">
+      <path
+         transform="matrix(0.2,0,0,0.2,1.2,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path1497" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker1939"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow2Send">
+      <path
+         transform="matrix(-0.3,0,0,-0.3,0.69,0)"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         id="path1937" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="Arrow2Sstart"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow2Sstart">
+      <path
+         transform="matrix(0.3,0,0,0.3,-0.69,0)"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         id="path1515" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="Arrow2Send"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow2Send">
+      <path
+         transform="matrix(-0.3,0,0,-0.3,0.69,0)"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         id="path1518" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="Arrow2Mstart"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow2Mstart">
+      <path
+         transform="scale(0.6)"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         id="path1509" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="Arrow1Mend"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mend">
+      <path
+         transform="matrix(-0.4,0,0,-0.4,-4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path1494" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:stockid="Arrow1Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker4128-8"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path4126-2"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow2Send"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker4852-2"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path4850-0"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         transform="matrix(-0.3,0,0,-0.3,0.69,0)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow2Send"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker4852-2-2"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path4850-0-3"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         transform="matrix(-0.3,0,0,-0.3,0.69,0)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       id="DistanceX"
+       orient="auto"
+       refX="0"
+       refY="0"
+       style="overflow:visible">
+      <path
+         d="M 3,-3 -3,3 M 0,-5 V 5"
+         style="stroke:#000000;stroke-width:0.5"
+         id="path1492" />
+    </marker>
+    <pattern
+       id="Hatch"
+       patternUnits="userSpaceOnUse"
+       width="8"
+       height="8"
+       x="0"
+       y="0">
+      <path
+         d="M8 4 l-4,4"
+         stroke="#000000"
+         stroke-width="0.25"
+         linecap="square"
+         id="path1495" />
+      <path
+         d="M6 2 l-4,4"
+         stroke="#000000"
+         stroke-width="0.25"
+         linecap="square"
+         id="path1497-9" />
+      <path
+         d="M4 0 l-4,4"
+         stroke="#000000"
+         stroke-width="0.25"
+         linecap="square"
+         id="path1499" />
+    </pattern>
+    <marker
+       id="DistanceX-7"
+       orient="auto"
+       refX="0"
+       refY="0"
+       style="overflow:visible">
+      <path
+         d="M 3,-3 -3,3 M 0,-5 V 5"
+         style="stroke:#000000;stroke-width:0.5"
+         id="path1451" />
+    </marker>
+    <pattern
+       id="Hatch-3"
+       patternUnits="userSpaceOnUse"
+       width="8"
+       height="8"
+       x="0"
+       y="0">
+      <path
+         d="M8 4 l-4,4"
+         stroke="#000000"
+         stroke-width="0.25"
+         linecap="square"
+         id="path1454" />
+      <path
+         d="M6 2 l-4,4"
+         stroke="#000000"
+         stroke-width="0.25"
+         linecap="square"
+         id="path1456" />
+      <path
+         d="M4 0 l-4,4"
+         stroke="#000000"
+         stroke-width="0.25"
+         linecap="square"
+         id="path1458" />
+    </pattern>
+  </defs>
+  <sodipodi:namedview
+     height="281mm"
+     inkscape:document-rotation="0"
+     inkscape:snap-to-guides="true"
+     inkscape:snap-global="true"
+     inkscape:snap-bbox="false"
+     inkscape:object-paths="true"
+     inkscape:snap-intersection-paths="true"
+     inkscape:snap-object-midpoints="true"
+     inkscape:snap-others="true"
+     inkscape:snap-smooth-nodes="true"
+     inkscape:snap-midpoints="true"
+     inkscape:snap-center="true"
+     inkscape:window-maximized="1"
+     inkscape:window-y="-6"
+     inkscape:window-x="-6"
+     inkscape:window-height="650"
+     inkscape:window-width="1280"
+     inkscape:guide-bbox="true"
+     showguides="false"
+     showborder="true"
+     showgrid="false"
+     inkscape:current-layer="layer4"
+     inkscape:document-units="mm"
+     inkscape:cy="281.12341"
+     inkscape:cx="335.38734"
+     inkscape:zoom="0.7071068"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     borderopacity="1.0"
+     bordercolor="#666666"
+     pagecolor="#ffffff"
+     id="base" />
+  <metadata
+     id="metadata834">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     style="display:none"
+     inkscape:label="Background"
+     id="layer5"
+     inkscape:groupmode="layer"
+     transform="translate(-2.0174882,-1.0355714)" />
+  <g
+     style="display:none"
+     id="layer1"
+     inkscape:groupmode="layer"
+     inkscape:label="Total_Motor"
+     transform="translate(-2.0174882,-1.0355714)">
+    <path
+       inkscape:connector-curvature="0"
+       id="path1388"
+       transform="scale(0.26458333)"
+       d="M 0,650.07812 A 472.4409,472.4409 0 0 0 -472.44141,1122.5195 472.4409,472.4409 0 0 0 0,1594.9609 472.4409,472.4409 0 0 0 472.44141,1122.5195 472.4409,472.4409 0 0 0 0,650.07812 Z m -62.580078,131.7168 c 2.119773,-0.0633 4.238058,0.0941 6.103516,0.6543 2.541358,0.7632 4.943413,2.47682 6.457031,4.65625 1.450551,2.08861 2.260179,4.14371 2.77539,6.56445 v 96.20703 l -32.126953,32.12696 v 25.01171 A 192.85715,192.85715 0 0 1 0,929.66211 192.85715,192.85715 0 0 1 79.371094,946.94922 V 922.00391 L 47.244141,889.87695 v -96.1914 c 0.515003,-2.42755 1.32369,-4.487 2.777343,-6.58008 1.513618,-2.17943 3.915677,-3.89305 6.457032,-4.65625 1.645518,-0.49416 3.491159,-0.65631 5.357422,-0.64844 A 347.10338,347.10338 0 0 1 262.25586,895.70703 c 1.75673,2.4167 3.37685,5.15152 4.01758,7.86524 0.60972,2.58247 0.32595,5.51939 -0.80469,7.91992 -1.08536,2.30442 -2.46502,4.03425 -4.30859,5.69336 l -83.3086,48.09765 -43.88476,-11.75781 -21.66211,12.50586 a 192.85715,192.85715 0 0 1 54.71484,60.06055 192.85715,192.85715 0 0 1 24.71485,77.3809 L 213.33789,1091 l 11.75781,-43.8867 83.31055,-48.09963 c 2.35704,-0.76605 4.54514,-1.093 7.08203,-0.88086 2.64428,0.2211 5.33009,1.4444 7.26172,3.26369 1.49012,1.4034 2.72559,3.2743 3.76172,5.248 a 347.10338,347.10338 0 0 1 20.5918,115.875 347.10338,347.10338 0 0 1 -20.0625,114.8164 c -1.13505,2.3551 -2.53462,4.6543 -4.28907,6.3067 -1.93162,1.8193 -4.61553,3.0425 -7.25976,3.2636 -2.5387,0.2123 -4.72893,-0.1155 -7.08789,-0.8828 l -83.3086,-48.0976 -11.75781,-43.8848 -21.66211,-12.5058 a 192.85715,192.85715 0 0 1 -24.65625,77.414 192.85715,192.85715 0 0 1 -54.65625,60.0938 l 21.60352,12.4726 43.88476,-11.7597 83.30664,48.0976 c 1.84358,1.6591 3.22324,3.3889 4.3086,5.6934 1.13066,2.4005 1.41246,5.3374 0.80273,7.9199 -0.38563,1.6333 -1.14266,3.2715 -2.05273,4.8496 A 347.10338,347.10338 0 0 1 63.15625,1463.209 c -2.309571,0.1107 -4.639833,-0.01 -6.673828,-0.6192 -2.541351,-0.7632 -4.94539,-2.4748 -6.458984,-4.6543 -1.45523,-2.0953 -2.264404,-4.1588 -2.779297,-6.5898 v -96.1836 l 32.126953,-32.1269 v -25.0118 A 192.85715,192.85715 0 0 1 0,1315.377 192.85715,192.85715 0 0 1 -79.371094,1298.0898 v 24.9454 l 32.126953,32.1269 v 96.1914 c -0.514998,2.4276 -1.323687,4.489 -2.777343,6.582 -1.513614,2.1795 -3.915681,3.8911 -6.457032,4.6543 -1.645521,0.4942 -3.491159,0.6564 -5.357422,0.6485 A 347.10338,347.10338 0 0 1 -262.22656,1349.3672 c -1.76655,-2.4252 -3.39721,-5.1736 -4.04102,-7.9004 -0.60972,-2.5825 -0.32791,-5.5194 0.80274,-7.9199 1.08656,-2.307 2.46775,-4.0385 4.31445,-5.6992 l 83.29883,-48.0918 43.88476,11.7597 21.66211,-12.5058 a 192.85715,192.85715 0 0 1 -54.71484,-60.0606 192.85715,192.85715 0 0 1 -24.71485,-77.3808 l -21.60351,12.4726 -11.75781,43.8848 -83.31055,48.0996 c -2.35704,0.766 -4.54513,1.093 -7.08203,0.8808 -2.64427,-0.2211 -5.33009,-1.4443 -7.26172,-3.2636 -1.49012,-1.4035 -2.72559,-3.2744 -3.76172,-5.2481 a 347.10338,347.10338 0 0 1 -20.5918,-115.875 347.10338,347.10338 0 0 1 20.04688,-114.7754 c 1.13845,-2.3696 2.54575,-4.6855 4.31055,-6.3476 1.93163,-1.81929 4.61551,-3.04259 7.25976,-3.26369 2.53416,-0.21191 4.7201,0.11466 7.07422,0.87891 l 83.31641,48.10158 11.75781,43.8867 21.66211,12.5059 a 192.85715,192.85715 0 0 1 24.65625,-77.4141 192.85715,192.85715 0 0 1 54.65625,-60.09571 l -21.60352,-12.4707 -43.88476,11.75781 -83.30664,-48.09765 c -1.84358,-1.65911 -3.22324,-3.38894 -4.3086,-5.69336 -1.13063,-2.40057 -1.41246,-5.33745 -0.80273,-7.91992 0.3858,-1.63403 1.14211,-3.27284 2.05273,-4.85157 A 347.10338,347.10338 0 0 1 -63.158203,781.83008 c 0.193318,-0.009 0.38466,-0.0294 0.578125,-0.0352 z"
+       style="opacity:1;fill:#008000;fill-opacity:1;stroke:#000000;stroke-width:3.77953;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+    <circle
+       r="43.733097"
+       cy="297"
+       cx="0"
+       id="path1390"
+       style="opacity:1;fill:#ff0000;fill-opacity:1;stroke:#000000;stroke-width:1.09333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+  </g>
+  <g
+     style="display:none"
+     inkscape:label="Motor_Cutaway"
+     id="layer2"
+     inkscape:groupmode="layer"
+     transform="translate(-2.0174882,-1.0355714)" />
+  <g
+     style="display:none"
+     inkscape:label="Annotations_1"
+     id="layer3"
+     inkscape:groupmode="layer"
+     transform="translate(-2.0174882,-1.0355714)">
+    <path
+       inkscape:connector-curvature="0"
+       id="path5884"
+       d="M -7.5563861,234.90369 V 206.70526"
+       style="fill:none;stroke:#000000;stroke-width:0.259632px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-start:url(#marker6012);marker-end:url(#marker5894)" />
+    <rect
+       y="218.84871"
+       x="-8.3674479"
+       height="2.2158854"
+       width="1.5875"
+       id="rect6524"
+       style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.264583;stroke-miterlimit:4;stroke-dasharray:0.79375, 0.264583;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal" />
+    <path
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       id="path1464"
+       d="M -0.02743323,297.01265 35.30925,221.27907"
+       style="fill:none;stroke:#000000;stroke-width:0.202531;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:0.810125, 0.202531;stroke-dashoffset:0;stroke-opacity:1" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.202531;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:0.810125, 0.202531;stroke-dashoffset:0;stroke-opacity:1"
+       d="M 0,297 -35.336683,221.26642"
+       id="path1466"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cc" />
+    <path
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       id="path1470"
+       d="M -21.000268,250.56454 V 221.26642"
+       style="fill:none;stroke:#000000;stroke-width:0.264583;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:0.79375, 0.264583;stroke-dashoffset:0;stroke-opacity:1" />
+    <path
+       sodipodi:nodetypes="csc"
+       inkscape:connector-curvature="0"
+       id="path1482"
+       d="m -11.797594,270.57892 c 3.5813579,-1.66871 7.5752744,-2.60053 11.78682858,-2.60053 4.23356982,0 8.24722062,0.94159 11.84295942,2.62676"
+       style="opacity:1;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.264583;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-start:url(#Arrow2Sstart);marker-end:url(#Arrow2Send);paint-order:normal" />
+    <g
+       transform="translate(-23.187493,-34.196779)"
+       id="g1919">
+      <rect
+         style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.264583;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal"
+         id="rect1907"
+         width="6.160902"
+         height="5.5858846"
+         x="20.12562"
+         y="299.38223" />
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+         x="20.947077"
+         y="304.3931"
+         id="text1895"><tspan
+           sodipodi:role="line"
+           id="tspan1893"
+           x="20.947077"
+           y="304.3931"
+           style="stroke-width:0.264583">θ<tspan
+   style="font-size:3.52778px"
+   id="tspan1897">t</tspan></tspan></text>
+    </g>
+    <flowRoot
+       transform="scale(0.26458333)"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:24px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none"
+       id="flowRoot1899"
+       xml:space="preserve"><flowRegion
+         id="flowRegion1901"><rect
+           y="1122.5197"
+           x="61.473213"
+           height="49.675323"
+           width="50.91721"
+           id="rect1903" /></flowRegion><flowPara
+         id="flowPara1905" /></flowRoot>
+    <path
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       id="path1934"
+       d="m -29.626283,232.40708 c 2.447086,-1.23671 5.213559,-1.9334 8.142751,-1.9334"
+       style="display:inline;opacity:1;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.236671;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-start:url(#Arrow1Sstart);marker-end:url(#marker1939);paint-order:normal" />
+    <rect
+       y="229.11623"
+       x="-27.407322"
+       height="3.6542518"
+       width="3.6240244"
+       id="rect1927"
+       style="display:inline;opacity:1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.13113;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal" />
+    <text
+       id="text1923"
+       y="232.42699"
+       x="-27.561081"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+       xml:space="preserve"><tspan
+         style="stroke-width:0.264583"
+         y="232.42699"
+         x="-27.561081"
+         id="tspan1921"
+         sodipodi:role="line">α</tspan></text>
+    <path
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       id="path3542"
+       d="m 25.501249,208.12668 8.748058,-30.47166"
+       style="fill:none;stroke:#000000;stroke-width:0.251839px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-start:url(#Arrow1Mstart);marker-end:url(#marker3864)" />
+    <text
+       id="text4090"
+       y="162.72395"
+       x="57.811459"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+       xml:space="preserve"><tspan
+         style="stroke-width:0.264583"
+         y="162.72395"
+         x="57.811459"
+         id="tspan4088"
+         sodipodi:role="line" /></text>
+    <path
+       inkscape:connector-curvature="0"
+       id="path3528"
+       d="M -12.500012,236.16224 V 246.8512"
+       style="display:inline;fill:none;stroke:#000000;stroke-width:0.24847px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-start:url(#marker5567);marker-end:url(#marker5461)" />
+    <text
+       id="text4094"
+       y="173.58723"
+       x="-52.318027"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+       xml:space="preserve"><tspan
+         style="stroke-width:0.264583"
+         y="173.58723"
+         x="-52.318027"
+         id="tspan4092"
+         sodipodi:role="line">D<tspan
+   id="tspan4096"
+   style="font-size:3.52778px">os</tspan></tspan></text>
+    <g
+       transform="translate(-16.559098,-7.3212701)"
+       id="g4116">
+      <rect
+         style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:0.237103;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal"
+         id="rect4104"
+         width="6.6424799"
+         height="5.9479485"
+         x="43.113136"
+         y="197.23814" />
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+         x="43.78854"
+         y="202.14687"
+         id="text4100"><tspan
+           sodipodi:role="line"
+           id="tspan4098"
+           x="43.78854"
+           y="202.14687"
+           style="stroke-width:0.264583">T<tspan
+   style="font-size:3.52778px"
+   id="tspan4102">s</tspan></tspan></text>
+    </g>
+    <path
+       sodipodi:nodetypes="ccc"
+       inkscape:connector-curvature="0"
+       id="path4118"
+       d="m -44.334244,171.98437 h 2.000911 l 4.828646,4.82865"
+       style="fill:none;stroke:#000000;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#marker4128)" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path4364"
+       d="m 15.718783,210.03594 -1.547002,-1.79208"
+       style="fill:none;stroke:#000000;stroke-width:0.191617;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:0.383234, 0.191617;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker4450)" />
+    <text
+       id="text4634"
+       y="212.41602"
+       x="15.941146"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+       xml:space="preserve"><tspan
+         style="stroke-width:0.264583"
+         y="212.41602"
+         x="15.941146"
+         id="tspan4632"
+         sodipodi:role="line">r</tspan></text>
+    <path
+       inkscape:connector-curvature="0"
+       id="path4976"
+       d="M -11.547554,219.80781 H 11.547554"
+       style="fill:none;stroke:#000000;stroke-width:0.254303px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-start:url(#marker5080);marker-end:url(#marker4986)" />
+    <g
+       transform="translate(-43.306146,19.473489)"
+       id="g4116-9">
+      <g
+         transform="translate(0,0.18708867)"
+         id="g5421">
+        <rect
+           y="197.24779"
+           x="42.65506"
+           height="5.928659"
+           width="7.7924948"
+           id="rect4104-4"
+           style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:0.256393;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal" />
+        <text
+           id="text4100-8"
+           y="202.70813"
+           x="42.993412"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+           xml:space="preserve"><tspan
+             style="stroke-width:0.264583"
+             y="202.70813"
+             x="42.993412"
+             id="tspan4098-5"
+             sodipodi:role="line">W<tspan
+   style="font-size:3.52778px"
+   id="tspan5415">t</tspan></tspan></text>
+      </g>
+    </g>
+    <path
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       id="path5449"
+       d="m -12.500012,247.56684 h 9.8872516"
+       style="fill:none;stroke:#000000;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+    <path
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       id="path5451"
+       d="m -12.500012,235.4466 h 9.8872516"
+       style="fill:none;stroke:#000000;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+    <path
+       sodipodi:arc-type="arc"
+       style="display:inline;opacity:1;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.265;stroke-miterlimit:4;stroke-dasharray:0.795, 0.265;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal"
+       id="path5875"
+       sodipodi:type="arc"
+       sodipodi:cx="0"
+       sodipodi:cy="296.99997"
+       sodipodi:rx="91.67807"
+       sodipodi:ry="91.67807"
+       sodipodi:start="4.4466291"
+       sodipodi:end="4.5768786"
+       sodipodi:open="true"
+       d="m -24.078562,208.54042 a 91.67807,91.67807 0 0 1 11.693219,-2.37806" />
+    <path
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       id="path5878"
+       d="m -12.500012,213.23104 v -7.0392"
+       style="fill:none;stroke:#000000;stroke-width:0.264583;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:0.79375, 0.264583;stroke-dashoffset:0;stroke-opacity:1" />
+    <path
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       id="path5882"
+       d="m -12.385343,206.16235 h 9.7725826"
+       style="fill:none;stroke:#000000;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+    <g
+       transform="translate(-53.364328,27.478398)"
+       id="g4116-9-8"
+       style="display:inline">
+      <g
+         transform="translate(0,0.18708867)"
+         id="g5421-1">
+        <rect
+           y="197.24779"
+           x="42.65506"
+           height="5.928659"
+           width="7.7924948"
+           id="rect4104-4-4"
+           style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:0.256393;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal" />
+        <text
+           id="text4100-8-5"
+           y="202.17897"
+           x="43.456432"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+           xml:space="preserve"><tspan
+             style="stroke-width:0.264583"
+             y="202.17897"
+             x="43.456432"
+             id="tspan4098-5-6"
+             sodipodi:role="line"><tspan
+               style="font-size:3.52778px"
+               id="tspan5415-7"><tspan
+   id="tspan6615"
+   style="font-size:6.35px">L</tspan>t</tspan></tspan></text>
+      </g>
+    </g>
+    <g
+       transform="translate(-53.364328,40.708055)"
+       id="g4116-9-8-7"
+       style="display:inline">
+      <g
+         transform="translate(0,0.18708867)"
+         id="g5421-1-5">
+        <rect
+           y="197.24779"
+           x="42.65506"
+           height="5.928659"
+           width="7.7924948"
+           id="rect4104-4-4-1"
+           style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:0.256393;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal" />
+        <text
+           id="text4100-8-5-7"
+           y="202.17897"
+           x="43.456432"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+           xml:space="preserve"><tspan
+             style="stroke-width:0.264583"
+             y="202.17897"
+             x="43.456432"
+             id="tspan4098-5-6-6"
+             sodipodi:role="line"><tspan
+               style="font-size:3.52778px"
+               id="tspan5415-7-7"><tspan
+   id="tspan6580-5"
+   style="font-size:6.35px">L</tspan>tt</tspan></tspan></text>
+      </g>
+    </g>
+    <path
+       sodipodi:nodetypes="ccc"
+       inkscape:connector-curvature="0"
+       id="path4118-8"
+       d="m -28.486583,277.7367 h -2.000911 l -4.828646,-4.82865"
+       style="display:inline;fill:none;stroke:#000000;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#marker4128-8)" />
+    <text
+       id="text4094-6"
+       y="279.95316"
+       x="-28.468546"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+       xml:space="preserve"><tspan
+         style="stroke-width:0.264583"
+         y="279.95316"
+         x="-28.468546"
+         id="tspan4092-2"
+         sodipodi:role="line">D<tspan
+   id="tspan4096-9"
+   style="font-size:3.52778px;stroke-width:0.264583">or</tspan></tspan></text>
+    <path
+       inkscape:transform-center-y="-47.336963"
+       inkscape:transform-center-x="-0.53635573"
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       id="path6617"
+       d="m 0.49341607,252.4546 0.0643483,-5.62927"
+       style="display:inline;fill:none;stroke:#000000;stroke-width:0.204665px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-start:url(#marker6757);marker-end:url(#marker6627)" />
+    <text
+       id="text4100-8-5-7-6"
+       y="251.6891"
+       x="1.700698"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+       xml:space="preserve"><tspan
+         style="stroke-width:0.264583"
+         y="251.6891"
+         x="1.700698"
+         id="tspan4098-5-6-6-5"
+         sodipodi:role="line"><tspan
+           style="font-size:3.52778px"
+           id="tspan5415-7-7-3"><tspan
+   id="tspan6580-5-5"
+   style="font-size:6.35px">L</tspan>g</tspan></tspan></text>
+    <path
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       id="path15507"
+       d="m 21.000268,250.54698 h 8.688366"
+       style="fill:none;stroke:#000000;stroke-width:0.23934px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+    <path
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       id="path15509"
+       d="m 21.000268,243.94686 h 8.688366"
+       style="fill:none;stroke:#000000;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+    <text
+       id="text15513"
+       y="248.73111"
+       x="25.765221"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+       xml:space="preserve"><tspan
+         style="stroke-width:0.264583"
+         y="248.73111"
+         x="25.765221"
+         id="tspan15511"
+         sodipodi:role="line">s</tspan></text>
+    <path
+       inkscape:connector-curvature="0"
+       id="path15515"
+       d="m 27.057699,249.05852 v 0.97042"
+       style="fill:none;stroke:#000000;stroke-width:0.276484px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#marker15733)" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path15945"
+       d="m 27.060298,245.50384 v -1.05237"
+       style="fill:none;stroke:#000000;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#marker16235)" />
+  </g>
+  <g
+     style="display:inline"
+     inkscape:label="Annotations_2"
+     id="layer4"
+     inkscape:groupmode="layer"
+     transform="translate(-2.0174882,-1.0355714)">
+    <g
+       transform="translate(125.42796,-33.89125)"
+       id="g4116-9-8-2-5"
+       style="display:inline">
+      <g
+         transform="translate(0,0.18708867)"
+         id="g5421-1-7-0">
+        <text
+           id="text4100-8-5-1-8"
+           y="202.24512"
+           x="42.629608"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+           xml:space="preserve"><tspan
+             style="stroke-width:0.264583"
+             y="0"
+             x="0"
+             id="tspan4098-5-6-1-3"
+             sodipodi:role="line"><tspan
+               style="font-size:3.52778px"
+               id="tspan5415-7-3-8"><tspan
+                 id="tspan6615-5-9"
+                 style="font-size:6.35px" /></tspan></tspan></text>
+      </g>
+    </g>
+    <path
+       style="fill:#000000;stroke:#000000;stroke-width:0.4;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#marker4395)"
+       d="m 127.82007,83.795797 v 6.28444"
+       id="path4379"
+       inkscape:connector-curvature="0" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path4381"
+       d="M 127.82007,101.42665 V 95.761863"
+       style="fill:#000000;stroke:#000000;stroke-width:0.4;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#marker4385)" />
+    <text
+       xml:space="preserve"
+       style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;line-height:1.25;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman, Italic';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#999999;fill-opacity:1;stroke:none;stroke-width:0.264583"
+       x="118.35709"
+       y="100.43185"
+       id="text4959"><tspan
+         sodipodi:role="line"
+         id="tspan4957"
+         x="118.35709"
+         y="100.43185"
+         style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman,  Italic';fill:#000000;stroke-width:0.264583">w<tspan
+   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:65%;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman, ';baseline-shift:sub;fill:#000000"
+   id="tspan4955">so</tspan></tspan></text>
+    <path
+       style="fill:#000000;stroke:#000000;stroke-width:0.4;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#marker5969)"
+       d="m 111.99018,92.449211 4.30862,-0.115558"
+       id="path5965"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 116.919,93.424367 6.7e-4,-2.82503"
+       style="fill:none;stroke:#000000;stroke-width:0.2;stroke-miterlimit:4;stroke-dasharray:none"
+       id="path6533" />
+    <path
+       d="m 132.0177,93.494527 6.7e-4,-2.82503"
+       style="fill:none;stroke:#000000;stroke-width:0.2;stroke-miterlimit:4;stroke-dasharray:none"
+       id="path6541" />
+    <path
+       style="fill:#000000;stroke:#000000;stroke-width:0.4;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#marker6553)"
+       d="m 136.42734,92.443516 -3.88388,-0.104168"
+       id="path6549"
+       inkscape:connector-curvature="0" />
+    <text
+       xml:space="preserve"
+       style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;line-height:1.25;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman, Italic';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#999999;fill-opacity:1;stroke:none;stroke-width:0.264583"
+       x="133.55348"
+       y="90.170494"
+       id="text7129"><tspan
+         sodipodi:role="line"
+         id="tspan7127"
+         x="133.55348"
+         y="90.170494"
+         style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman,  Italic';fill:#000000;stroke-width:0.264583">d<tspan
+   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:65%;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman, ';baseline-shift:sub;fill:#000000"
+   id="tspan7125">so</tspan></tspan></text>
+    <path
+       id="path7149"
+       d="m 82.238,87.63741 4.1193,5.445744"
+       style="fill:none;stroke:#000000;stroke-width:0.4;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-start:url(#marker7153);marker-end:url(#marker7163)" />
+    <text
+       xml:space="preserve"
+       style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;line-height:1.25;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman, Italic';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#999999;fill-opacity:1;stroke:none;stroke-width:0.264583"
+       x="85.075691"
+       y="89.716331"
+       id="text8173"><tspan
+         sodipodi:role="line"
+         id="tspan8171"
+         x="85.075691"
+         y="89.716331"
+         style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman,  Italic';fill:#000000;stroke-width:0.264583">r<tspan
+   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:65%;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman, ';baseline-shift:sub;fill:#000000"
+   id="tspan8169">rb</tspan></tspan></text>
+    <path
+       id="path9005"
+       d="m 77.60073,92.788008 -28.29645,0.0065"
+       style="fill:none;stroke:#000000;stroke-width:0.4;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-start:url(#marker9009);marker-end:url(#marker9019)" />
+    <text
+       xml:space="preserve"
+       style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;line-height:1.25;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman, Italic';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#999999;fill-opacity:1;stroke:none;stroke-width:0.264583"
+       x="61.121838"
+       y="90.555687"
+       id="text9973"><tspan
+         sodipodi:role="line"
+         id="tspan9971"
+         x="61.121838"
+         y="90.555687"
+         style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman,  Italic';fill:#000000;stroke-width:0.264583">d<tspan
+   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:65%;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman, ';baseline-shift:sub;fill:#000000"
+   id="tspan9969">ri</tspan></tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-size:6.35px;line-height:0.95;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math';display:inline;stroke-width:0.264583"
+       x="131.43135"
+       y="140.2914"
+       id="text1453"><tspan
+         sodipodi:role="line"
+         id="tspan1451"
+         x="131.43135"
+         y="140.2914"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman, ';stroke-width:0.264583"><tspan
+   style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman, Italic';stroke-width:0.264583"
+   id="tspan1455">Q<tspan
+   style="font-style:normal;font-size:65%;baseline-shift:sub"
+   id="tspan1571">r</tspan></tspan> = number of slots</tspan></text>
+    <path
+       d="M 132.02246,94.703528 H 116.74631"
+       style="fill:none;stroke:#000000;stroke-width:0.800002;stroke-miterlimit:4;stroke-dasharray:none"
+       id="path1463" />
+    <path
+       d="m 116.74631,90.885498 h 15.27615"
+       style="fill:none;stroke:#000000;stroke-width:0.800002;stroke-miterlimit:4;stroke-dasharray:none"
+       id="path1465" />
+    <path
+       d="m 118.6834,41.117561 -13.22954,7.635858"
+       style="fill:none;stroke:#000000;stroke-width:0.800002;stroke-miterlimit:4;stroke-dasharray:none"
+       id="path1467" />
+    <path
+       d="M 103.54434,45.446937 116.77388,37.81108"
+       style="fill:none;stroke:#000000;stroke-width:0.800002;stroke-miterlimit:4;stroke-dasharray:none"
+       id="path1469" />
+    <path
+       d="m 128.40357,120.4046 a 106.7076,106.6774 0 0 0 3.61889,-25.701072"
+       style="fill:none;stroke:#000000;stroke-width:0.800002;stroke-miterlimit:4;stroke-dasharray:none"
+       id="path1511" />
+    <path
+       d="m 101.71269,92.794508 a 7.6380764,7.6359145 0 0 0 15.03362,1.90902"
+       style="fill:none;stroke:#000000;stroke-width:0.800002;stroke-miterlimit:4;stroke-dasharray:none"
+       id="path1513" />
+    <path
+       d="m 116.74631,90.885498 a 7.6380764,7.6359145 0 0 0 -15.03362,1.90901"
+       style="fill:none;stroke:#000000;stroke-width:0.800002;stroke-miterlimit:4;stroke-dasharray:none"
+       id="path1515-7" />
+    <path
+       d="M 132.02246,90.885498 A 106.7076,106.6774 0 0 0 128.40357,65.184403"
+       style="fill:none;stroke:#000000;stroke-width:0.800002;stroke-miterlimit:4;stroke-dasharray:none"
+       id="path1517" />
+    <path
+       d="m 78.79833,92.794508 a 7.638115,7.6359531 0 0 0 15.27623,0"
+       style="fill:none;stroke:#000000;stroke-width:0.800002;stroke-miterlimit:4;stroke-dasharray:none"
+       id="path1519" />
+    <path
+       d="m 94.07456,92.794508 a 7.638115,7.6359531 0 0 0 -15.27623,0"
+       style="fill:none;stroke:#000000;stroke-width:0.800002;stroke-miterlimit:4;stroke-dasharray:none"
+       id="path1521" />
+    <path
+       d="M 128.40357,65.184403 A 106.7076,106.6774 0 0 0 118.6834,41.117561"
+       style="fill:none;stroke:#000000;stroke-width:0.800002;stroke-miterlimit:4;stroke-dasharray:none"
+       id="path1523" />
+    <path
+       d="m 91.47954,54.614816 a 7.6380764,7.6359145 0 0 0 13.97432,-5.861397"
+       style="fill:none;stroke:#000000;stroke-width:0.800002;stroke-miterlimit:4;stroke-dasharray:none"
+       id="path1525" />
+    <path
+       d="m 103.54434,45.446937 a 7.6380764,7.6359145 0 0 0 -12.0648,9.167879"
+       style="fill:none;stroke:#000000;stroke-width:0.800002;stroke-miterlimit:4;stroke-dasharray:none"
+       id="path1527" />
+    <path
+       d="M 116.77388,37.81108 A 106.7076,106.6774 0 0 0 100.78559,17.362255"
+       style="fill:none;stroke:#000000;stroke-width:0.800002;stroke-miterlimit:4;stroke-dasharray:none"
+       id="path1529" />
+    <path
+       d="M 71.63513,66.068704 A 7.6380941,7.6359322 0 0 0 84.86474,58.432846"
+       style="fill:none;stroke:#000000;stroke-width:0.800002;stroke-miterlimit:4;stroke-dasharray:none"
+       id="path1531" />
+    <path
+       d="M 84.86474,58.432846 A 7.6380941,7.6359322 0 0 0 71.63513,66.068704"
+       style="fill:none;stroke:#000000;stroke-width:0.800002;stroke-miterlimit:4;stroke-dasharray:none"
+       id="path1533" />
+    <path
+       d="M 100.78559,17.362255 A 106.7076,106.6774 0 0 0 80.33076,1.3783736"
+       style="fill:none;stroke:#000000;stroke-width:0.800002;stroke-miterlimit:4;stroke-dasharray:none"
+       id="path1535" />
+    <path
+       d="m 118.6834,144.47144 a 106.7076,106.6774 0 0 0 9.72017,-24.06684"
+       style="fill:none;stroke:#000000;stroke-width:0.800002;stroke-miterlimit:4;stroke-dasharray:none"
+       id="path1649" />
+    <path
+       d="m 48.24594,92.794508 a 22.914228,22.907742 0 0 0 -45.8284509,0"
+       style="fill:none;stroke:#000000;stroke-width:0.800002;stroke-miterlimit:4;stroke-dasharray:none"
+       id="path1655" />
+    <path
+       d="m 2.4174891,92.794508 a 22.914228,22.907742 0 0 0 45.8284509,0"
+       style="fill:none;stroke:#000000;stroke-width:0.800002;stroke-miterlimit:4;stroke-dasharray:none"
+       id="path1657" />
+    <g
+       id="g2547"
+       transform="translate(102.75987,-40.366636)"
+       style="stroke-width:0.8;stroke-miterlimit:4;stroke-dasharray:none">
+      <text
+         xml:space="preserve"
+         style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.23333px;line-height:1.25;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman, Italic';letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.8;stroke-miterlimit:4;stroke-dasharray:none"
+         x="-61.300587"
+         y="137.48808"
+         id="text2537"><tspan
+           sodipodi:role="line"
+           id="tspan2535"
+           x="-61.300587"
+           y="137.48808"
+           style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman, Italic';stroke-width:0.8;stroke-miterlimit:4;stroke-dasharray:none">x</tspan></text>
+      <text
+         xml:space="preserve"
+         style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:10.5833px;line-height:1.25;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman, Italic';letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.8;stroke-miterlimit:4;stroke-dasharray:none"
+         x="-81.795479"
+         y="117.64843"
+         id="text2541"><tspan
+           sodipodi:role="line"
+           id="tspan2539"
+           x="-81.795479"
+           y="117.64843"
+           style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman, Italic';stroke-width:0.8;stroke-miterlimit:4;stroke-dasharray:none">y</tspan></text>
+      <path
+         inkscape:connector-curvature="0"
+         id="path2543"
+         d="m -76.955365,132.96748 h 17.58635"
+         style="fill:none;stroke:#ff0000;stroke-width:0.8;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#marker2579)" />
+      <path
+         inkscape:transform-center-x="8.793175"
+         style="fill:none;stroke:#ff0000;stroke-width:0.8;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#marker2589)"
+         d="M -76.955365,132.96748 V 115.38113"
+         id="path2545"
+         inkscape:connector-curvature="0" />
+    </g>
+    <path
+       id="path2549"
+       d="M 10.795979,76.240819 25.12525,92.297278"
+       style="fill:none;stroke:#000000;stroke-width:0.4;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-start:url(#marker2559);marker-end:url(#marker2569)" />
+    <text
+       xml:space="preserve"
+       style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;line-height:1.25;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman, Italic';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#999999;fill-opacity:1;stroke:none;stroke-width:0.264583"
+       x="13.830588"
+       y="88.619675"
+       id="text2555"><tspan
+         sodipodi:role="line"
+         id="tspan2553"
+         x="13.830588"
+         y="88.619675"
+         style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman,  Italic';fill:#000000;stroke-width:0.264583">r<tspan
+   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:65%;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman, ';baseline-shift:sub;fill:#000000"
+   id="tspan2551"
+   dy="0 0">ri</tspan></tspan></text>
+    <path
+       id="path3463"
+       d="m 105.03105,87.637398 4.1193,5.445744"
+       style="fill:none;stroke:#000000;stroke-width:0.4;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-start:url(#marker3473);marker-end:url(#marker3483)" />
+    <text
+       xml:space="preserve"
+       style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;line-height:1.25;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman, Italic';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#999999;fill-opacity:1;stroke:none;stroke-width:0.264583"
+       x="107.86874"
+       y="89.716316"
+       id="text3469"><tspan
+         sodipodi:role="line"
+         id="tspan3467"
+         x="107.86874"
+         y="89.716316"
+         style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman,  Italic';fill:#000000;stroke-width:0.264583">r<tspan
+   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:65%;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman, ';baseline-shift:sub;fill:#000000"
+   id="tspan3465">rb</tspan></tspan></text>
+    <path
+       id="path4197"
+       d="m 101.18352,92.790503 -6.57979,0.0015"
+       style="fill:none;stroke:#000000;stroke-width:0.400001;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-start:url(#marker4207);marker-end:url(#marker4217)" />
+    <text
+       xml:space="preserve"
+       style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;line-height:1.25;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman, Italic';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#999999;fill-opacity:1;stroke:none;stroke-width:0.264583"
+       x="94.634712"
+       y="89.932976"
+       id="text4203"><tspan
+         sodipodi:role="line"
+         id="tspan4201"
+         x="94.634712"
+         y="89.932976"
+         style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman,  Italic';fill:#000000;stroke-width:0.264583">d<tspan
+   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:65%;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman, ';baseline-shift:sub;fill:#000000"
+   id="tspan4199"
+   dy="0">rb</tspan></tspan></text>
+  </g>
+</svg>

--- a/mach_cad/model_obj/cross_sects/inner_rotor_round_slots_double_cage/CrossSectInnerRotorRoundSlotsDoubleCageBar1.svg
+++ b/mach_cad/model_obj/cross_sects/inner_rotor_round_slots_double_cage/CrossSectInnerRotorRoundSlotsDoubleCageBar1.svg
@@ -1,0 +1,1535 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   inkscape:export-ydpi="150"
+   inkscape:export-xdpi="150"
+   inkscape:export-filename="C:\Users\nheme\Documents\Research\Bearingless Motor\Bearinless_Parametrization_Rev1_wht_bckgrnd.png"
+   inkscape:version="1.0.1 (3bc2e813f5, 2020-09-07)"
+   sodipodi:docname="CrossSectInnerRotorRoundSlotsDoubleCageBar1.svg"
+   id="svg837"
+   version="1.1"
+   viewBox="0 0 130.3549 143.56261"
+   height="143.56261mm"
+   width="130.3549mm">
+  <defs
+     id="defs831">
+    <marker
+       inkscape:stockid="Arrow1Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker4217"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path4215"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker4207"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mstart">
+      <path
+         transform="matrix(0.4,0,0,0.4,4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path4205" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker3483"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path3481"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker3473"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mstart">
+      <path
+         transform="matrix(0.4,0,0,0.4,4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path3471" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker2589"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path2587"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#ff0000;fill-opacity:1;fill-rule:evenodd;stroke:#ff0000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker2579"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mend">
+      <path
+         transform="matrix(-0.4,0,0,-0.4,-4,0)"
+         style="fill:#ff0000;fill-opacity:1;fill-rule:evenodd;stroke:#ff0000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path2577" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker2569"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path2567"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker2559"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mstart">
+      <path
+         transform="matrix(0.4,0,0,0.4,4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path2557" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker6553"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path6551"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker5313"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mend">
+      <path
+         transform="matrix(-0.4,0,0,-0.4,-4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path5311" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker3363"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path3361"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mstart"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker2957"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path2955"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(0.4,0,0,0.4,4,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mstart"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker4727"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path4725"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(0.4,0,0,0.4,4,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mstart"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker4345"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path4343"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(0.4,0,0,0.4,4,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mstart"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker3969"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path3967"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(0.4,0,0,0.4,4,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mstart"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker3599"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path3597"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(0.4,0,0,0.4,4,0)" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker2905"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow2Send">
+      <path
+         transform="matrix(-0.3,0,0,-0.3,0.69,0)"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         id="path2903" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker3124"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow2Send">
+      <path
+         transform="matrix(-0.3,0,0,-0.3,0.69,0)"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         id="path3122" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow2Send"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker4852"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path4850"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         transform="matrix(-0.3,0,0,-0.3,0.69,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow2Send"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker3691"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path3689"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         transform="matrix(-0.3,0,0,-0.3,0.69,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Sstart"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker3429"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path3427"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(0.2,0,0,0.2,1.2,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow2Send"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker2019"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path2017"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         transform="matrix(-0.3,0,0,-0.3,0.69,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow2Sstart"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker1781"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path1779"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         transform="matrix(0.3,0,0,0.3,-0.69,0)" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker1488"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mend">
+      <path
+         transform="matrix(-0.4,0,0,-0.4,-4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path1486" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker1244"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mend">
+      <path
+         inkscape:connector-curvature="0"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path1242" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow2Send"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker16235"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path16233"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         transform="matrix(-0.3,0,0,-0.3,0.69,0)" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:stockid="Arrow2Send"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker15733"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path15731"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         transform="matrix(-0.3,0,0,-0.3,0.69,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker15525"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path15523"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker9500"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mend">
+      <path
+         transform="matrix(-0.4,0,0,-0.4,-4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path9498" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker8403"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mstart">
+      <path
+         transform="matrix(0.4,0,0,0.4,4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path8401" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker8209"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mend">
+      <path
+         transform="matrix(-0.4,0,0,-0.4,-4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path8207" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker8061"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mstart">
+      <path
+         transform="matrix(0.4,0,0,0.4,4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path8059" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker7820"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path7818"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mstart"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker7684"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path7682"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(0.4,0,0,0.4,4,0)" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:stockid="Arrow1Mstart"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker6757"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path6755"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(0.4,0,0,0.4,4,0)" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:stockid="Arrow1Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker6627"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path6625"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker6012"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mstart">
+      <path
+         transform="matrix(0.4,0,0,0.4,4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path6010" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker5894"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mend">
+      <path
+         transform="matrix(-0.4,0,0,-0.4,-4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path5892" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:stockid="Arrow1Mstart"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker5567"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path5565"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(0.4,0,0,0.4,4,0)" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:stockid="Arrow1Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker5461"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path5459"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:stockid="Arrow1Mstart"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker5080"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path5078"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(0.4,0,0,0.4,4,0)" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker4986"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mend">
+      <path
+         transform="matrix(-0.4,0,0,-0.4,-4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path4984" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker4450"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow2Send">
+      <path
+         transform="matrix(-0.3,0,0,-0.3,0.69,0)"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         id="path4448" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker4374"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path4372"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:stockid="Arrow1Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker4128"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path4126"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker3864"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mend">
+      <path
+         transform="matrix(-0.4,0,0,-0.4,-4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path3862" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="Arrow1Mstart"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mstart">
+      <path
+         transform="matrix(0.4,0,0,0.4,4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path1491" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="Arrow1Sstart"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Sstart">
+      <path
+         transform="matrix(0.2,0,0,0.2,1.2,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path1497" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker1939"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow2Send">
+      <path
+         transform="matrix(-0.3,0,0,-0.3,0.69,0)"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         id="path1937" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="Arrow2Sstart"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow2Sstart">
+      <path
+         transform="matrix(0.3,0,0,0.3,-0.69,0)"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         id="path1515" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="Arrow2Send"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow2Send">
+      <path
+         transform="matrix(-0.3,0,0,-0.3,0.69,0)"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         id="path1518" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="Arrow2Mstart"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow2Mstart">
+      <path
+         transform="scale(0.6)"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         id="path1509" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="Arrow1Mend"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mend">
+      <path
+         transform="matrix(-0.4,0,0,-0.4,-4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path1494" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:stockid="Arrow1Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker4128-8"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path4126-2"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow2Send"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker4852-2"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path4850-0"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         transform="matrix(-0.3,0,0,-0.3,0.69,0)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow2Send"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker4852-2-2"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path4850-0-3"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         transform="matrix(-0.3,0,0,-0.3,0.69,0)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       id="DistanceX"
+       orient="auto"
+       refX="0"
+       refY="0"
+       style="overflow:visible">
+      <path
+         d="M 3,-3 -3,3 M 0,-5 V 5"
+         style="stroke:#000000;stroke-width:0.5"
+         id="path1492" />
+    </marker>
+    <pattern
+       id="Hatch"
+       patternUnits="userSpaceOnUse"
+       width="8"
+       height="8"
+       x="0"
+       y="0">
+      <path
+         d="M8 4 l-4,4"
+         stroke="#000000"
+         stroke-width="0.25"
+         linecap="square"
+         id="path1495" />
+      <path
+         d="M6 2 l-4,4"
+         stroke="#000000"
+         stroke-width="0.25"
+         linecap="square"
+         id="path1497-9" />
+      <path
+         d="M4 0 l-4,4"
+         stroke="#000000"
+         stroke-width="0.25"
+         linecap="square"
+         id="path1499" />
+    </pattern>
+    <marker
+       id="DistanceX-7"
+       orient="auto"
+       refX="0"
+       refY="0"
+       style="overflow:visible">
+      <path
+         d="M 3,-3 -3,3 M 0,-5 V 5"
+         style="stroke:#000000;stroke-width:0.5"
+         id="path1451" />
+    </marker>
+    <pattern
+       id="Hatch-3"
+       patternUnits="userSpaceOnUse"
+       width="8"
+       height="8"
+       x="0"
+       y="0">
+      <path
+         d="M8 4 l-4,4"
+         stroke="#000000"
+         stroke-width="0.25"
+         linecap="square"
+         id="path1454" />
+      <path
+         d="M6 2 l-4,4"
+         stroke="#000000"
+         stroke-width="0.25"
+         linecap="square"
+         id="path1456" />
+      <path
+         d="M4 0 l-4,4"
+         stroke="#000000"
+         stroke-width="0.25"
+         linecap="square"
+         id="path1458" />
+    </pattern>
+  </defs>
+  <sodipodi:namedview
+     height="281mm"
+     inkscape:document-rotation="0"
+     inkscape:snap-to-guides="true"
+     inkscape:snap-global="true"
+     inkscape:snap-bbox="false"
+     inkscape:object-paths="true"
+     inkscape:snap-intersection-paths="true"
+     inkscape:snap-object-midpoints="true"
+     inkscape:snap-others="true"
+     inkscape:snap-smooth-nodes="true"
+     inkscape:snap-midpoints="true"
+     inkscape:snap-center="true"
+     inkscape:window-maximized="1"
+     inkscape:window-y="-6"
+     inkscape:window-x="-6"
+     inkscape:window-height="650"
+     inkscape:window-width="1280"
+     inkscape:guide-bbox="true"
+     showguides="false"
+     showborder="true"
+     showgrid="false"
+     inkscape:current-layer="layer4"
+     inkscape:document-units="mm"
+     inkscape:cy="276.40583"
+     inkscape:cx="291.55815"
+     inkscape:zoom="0.50000001"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     borderopacity="1.0"
+     bordercolor="#666666"
+     pagecolor="#ffffff"
+     id="base" />
+  <metadata
+     id="metadata834">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     style="display:none"
+     inkscape:label="Background"
+     id="layer5"
+     inkscape:groupmode="layer"
+     transform="translate(-210.50915,-1.0784224)" />
+  <g
+     style="display:none"
+     id="layer1"
+     inkscape:groupmode="layer"
+     inkscape:label="Total_Motor"
+     transform="translate(-210.50915,-1.0784224)">
+    <path
+       inkscape:connector-curvature="0"
+       id="path1388"
+       transform="scale(0.26458333)"
+       d="M 0,650.07812 A 472.4409,472.4409 0 0 0 -472.44141,1122.5195 472.4409,472.4409 0 0 0 0,1594.9609 472.4409,472.4409 0 0 0 472.44141,1122.5195 472.4409,472.4409 0 0 0 0,650.07812 Z m -62.580078,131.7168 c 2.119773,-0.0633 4.238058,0.0941 6.103516,0.6543 2.541358,0.7632 4.943413,2.47682 6.457031,4.65625 1.450551,2.08861 2.260179,4.14371 2.77539,6.56445 v 96.20703 l -32.126953,32.12696 v 25.01171 A 192.85715,192.85715 0 0 1 0,929.66211 192.85715,192.85715 0 0 1 79.371094,946.94922 V 922.00391 L 47.244141,889.87695 v -96.1914 c 0.515003,-2.42755 1.32369,-4.487 2.777343,-6.58008 1.513618,-2.17943 3.915677,-3.89305 6.457032,-4.65625 1.645518,-0.49416 3.491159,-0.65631 5.357422,-0.64844 A 347.10338,347.10338 0 0 1 262.25586,895.70703 c 1.75673,2.4167 3.37685,5.15152 4.01758,7.86524 0.60972,2.58247 0.32595,5.51939 -0.80469,7.91992 -1.08536,2.30442 -2.46502,4.03425 -4.30859,5.69336 l -83.3086,48.09765 -43.88476,-11.75781 -21.66211,12.50586 a 192.85715,192.85715 0 0 1 54.71484,60.06055 192.85715,192.85715 0 0 1 24.71485,77.3809 L 213.33789,1091 l 11.75781,-43.8867 83.31055,-48.09963 c 2.35704,-0.76605 4.54514,-1.093 7.08203,-0.88086 2.64428,0.2211 5.33009,1.4444 7.26172,3.26369 1.49012,1.4034 2.72559,3.2743 3.76172,5.248 a 347.10338,347.10338 0 0 1 20.5918,115.875 347.10338,347.10338 0 0 1 -20.0625,114.8164 c -1.13505,2.3551 -2.53462,4.6543 -4.28907,6.3067 -1.93162,1.8193 -4.61553,3.0425 -7.25976,3.2636 -2.5387,0.2123 -4.72893,-0.1155 -7.08789,-0.8828 l -83.3086,-48.0976 -11.75781,-43.8848 -21.66211,-12.5058 a 192.85715,192.85715 0 0 1 -24.65625,77.414 192.85715,192.85715 0 0 1 -54.65625,60.0938 l 21.60352,12.4726 43.88476,-11.7597 83.30664,48.0976 c 1.84358,1.6591 3.22324,3.3889 4.3086,5.6934 1.13066,2.4005 1.41246,5.3374 0.80273,7.9199 -0.38563,1.6333 -1.14266,3.2715 -2.05273,4.8496 A 347.10338,347.10338 0 0 1 63.15625,1463.209 c -2.309571,0.1107 -4.639833,-0.01 -6.673828,-0.6192 -2.541351,-0.7632 -4.94539,-2.4748 -6.458984,-4.6543 -1.45523,-2.0953 -2.264404,-4.1588 -2.779297,-6.5898 v -96.1836 l 32.126953,-32.1269 v -25.0118 A 192.85715,192.85715 0 0 1 0,1315.377 192.85715,192.85715 0 0 1 -79.371094,1298.0898 v 24.9454 l 32.126953,32.1269 v 96.1914 c -0.514998,2.4276 -1.323687,4.489 -2.777343,6.582 -1.513614,2.1795 -3.915681,3.8911 -6.457032,4.6543 -1.645521,0.4942 -3.491159,0.6564 -5.357422,0.6485 A 347.10338,347.10338 0 0 1 -262.22656,1349.3672 c -1.76655,-2.4252 -3.39721,-5.1736 -4.04102,-7.9004 -0.60972,-2.5825 -0.32791,-5.5194 0.80274,-7.9199 1.08656,-2.307 2.46775,-4.0385 4.31445,-5.6992 l 83.29883,-48.0918 43.88476,11.7597 21.66211,-12.5058 a 192.85715,192.85715 0 0 1 -54.71484,-60.0606 192.85715,192.85715 0 0 1 -24.71485,-77.3808 l -21.60351,12.4726 -11.75781,43.8848 -83.31055,48.0996 c -2.35704,0.766 -4.54513,1.093 -7.08203,0.8808 -2.64427,-0.2211 -5.33009,-1.4443 -7.26172,-3.2636 -1.49012,-1.4035 -2.72559,-3.2744 -3.76172,-5.2481 a 347.10338,347.10338 0 0 1 -20.5918,-115.875 347.10338,347.10338 0 0 1 20.04688,-114.7754 c 1.13845,-2.3696 2.54575,-4.6855 4.31055,-6.3476 1.93163,-1.81929 4.61551,-3.04259 7.25976,-3.26369 2.53416,-0.21191 4.7201,0.11466 7.07422,0.87891 l 83.31641,48.10158 11.75781,43.8867 21.66211,12.5059 a 192.85715,192.85715 0 0 1 24.65625,-77.4141 192.85715,192.85715 0 0 1 54.65625,-60.09571 l -21.60352,-12.4707 -43.88476,11.75781 -83.30664,-48.09765 c -1.84358,-1.65911 -3.22324,-3.38894 -4.3086,-5.69336 -1.13063,-2.40057 -1.41246,-5.33745 -0.80273,-7.91992 0.3858,-1.63403 1.14211,-3.27284 2.05273,-4.85157 A 347.10338,347.10338 0 0 1 -63.158203,781.83008 c 0.193318,-0.009 0.38466,-0.0294 0.578125,-0.0352 z"
+       style="opacity:1;fill:#008000;fill-opacity:1;stroke:#000000;stroke-width:3.77953;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+    <circle
+       r="43.733097"
+       cy="297"
+       cx="0"
+       id="path1390"
+       style="opacity:1;fill:#ff0000;fill-opacity:1;stroke:#000000;stroke-width:1.09333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+  </g>
+  <g
+     style="display:none"
+     inkscape:label="Motor_Cutaway"
+     id="layer2"
+     inkscape:groupmode="layer"
+     transform="translate(-210.50915,-1.0784224)" />
+  <g
+     style="display:none"
+     inkscape:label="Annotations_1"
+     id="layer3"
+     inkscape:groupmode="layer"
+     transform="translate(-210.50915,-1.0784224)">
+    <path
+       inkscape:connector-curvature="0"
+       id="path5884"
+       d="M -7.5563861,234.90369 V 206.70526"
+       style="fill:none;stroke:#000000;stroke-width:0.259632px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-start:url(#marker6012);marker-end:url(#marker5894)" />
+    <rect
+       y="218.84871"
+       x="-8.3674479"
+       height="2.2158854"
+       width="1.5875"
+       id="rect6524"
+       style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.264583;stroke-miterlimit:4;stroke-dasharray:0.79375, 0.264583;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal" />
+    <path
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       id="path1464"
+       d="M -0.02743323,297.01265 35.30925,221.27907"
+       style="fill:none;stroke:#000000;stroke-width:0.202531;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:0.810125, 0.202531;stroke-dashoffset:0;stroke-opacity:1" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.202531;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:0.810125, 0.202531;stroke-dashoffset:0;stroke-opacity:1"
+       d="M 0,297 -35.336683,221.26642"
+       id="path1466"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cc" />
+    <path
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       id="path1470"
+       d="M -21.000268,250.56454 V 221.26642"
+       style="fill:none;stroke:#000000;stroke-width:0.264583;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:0.79375, 0.264583;stroke-dashoffset:0;stroke-opacity:1" />
+    <path
+       sodipodi:nodetypes="csc"
+       inkscape:connector-curvature="0"
+       id="path1482"
+       d="m -11.797594,270.57892 c 3.5813579,-1.66871 7.5752744,-2.60053 11.78682858,-2.60053 4.23356982,0 8.24722062,0.94159 11.84295942,2.62676"
+       style="opacity:1;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.264583;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-start:url(#Arrow2Sstart);marker-end:url(#Arrow2Send);paint-order:normal" />
+    <g
+       transform="translate(-23.187493,-34.196779)"
+       id="g1919">
+      <rect
+         style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.264583;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal"
+         id="rect1907"
+         width="6.160902"
+         height="5.5858846"
+         x="20.12562"
+         y="299.38223" />
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+         x="20.947077"
+         y="304.3931"
+         id="text1895"><tspan
+           sodipodi:role="line"
+           id="tspan1893"
+           x="20.947077"
+           y="304.3931"
+           style="stroke-width:0.264583">θ<tspan
+   style="font-size:3.52778px"
+   id="tspan1897">t</tspan></tspan></text>
+    </g>
+    <flowRoot
+       transform="scale(0.26458333)"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:24px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none"
+       id="flowRoot1899"
+       xml:space="preserve"><flowRegion
+         id="flowRegion1901"><rect
+           y="1122.5197"
+           x="61.473213"
+           height="49.675323"
+           width="50.91721"
+           id="rect1903" /></flowRegion><flowPara
+         id="flowPara1905" /></flowRoot>
+    <path
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       id="path1934"
+       d="m -29.626283,232.40708 c 2.447086,-1.23671 5.213559,-1.9334 8.142751,-1.9334"
+       style="display:inline;opacity:1;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.236671;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-start:url(#Arrow1Sstart);marker-end:url(#marker1939);paint-order:normal" />
+    <rect
+       y="229.11623"
+       x="-27.407322"
+       height="3.6542518"
+       width="3.6240244"
+       id="rect1927"
+       style="display:inline;opacity:1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.13113;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal" />
+    <text
+       id="text1923"
+       y="232.42699"
+       x="-27.561081"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+       xml:space="preserve"><tspan
+         style="stroke-width:0.264583"
+         y="232.42699"
+         x="-27.561081"
+         id="tspan1921"
+         sodipodi:role="line">α</tspan></text>
+    <path
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       id="path3542"
+       d="m 25.501249,208.12668 8.748058,-30.47166"
+       style="fill:none;stroke:#000000;stroke-width:0.251839px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-start:url(#Arrow1Mstart);marker-end:url(#marker3864)" />
+    <text
+       id="text4090"
+       y="162.72395"
+       x="57.811459"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+       xml:space="preserve"><tspan
+         style="stroke-width:0.264583"
+         y="162.72395"
+         x="57.811459"
+         id="tspan4088"
+         sodipodi:role="line" /></text>
+    <path
+       inkscape:connector-curvature="0"
+       id="path3528"
+       d="M -12.500012,236.16224 V 246.8512"
+       style="display:inline;fill:none;stroke:#000000;stroke-width:0.24847px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-start:url(#marker5567);marker-end:url(#marker5461)" />
+    <text
+       id="text4094"
+       y="173.58723"
+       x="-52.318027"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+       xml:space="preserve"><tspan
+         style="stroke-width:0.264583"
+         y="173.58723"
+         x="-52.318027"
+         id="tspan4092"
+         sodipodi:role="line">D<tspan
+   id="tspan4096"
+   style="font-size:3.52778px">os</tspan></tspan></text>
+    <g
+       transform="translate(-16.559098,-7.3212701)"
+       id="g4116">
+      <rect
+         style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:0.237103;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal"
+         id="rect4104"
+         width="6.6424799"
+         height="5.9479485"
+         x="43.113136"
+         y="197.23814" />
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+         x="43.78854"
+         y="202.14687"
+         id="text4100"><tspan
+           sodipodi:role="line"
+           id="tspan4098"
+           x="43.78854"
+           y="202.14687"
+           style="stroke-width:0.264583">T<tspan
+   style="font-size:3.52778px"
+   id="tspan4102">s</tspan></tspan></text>
+    </g>
+    <path
+       sodipodi:nodetypes="ccc"
+       inkscape:connector-curvature="0"
+       id="path4118"
+       d="m -44.334244,171.98437 h 2.000911 l 4.828646,4.82865"
+       style="fill:none;stroke:#000000;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#marker4128)" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path4364"
+       d="m 15.718783,210.03594 -1.547002,-1.79208"
+       style="fill:none;stroke:#000000;stroke-width:0.191617;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:0.383234, 0.191617;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker4450)" />
+    <text
+       id="text4634"
+       y="212.41602"
+       x="15.941146"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+       xml:space="preserve"><tspan
+         style="stroke-width:0.264583"
+         y="212.41602"
+         x="15.941146"
+         id="tspan4632"
+         sodipodi:role="line">r</tspan></text>
+    <path
+       inkscape:connector-curvature="0"
+       id="path4976"
+       d="M -11.547554,219.80781 H 11.547554"
+       style="fill:none;stroke:#000000;stroke-width:0.254303px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-start:url(#marker5080);marker-end:url(#marker4986)" />
+    <g
+       transform="translate(-43.306146,19.473489)"
+       id="g4116-9">
+      <g
+         transform="translate(0,0.18708867)"
+         id="g5421">
+        <rect
+           y="197.24779"
+           x="42.65506"
+           height="5.928659"
+           width="7.7924948"
+           id="rect4104-4"
+           style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:0.256393;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal" />
+        <text
+           id="text4100-8"
+           y="202.70813"
+           x="42.993412"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+           xml:space="preserve"><tspan
+             style="stroke-width:0.264583"
+             y="202.70813"
+             x="42.993412"
+             id="tspan4098-5"
+             sodipodi:role="line">W<tspan
+   style="font-size:3.52778px"
+   id="tspan5415">t</tspan></tspan></text>
+      </g>
+    </g>
+    <path
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       id="path5449"
+       d="m -12.500012,247.56684 h 9.8872516"
+       style="fill:none;stroke:#000000;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+    <path
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       id="path5451"
+       d="m -12.500012,235.4466 h 9.8872516"
+       style="fill:none;stroke:#000000;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+    <path
+       sodipodi:arc-type="arc"
+       style="display:inline;opacity:1;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.265;stroke-miterlimit:4;stroke-dasharray:0.795, 0.265;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal"
+       id="path5875"
+       sodipodi:type="arc"
+       sodipodi:cx="0"
+       sodipodi:cy="296.99997"
+       sodipodi:rx="91.67807"
+       sodipodi:ry="91.67807"
+       sodipodi:start="4.4466291"
+       sodipodi:end="4.5768786"
+       sodipodi:open="true"
+       d="m -24.078562,208.54042 a 91.67807,91.67807 0 0 1 11.693219,-2.37806" />
+    <path
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       id="path5878"
+       d="m -12.500012,213.23104 v -7.0392"
+       style="fill:none;stroke:#000000;stroke-width:0.264583;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:0.79375, 0.264583;stroke-dashoffset:0;stroke-opacity:1" />
+    <path
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       id="path5882"
+       d="m -12.385343,206.16235 h 9.7725826"
+       style="fill:none;stroke:#000000;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+    <g
+       transform="translate(-53.364328,27.478398)"
+       id="g4116-9-8"
+       style="display:inline">
+      <g
+         transform="translate(0,0.18708867)"
+         id="g5421-1">
+        <rect
+           y="197.24779"
+           x="42.65506"
+           height="5.928659"
+           width="7.7924948"
+           id="rect4104-4-4"
+           style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:0.256393;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal" />
+        <text
+           id="text4100-8-5"
+           y="202.17897"
+           x="43.456432"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+           xml:space="preserve"><tspan
+             style="stroke-width:0.264583"
+             y="202.17897"
+             x="43.456432"
+             id="tspan4098-5-6"
+             sodipodi:role="line"><tspan
+               style="font-size:3.52778px"
+               id="tspan5415-7"><tspan
+   id="tspan6615"
+   style="font-size:6.35px">L</tspan>t</tspan></tspan></text>
+      </g>
+    </g>
+    <g
+       transform="translate(-53.364328,40.708055)"
+       id="g4116-9-8-7"
+       style="display:inline">
+      <g
+         transform="translate(0,0.18708867)"
+         id="g5421-1-5">
+        <rect
+           y="197.24779"
+           x="42.65506"
+           height="5.928659"
+           width="7.7924948"
+           id="rect4104-4-4-1"
+           style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:0.256393;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal" />
+        <text
+           id="text4100-8-5-7"
+           y="202.17897"
+           x="43.456432"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+           xml:space="preserve"><tspan
+             style="stroke-width:0.264583"
+             y="202.17897"
+             x="43.456432"
+             id="tspan4098-5-6-6"
+             sodipodi:role="line"><tspan
+               style="font-size:3.52778px"
+               id="tspan5415-7-7"><tspan
+   id="tspan6580-5"
+   style="font-size:6.35px">L</tspan>tt</tspan></tspan></text>
+      </g>
+    </g>
+    <path
+       sodipodi:nodetypes="ccc"
+       inkscape:connector-curvature="0"
+       id="path4118-8"
+       d="m -28.486583,277.7367 h -2.000911 l -4.828646,-4.82865"
+       style="display:inline;fill:none;stroke:#000000;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#marker4128-8)" />
+    <text
+       id="text4094-6"
+       y="279.95316"
+       x="-28.468546"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+       xml:space="preserve"><tspan
+         style="stroke-width:0.264583"
+         y="279.95316"
+         x="-28.468546"
+         id="tspan4092-2"
+         sodipodi:role="line">D<tspan
+   id="tspan4096-9"
+   style="font-size:3.52778px;stroke-width:0.264583">or</tspan></tspan></text>
+    <path
+       inkscape:transform-center-y="-47.336963"
+       inkscape:transform-center-x="-0.53635573"
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       id="path6617"
+       d="m 0.49341607,252.4546 0.0643483,-5.62927"
+       style="display:inline;fill:none;stroke:#000000;stroke-width:0.204665px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-start:url(#marker6757);marker-end:url(#marker6627)" />
+    <text
+       id="text4100-8-5-7-6"
+       y="251.6891"
+       x="1.700698"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+       xml:space="preserve"><tspan
+         style="stroke-width:0.264583"
+         y="251.6891"
+         x="1.700698"
+         id="tspan4098-5-6-6-5"
+         sodipodi:role="line"><tspan
+           style="font-size:3.52778px"
+           id="tspan5415-7-7-3"><tspan
+   id="tspan6580-5-5"
+   style="font-size:6.35px">L</tspan>g</tspan></tspan></text>
+    <path
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       id="path15507"
+       d="m 21.000268,250.54698 h 8.688366"
+       style="fill:none;stroke:#000000;stroke-width:0.23934px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+    <path
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       id="path15509"
+       d="m 21.000268,243.94686 h 8.688366"
+       style="fill:none;stroke:#000000;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+    <text
+       id="text15513"
+       y="248.73111"
+       x="25.765221"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+       xml:space="preserve"><tspan
+         style="stroke-width:0.264583"
+         y="248.73111"
+         x="25.765221"
+         id="tspan15511"
+         sodipodi:role="line">s</tspan></text>
+    <path
+       inkscape:connector-curvature="0"
+       id="path15515"
+       d="m 27.057699,249.05852 v 0.97042"
+       style="fill:none;stroke:#000000;stroke-width:0.276484px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#marker15733)" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path15945"
+       d="m 27.060298,245.50384 v -1.05237"
+       style="fill:none;stroke:#000000;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#marker16235)" />
+  </g>
+  <g
+     style="display:inline"
+     inkscape:label="Annotations_2"
+     id="layer4"
+     inkscape:groupmode="layer"
+     transform="translate(-210.50915,-1.0784224)">
+    <g
+       transform="translate(125.42796,-33.89125)"
+       id="g4116-9-8-2-5"
+       style="display:inline">
+      <g
+         transform="translate(0,0.18708867)"
+         id="g5421-1-7-0">
+        <text
+           id="text4100-8-5-1-8"
+           y="202.24512"
+           x="42.629608"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+           xml:space="preserve"><tspan
+             style="stroke-width:0.264583"
+             y="0"
+             x="0"
+             id="tspan4098-5-6-1-3"
+             sodipodi:role="line"><tspan
+               style="font-size:3.52778px"
+               id="tspan5415-7-3-8"><tspan
+                 id="tspan6615-5-9"
+                 style="font-size:6.35px" /></tspan></tspan></text>
+      </g>
+    </g>
+    <path
+       d="M 340.51411,94.703528 H 325.23796"
+       style="fill:none;stroke:#b3b3b3;stroke-width:0.7;stroke-miterlimit:4;stroke-dasharray:none"
+       id="path1463" />
+    <path
+       d="m 325.23796,90.885498 h 15.27615"
+       style="fill:none;stroke:#b3b3b3;stroke-width:0.7;stroke-miterlimit:4;stroke-dasharray:none"
+       id="path1465" />
+    <path
+       d="m 327.17505,41.117561 -13.22954,7.635858"
+       style="fill:none;stroke:#b3b3b3;stroke-width:0.7;stroke-miterlimit:4;stroke-dasharray:none"
+       id="path1467" />
+    <path
+       d="M 312.03599,45.446937 325.26553,37.81108"
+       style="fill:none;stroke:#b3b3b3;stroke-width:0.7;stroke-miterlimit:4;stroke-dasharray:none"
+       id="path1469" />
+    <path
+       d="m 336.89522,120.4046 a 106.7076,106.6774 0 0 0 3.61889,-25.701072"
+       style="fill:none;stroke:#b3b3b3;stroke-width:0.7;stroke-miterlimit:4;stroke-dasharray:none"
+       id="path1511" />
+    <path
+       d="m 310.20434,92.794508 a 7.6380764,7.6359145 0 0 0 15.03362,1.90902"
+       style="fill:none;stroke:#000000;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none"
+       id="path1513" />
+    <path
+       d="m 325.23796,90.885498 a 7.6380764,7.6359145 0 0 0 -15.03362,1.90901"
+       style="fill:none;stroke:#000000;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none"
+       id="path1515-7" />
+    <path
+       d="M 340.51411,90.885498 A 106.7076,106.6774 0 0 0 336.89522,65.184403"
+       style="fill:none;stroke:#b3b3b3;stroke-width:0.7;stroke-miterlimit:4;stroke-dasharray:none"
+       id="path1517" />
+    <path
+       d="m 287.28999,92.794508 a 7.638115,7.6359531 0 0 0 15.27623,0"
+       style="fill:none;stroke:#b3b3b3;stroke-width:0.7;stroke-miterlimit:4;stroke-dasharray:none"
+       id="path1519" />
+    <path
+       d="m 302.56622,92.794508 a 7.638115,7.6359531 0 0 0 -15.27623,0"
+       style="fill:none;stroke:#b3b3b3;stroke-width:0.7;stroke-miterlimit:4;stroke-dasharray:none"
+       id="path1521" />
+    <path
+       d="M 336.89522,65.184403 A 106.7076,106.6774 0 0 0 327.17505,41.117561"
+       style="fill:none;stroke:#b3b3b3;stroke-width:0.7;stroke-miterlimit:4;stroke-dasharray:none"
+       id="path1523" />
+    <path
+       d="m 299.9712,54.614816 a 7.6380764,7.6359145 0 0 0 13.97431,-5.861397"
+       style="fill:none;stroke:#b3b3b3;stroke-width:0.7;stroke-miterlimit:4;stroke-dasharray:none"
+       id="path1525" />
+    <path
+       d="M 312.03599,45.446937 A 7.6380764,7.6359145 0 0 0 299.9712,54.614816"
+       style="fill:none;stroke:#b3b3b3;stroke-width:0.7;stroke-miterlimit:4;stroke-dasharray:none"
+       id="path1527" />
+    <path
+       d="M 325.26553,37.81108 A 106.7076,106.6774 0 0 0 309.27725,17.362255"
+       style="fill:none;stroke:#b3b3b3;stroke-width:0.7;stroke-miterlimit:4;stroke-dasharray:none"
+       id="path1529" />
+    <path
+       d="M 280.12679,66.068704 A 7.6380941,7.6359322 0 0 0 293.3564,58.432846"
+       style="fill:none;stroke:#b3b3b3;stroke-width:0.7;stroke-miterlimit:4;stroke-dasharray:none"
+       id="path1531" />
+    <path
+       d="m 293.3564,58.432846 a 7.6380941,7.6359322 0 0 0 -13.22961,7.635858"
+       style="fill:none;stroke:#b3b3b3;stroke-width:0.7;stroke-miterlimit:4;stroke-dasharray:none"
+       id="path1533" />
+    <path
+       d="M 309.27725,17.362255 A 106.7076,106.6774 0 0 0 288.82242,1.3783736"
+       style="fill:none;stroke:#b3b3b3;stroke-width:0.7;stroke-miterlimit:4;stroke-dasharray:none"
+       id="path1535" />
+    <path
+       d="m 327.17505,144.47144 a 106.7076,106.6774 0 0 0 9.72017,-24.06684"
+       style="fill:none;stroke:#b3b3b3;stroke-width:0.7;stroke-miterlimit:4;stroke-dasharray:none"
+       id="path1649" />
+    <path
+       d="m 256.7376,92.794508 a 22.914228,22.907742 0 0 0 -45.82845,0"
+       style="fill:none;stroke:#b3b3b3;stroke-width:0.7;stroke-miterlimit:4;stroke-dasharray:none"
+       id="path1655" />
+    <path
+       d="m 210.90915,92.794508 a 22.914228,22.907742 0 0 0 45.82845,0"
+       style="fill:none;stroke:#b3b3b3;stroke-width:0.7;stroke-miterlimit:4;stroke-dasharray:none"
+       id="path1657" />
+    <path
+       d="m 325.4805,92.794508 a 7.6380764,7.6359145 0 0 0 -0.24254,-1.90901"
+       style="fill:none;stroke:#000000;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none"
+       id="path1659" />
+    <path
+       d="m 325.23796,94.703528 a 7.6380764,7.6359145 0 0 0 0.24254,-1.90902"
+       style="fill:none;stroke:#000000;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none"
+       id="path1661" />
+    <path
+       d="m 313.2008,46.978958 a 7.6380764,7.6359145 0 0 0 -1.16481,-1.532021"
+       style="fill:none;stroke:#b3b3b3;stroke-width:0.7;stroke-miterlimit:4;stroke-dasharray:none"
+       id="path1663" />
+    <path
+       d="M 313.94551,48.753419 A 7.6380764,7.6359145 0 0 0 313.2008,46.978958"
+       style="fill:none;stroke:#b3b3b3;stroke-width:0.7;stroke-miterlimit:4;stroke-dasharray:none"
+       id="path1665" />
+    <g
+       id="g2547"
+       transform="translate(311.25152,-40.366636)"
+       style="stroke-width:0.8;stroke-miterlimit:4;stroke-dasharray:none">
+      <text
+         xml:space="preserve"
+         style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.23333px;line-height:1.25;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman, Italic';letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.8;stroke-miterlimit:4;stroke-dasharray:none"
+         x="-61.300587"
+         y="137.48808"
+         id="text2537"><tspan
+           sodipodi:role="line"
+           id="tspan2535"
+           x="-61.300587"
+           y="137.48808"
+           style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman, Italic';stroke-width:0.8;stroke-miterlimit:4;stroke-dasharray:none">x</tspan></text>
+      <text
+         xml:space="preserve"
+         style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:10.5833px;line-height:1.25;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman, Italic';letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.8;stroke-miterlimit:4;stroke-dasharray:none"
+         x="-81.795479"
+         y="117.64843"
+         id="text2541"><tspan
+           sodipodi:role="line"
+           id="tspan2539"
+           x="-81.795479"
+           y="117.64843"
+           style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman, Italic';stroke-width:0.8;stroke-miterlimit:4;stroke-dasharray:none">y</tspan></text>
+      <path
+         inkscape:connector-curvature="0"
+         id="path2543"
+         d="m -76.955365,132.96748 h 17.58635"
+         style="fill:none;stroke:#ff0000;stroke-width:0.8;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#marker2579)" />
+      <path
+         inkscape:transform-center-x="8.793175"
+         style="fill:none;stroke:#ff0000;stroke-width:0.8;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#marker2589)"
+         d="M -76.955365,132.96748 V 115.38113"
+         id="path2545"
+         inkscape:connector-curvature="0" />
+    </g>
+  </g>
+</svg>

--- a/mach_cad/model_obj/cross_sects/inner_rotor_round_slots_double_cage/CrossSectInnerRotorRoundSlotsDoubleCageBar2.svg
+++ b/mach_cad/model_obj/cross_sects/inner_rotor_round_slots_double_cage/CrossSectInnerRotorRoundSlotsDoubleCageBar2.svg
@@ -1,0 +1,1535 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   inkscape:export-ydpi="150"
+   inkscape:export-xdpi="150"
+   inkscape:export-filename="C:\Users\nheme\Documents\Research\Bearingless Motor\Bearinless_Parametrization_Rev1_wht_bckgrnd.png"
+   inkscape:version="1.0.1 (3bc2e813f5, 2020-09-07)"
+   sodipodi:docname="CrossSectInnerRotorRoundSlotsDoubleCageBar2.svg"
+   id="svg837"
+   version="1.1"
+   viewBox="0 0 130.3549 143.56261"
+   height="143.56261mm"
+   width="130.3549mm">
+  <defs
+     id="defs831">
+    <marker
+       inkscape:stockid="Arrow1Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker4217"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path4215"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker4207"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mstart">
+      <path
+         transform="matrix(0.4,0,0,0.4,4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path4205" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker3483"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path3481"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker3473"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mstart">
+      <path
+         transform="matrix(0.4,0,0,0.4,4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path3471" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker2589"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path2587"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#ff0000;fill-opacity:1;fill-rule:evenodd;stroke:#ff0000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker2579"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mend">
+      <path
+         transform="matrix(-0.4,0,0,-0.4,-4,0)"
+         style="fill:#ff0000;fill-opacity:1;fill-rule:evenodd;stroke:#ff0000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path2577" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker2569"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path2567"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker2559"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mstart">
+      <path
+         transform="matrix(0.4,0,0,0.4,4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path2557" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker6553"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path6551"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker5313"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mend">
+      <path
+         transform="matrix(-0.4,0,0,-0.4,-4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path5311" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker3363"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path3361"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mstart"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker2957"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path2955"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(0.4,0,0,0.4,4,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mstart"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker4727"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path4725"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(0.4,0,0,0.4,4,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mstart"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker4345"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path4343"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(0.4,0,0,0.4,4,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mstart"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker3969"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path3967"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(0.4,0,0,0.4,4,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mstart"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker3599"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path3597"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(0.4,0,0,0.4,4,0)" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker2905"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow2Send">
+      <path
+         transform="matrix(-0.3,0,0,-0.3,0.69,0)"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         id="path2903" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker3124"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow2Send">
+      <path
+         transform="matrix(-0.3,0,0,-0.3,0.69,0)"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         id="path3122" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow2Send"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker4852"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path4850"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         transform="matrix(-0.3,0,0,-0.3,0.69,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow2Send"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker3691"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path3689"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         transform="matrix(-0.3,0,0,-0.3,0.69,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Sstart"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker3429"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path3427"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(0.2,0,0,0.2,1.2,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow2Send"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker2019"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path2017"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         transform="matrix(-0.3,0,0,-0.3,0.69,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow2Sstart"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker1781"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path1779"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         transform="matrix(0.3,0,0,0.3,-0.69,0)" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker1488"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mend">
+      <path
+         transform="matrix(-0.4,0,0,-0.4,-4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path1486" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker1244"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mend">
+      <path
+         inkscape:connector-curvature="0"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path1242" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow2Send"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker16235"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path16233"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         transform="matrix(-0.3,0,0,-0.3,0.69,0)" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:stockid="Arrow2Send"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker15733"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path15731"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         transform="matrix(-0.3,0,0,-0.3,0.69,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker15525"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path15523"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker9500"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mend">
+      <path
+         transform="matrix(-0.4,0,0,-0.4,-4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path9498" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker8403"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mstart">
+      <path
+         transform="matrix(0.4,0,0,0.4,4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path8401" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker8209"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mend">
+      <path
+         transform="matrix(-0.4,0,0,-0.4,-4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path8207" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker8061"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mstart">
+      <path
+         transform="matrix(0.4,0,0,0.4,4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path8059" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker7820"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path7818"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mstart"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker7684"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path7682"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(0.4,0,0,0.4,4,0)" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:stockid="Arrow1Mstart"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker6757"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path6755"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(0.4,0,0,0.4,4,0)" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:stockid="Arrow1Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker6627"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path6625"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker6012"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mstart">
+      <path
+         transform="matrix(0.4,0,0,0.4,4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path6010" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker5894"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mend">
+      <path
+         transform="matrix(-0.4,0,0,-0.4,-4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path5892" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:stockid="Arrow1Mstart"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker5567"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path5565"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(0.4,0,0,0.4,4,0)" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:stockid="Arrow1Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker5461"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path5459"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:stockid="Arrow1Mstart"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker5080"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path5078"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(0.4,0,0,0.4,4,0)" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker4986"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mend">
+      <path
+         transform="matrix(-0.4,0,0,-0.4,-4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path4984" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker4450"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow2Send">
+      <path
+         transform="matrix(-0.3,0,0,-0.3,0.69,0)"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         id="path4448" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker4374"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path4372"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:stockid="Arrow1Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker4128"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path4126"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker3864"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mend">
+      <path
+         transform="matrix(-0.4,0,0,-0.4,-4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path3862" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="Arrow1Mstart"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mstart">
+      <path
+         transform="matrix(0.4,0,0,0.4,4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path1491" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="Arrow1Sstart"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Sstart">
+      <path
+         transform="matrix(0.2,0,0,0.2,1.2,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path1497" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker1939"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow2Send">
+      <path
+         transform="matrix(-0.3,0,0,-0.3,0.69,0)"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         id="path1937" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="Arrow2Sstart"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow2Sstart">
+      <path
+         transform="matrix(0.3,0,0,0.3,-0.69,0)"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         id="path1515" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="Arrow2Send"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow2Send">
+      <path
+         transform="matrix(-0.3,0,0,-0.3,0.69,0)"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         id="path1518" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="Arrow2Mstart"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow2Mstart">
+      <path
+         transform="scale(0.6)"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         id="path1509" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="Arrow1Mend"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mend">
+      <path
+         transform="matrix(-0.4,0,0,-0.4,-4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path1494" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:stockid="Arrow1Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker4128-8"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path4126-2"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow2Send"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker4852-2"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path4850-0"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         transform="matrix(-0.3,0,0,-0.3,0.69,0)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow2Send"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker4852-2-2"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path4850-0-3"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         transform="matrix(-0.3,0,0,-0.3,0.69,0)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       id="DistanceX"
+       orient="auto"
+       refX="0"
+       refY="0"
+       style="overflow:visible">
+      <path
+         d="M 3,-3 -3,3 M 0,-5 V 5"
+         style="stroke:#000000;stroke-width:0.5"
+         id="path1492" />
+    </marker>
+    <pattern
+       id="Hatch"
+       patternUnits="userSpaceOnUse"
+       width="8"
+       height="8"
+       x="0"
+       y="0">
+      <path
+         d="M8 4 l-4,4"
+         stroke="#000000"
+         stroke-width="0.25"
+         linecap="square"
+         id="path1495" />
+      <path
+         d="M6 2 l-4,4"
+         stroke="#000000"
+         stroke-width="0.25"
+         linecap="square"
+         id="path1497-9" />
+      <path
+         d="M4 0 l-4,4"
+         stroke="#000000"
+         stroke-width="0.25"
+         linecap="square"
+         id="path1499" />
+    </pattern>
+    <marker
+       id="DistanceX-7"
+       orient="auto"
+       refX="0"
+       refY="0"
+       style="overflow:visible">
+      <path
+         d="M 3,-3 -3,3 M 0,-5 V 5"
+         style="stroke:#000000;stroke-width:0.5"
+         id="path1451" />
+    </marker>
+    <pattern
+       id="Hatch-3"
+       patternUnits="userSpaceOnUse"
+       width="8"
+       height="8"
+       x="0"
+       y="0">
+      <path
+         d="M8 4 l-4,4"
+         stroke="#000000"
+         stroke-width="0.25"
+         linecap="square"
+         id="path1454" />
+      <path
+         d="M6 2 l-4,4"
+         stroke="#000000"
+         stroke-width="0.25"
+         linecap="square"
+         id="path1456" />
+      <path
+         d="M4 0 l-4,4"
+         stroke="#000000"
+         stroke-width="0.25"
+         linecap="square"
+         id="path1458" />
+    </pattern>
+  </defs>
+  <sodipodi:namedview
+     height="281mm"
+     inkscape:document-rotation="0"
+     inkscape:snap-to-guides="true"
+     inkscape:snap-global="true"
+     inkscape:snap-bbox="false"
+     inkscape:object-paths="true"
+     inkscape:snap-intersection-paths="true"
+     inkscape:snap-object-midpoints="true"
+     inkscape:snap-others="true"
+     inkscape:snap-smooth-nodes="true"
+     inkscape:snap-midpoints="true"
+     inkscape:snap-center="true"
+     inkscape:window-maximized="1"
+     inkscape:window-y="-6"
+     inkscape:window-x="-6"
+     inkscape:window-height="650"
+     inkscape:window-width="1280"
+     inkscape:guide-bbox="true"
+     showguides="false"
+     showborder="true"
+     showgrid="false"
+     inkscape:current-layer="layer4"
+     inkscape:document-units="mm"
+     inkscape:cy="243.6972"
+     inkscape:cx="388.91254"
+     inkscape:zoom="0.50000001"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     borderopacity="1.0"
+     bordercolor="#666666"
+     pagecolor="#ffffff"
+     id="base" />
+  <metadata
+     id="metadata834">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     style="display:none"
+     inkscape:label="Background"
+     id="layer5"
+     inkscape:groupmode="layer"
+     transform="translate(-210.50915,-1.0784224)" />
+  <g
+     style="display:none"
+     id="layer1"
+     inkscape:groupmode="layer"
+     inkscape:label="Total_Motor"
+     transform="translate(-210.50915,-1.0784224)">
+    <path
+       inkscape:connector-curvature="0"
+       id="path1388"
+       transform="scale(0.26458333)"
+       d="M 0,650.07812 A 472.4409,472.4409 0 0 0 -472.44141,1122.5195 472.4409,472.4409 0 0 0 0,1594.9609 472.4409,472.4409 0 0 0 472.44141,1122.5195 472.4409,472.4409 0 0 0 0,650.07812 Z m -62.580078,131.7168 c 2.119773,-0.0633 4.238058,0.0941 6.103516,0.6543 2.541358,0.7632 4.943413,2.47682 6.457031,4.65625 1.450551,2.08861 2.260179,4.14371 2.77539,6.56445 v 96.20703 l -32.126953,32.12696 v 25.01171 A 192.85715,192.85715 0 0 1 0,929.66211 192.85715,192.85715 0 0 1 79.371094,946.94922 V 922.00391 L 47.244141,889.87695 v -96.1914 c 0.515003,-2.42755 1.32369,-4.487 2.777343,-6.58008 1.513618,-2.17943 3.915677,-3.89305 6.457032,-4.65625 1.645518,-0.49416 3.491159,-0.65631 5.357422,-0.64844 A 347.10338,347.10338 0 0 1 262.25586,895.70703 c 1.75673,2.4167 3.37685,5.15152 4.01758,7.86524 0.60972,2.58247 0.32595,5.51939 -0.80469,7.91992 -1.08536,2.30442 -2.46502,4.03425 -4.30859,5.69336 l -83.3086,48.09765 -43.88476,-11.75781 -21.66211,12.50586 a 192.85715,192.85715 0 0 1 54.71484,60.06055 192.85715,192.85715 0 0 1 24.71485,77.3809 L 213.33789,1091 l 11.75781,-43.8867 83.31055,-48.09963 c 2.35704,-0.76605 4.54514,-1.093 7.08203,-0.88086 2.64428,0.2211 5.33009,1.4444 7.26172,3.26369 1.49012,1.4034 2.72559,3.2743 3.76172,5.248 a 347.10338,347.10338 0 0 1 20.5918,115.875 347.10338,347.10338 0 0 1 -20.0625,114.8164 c -1.13505,2.3551 -2.53462,4.6543 -4.28907,6.3067 -1.93162,1.8193 -4.61553,3.0425 -7.25976,3.2636 -2.5387,0.2123 -4.72893,-0.1155 -7.08789,-0.8828 l -83.3086,-48.0976 -11.75781,-43.8848 -21.66211,-12.5058 a 192.85715,192.85715 0 0 1 -24.65625,77.414 192.85715,192.85715 0 0 1 -54.65625,60.0938 l 21.60352,12.4726 43.88476,-11.7597 83.30664,48.0976 c 1.84358,1.6591 3.22324,3.3889 4.3086,5.6934 1.13066,2.4005 1.41246,5.3374 0.80273,7.9199 -0.38563,1.6333 -1.14266,3.2715 -2.05273,4.8496 A 347.10338,347.10338 0 0 1 63.15625,1463.209 c -2.309571,0.1107 -4.639833,-0.01 -6.673828,-0.6192 -2.541351,-0.7632 -4.94539,-2.4748 -6.458984,-4.6543 -1.45523,-2.0953 -2.264404,-4.1588 -2.779297,-6.5898 v -96.1836 l 32.126953,-32.1269 v -25.0118 A 192.85715,192.85715 0 0 1 0,1315.377 192.85715,192.85715 0 0 1 -79.371094,1298.0898 v 24.9454 l 32.126953,32.1269 v 96.1914 c -0.514998,2.4276 -1.323687,4.489 -2.777343,6.582 -1.513614,2.1795 -3.915681,3.8911 -6.457032,4.6543 -1.645521,0.4942 -3.491159,0.6564 -5.357422,0.6485 A 347.10338,347.10338 0 0 1 -262.22656,1349.3672 c -1.76655,-2.4252 -3.39721,-5.1736 -4.04102,-7.9004 -0.60972,-2.5825 -0.32791,-5.5194 0.80274,-7.9199 1.08656,-2.307 2.46775,-4.0385 4.31445,-5.6992 l 83.29883,-48.0918 43.88476,11.7597 21.66211,-12.5058 a 192.85715,192.85715 0 0 1 -54.71484,-60.0606 192.85715,192.85715 0 0 1 -24.71485,-77.3808 l -21.60351,12.4726 -11.75781,43.8848 -83.31055,48.0996 c -2.35704,0.766 -4.54513,1.093 -7.08203,0.8808 -2.64427,-0.2211 -5.33009,-1.4443 -7.26172,-3.2636 -1.49012,-1.4035 -2.72559,-3.2744 -3.76172,-5.2481 a 347.10338,347.10338 0 0 1 -20.5918,-115.875 347.10338,347.10338 0 0 1 20.04688,-114.7754 c 1.13845,-2.3696 2.54575,-4.6855 4.31055,-6.3476 1.93163,-1.81929 4.61551,-3.04259 7.25976,-3.26369 2.53416,-0.21191 4.7201,0.11466 7.07422,0.87891 l 83.31641,48.10158 11.75781,43.8867 21.66211,12.5059 a 192.85715,192.85715 0 0 1 24.65625,-77.4141 192.85715,192.85715 0 0 1 54.65625,-60.09571 l -21.60352,-12.4707 -43.88476,11.75781 -83.30664,-48.09765 c -1.84358,-1.65911 -3.22324,-3.38894 -4.3086,-5.69336 -1.13063,-2.40057 -1.41246,-5.33745 -0.80273,-7.91992 0.3858,-1.63403 1.14211,-3.27284 2.05273,-4.85157 A 347.10338,347.10338 0 0 1 -63.158203,781.83008 c 0.193318,-0.009 0.38466,-0.0294 0.578125,-0.0352 z"
+       style="opacity:1;fill:#008000;fill-opacity:1;stroke:#000000;stroke-width:3.77953;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+    <circle
+       r="43.733097"
+       cy="297"
+       cx="0"
+       id="path1390"
+       style="opacity:1;fill:#ff0000;fill-opacity:1;stroke:#000000;stroke-width:1.09333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+  </g>
+  <g
+     style="display:none"
+     inkscape:label="Motor_Cutaway"
+     id="layer2"
+     inkscape:groupmode="layer"
+     transform="translate(-210.50915,-1.0784224)" />
+  <g
+     style="display:none"
+     inkscape:label="Annotations_1"
+     id="layer3"
+     inkscape:groupmode="layer"
+     transform="translate(-210.50915,-1.0784224)">
+    <path
+       inkscape:connector-curvature="0"
+       id="path5884"
+       d="M -7.5563861,234.90369 V 206.70526"
+       style="fill:none;stroke:#000000;stroke-width:0.259632px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-start:url(#marker6012);marker-end:url(#marker5894)" />
+    <rect
+       y="218.84871"
+       x="-8.3674479"
+       height="2.2158854"
+       width="1.5875"
+       id="rect6524"
+       style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.264583;stroke-miterlimit:4;stroke-dasharray:0.79375, 0.264583;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal" />
+    <path
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       id="path1464"
+       d="M -0.02743323,297.01265 35.30925,221.27907"
+       style="fill:none;stroke:#000000;stroke-width:0.202531;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:0.810125, 0.202531;stroke-dashoffset:0;stroke-opacity:1" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.202531;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:0.810125, 0.202531;stroke-dashoffset:0;stroke-opacity:1"
+       d="M 0,297 -35.336683,221.26642"
+       id="path1466"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cc" />
+    <path
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       id="path1470"
+       d="M -21.000268,250.56454 V 221.26642"
+       style="fill:none;stroke:#000000;stroke-width:0.264583;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:0.79375, 0.264583;stroke-dashoffset:0;stroke-opacity:1" />
+    <path
+       sodipodi:nodetypes="csc"
+       inkscape:connector-curvature="0"
+       id="path1482"
+       d="m -11.797594,270.57892 c 3.5813579,-1.66871 7.5752744,-2.60053 11.78682858,-2.60053 4.23356982,0 8.24722062,0.94159 11.84295942,2.62676"
+       style="opacity:1;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.264583;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-start:url(#Arrow2Sstart);marker-end:url(#Arrow2Send);paint-order:normal" />
+    <g
+       transform="translate(-23.187493,-34.196779)"
+       id="g1919">
+      <rect
+         style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.264583;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal"
+         id="rect1907"
+         width="6.160902"
+         height="5.5858846"
+         x="20.12562"
+         y="299.38223" />
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+         x="20.947077"
+         y="304.3931"
+         id="text1895"><tspan
+           sodipodi:role="line"
+           id="tspan1893"
+           x="20.947077"
+           y="304.3931"
+           style="stroke-width:0.264583">θ<tspan
+   style="font-size:3.52778px"
+   id="tspan1897">t</tspan></tspan></text>
+    </g>
+    <flowRoot
+       transform="scale(0.26458333)"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:24px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none"
+       id="flowRoot1899"
+       xml:space="preserve"><flowRegion
+         id="flowRegion1901"><rect
+           y="1122.5197"
+           x="61.473213"
+           height="49.675323"
+           width="50.91721"
+           id="rect1903" /></flowRegion><flowPara
+         id="flowPara1905" /></flowRoot>
+    <path
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       id="path1934"
+       d="m -29.626283,232.40708 c 2.447086,-1.23671 5.213559,-1.9334 8.142751,-1.9334"
+       style="display:inline;opacity:1;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.236671;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-start:url(#Arrow1Sstart);marker-end:url(#marker1939);paint-order:normal" />
+    <rect
+       y="229.11623"
+       x="-27.407322"
+       height="3.6542518"
+       width="3.6240244"
+       id="rect1927"
+       style="display:inline;opacity:1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.13113;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal" />
+    <text
+       id="text1923"
+       y="232.42699"
+       x="-27.561081"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+       xml:space="preserve"><tspan
+         style="stroke-width:0.264583"
+         y="232.42699"
+         x="-27.561081"
+         id="tspan1921"
+         sodipodi:role="line">α</tspan></text>
+    <path
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       id="path3542"
+       d="m 25.501249,208.12668 8.748058,-30.47166"
+       style="fill:none;stroke:#000000;stroke-width:0.251839px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-start:url(#Arrow1Mstart);marker-end:url(#marker3864)" />
+    <text
+       id="text4090"
+       y="162.72395"
+       x="57.811459"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+       xml:space="preserve"><tspan
+         style="stroke-width:0.264583"
+         y="162.72395"
+         x="57.811459"
+         id="tspan4088"
+         sodipodi:role="line" /></text>
+    <path
+       inkscape:connector-curvature="0"
+       id="path3528"
+       d="M -12.500012,236.16224 V 246.8512"
+       style="display:inline;fill:none;stroke:#000000;stroke-width:0.24847px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-start:url(#marker5567);marker-end:url(#marker5461)" />
+    <text
+       id="text4094"
+       y="173.58723"
+       x="-52.318027"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+       xml:space="preserve"><tspan
+         style="stroke-width:0.264583"
+         y="173.58723"
+         x="-52.318027"
+         id="tspan4092"
+         sodipodi:role="line">D<tspan
+   id="tspan4096"
+   style="font-size:3.52778px">os</tspan></tspan></text>
+    <g
+       transform="translate(-16.559098,-7.3212701)"
+       id="g4116">
+      <rect
+         style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:0.237103;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal"
+         id="rect4104"
+         width="6.6424799"
+         height="5.9479485"
+         x="43.113136"
+         y="197.23814" />
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+         x="43.78854"
+         y="202.14687"
+         id="text4100"><tspan
+           sodipodi:role="line"
+           id="tspan4098"
+           x="43.78854"
+           y="202.14687"
+           style="stroke-width:0.264583">T<tspan
+   style="font-size:3.52778px"
+   id="tspan4102">s</tspan></tspan></text>
+    </g>
+    <path
+       sodipodi:nodetypes="ccc"
+       inkscape:connector-curvature="0"
+       id="path4118"
+       d="m -44.334244,171.98437 h 2.000911 l 4.828646,4.82865"
+       style="fill:none;stroke:#000000;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#marker4128)" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path4364"
+       d="m 15.718783,210.03594 -1.547002,-1.79208"
+       style="fill:none;stroke:#000000;stroke-width:0.191617;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:0.383234, 0.191617;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker4450)" />
+    <text
+       id="text4634"
+       y="212.41602"
+       x="15.941146"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+       xml:space="preserve"><tspan
+         style="stroke-width:0.264583"
+         y="212.41602"
+         x="15.941146"
+         id="tspan4632"
+         sodipodi:role="line">r</tspan></text>
+    <path
+       inkscape:connector-curvature="0"
+       id="path4976"
+       d="M -11.547554,219.80781 H 11.547554"
+       style="fill:none;stroke:#000000;stroke-width:0.254303px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-start:url(#marker5080);marker-end:url(#marker4986)" />
+    <g
+       transform="translate(-43.306146,19.473489)"
+       id="g4116-9">
+      <g
+         transform="translate(0,0.18708867)"
+         id="g5421">
+        <rect
+           y="197.24779"
+           x="42.65506"
+           height="5.928659"
+           width="7.7924948"
+           id="rect4104-4"
+           style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:0.256393;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal" />
+        <text
+           id="text4100-8"
+           y="202.70813"
+           x="42.993412"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+           xml:space="preserve"><tspan
+             style="stroke-width:0.264583"
+             y="202.70813"
+             x="42.993412"
+             id="tspan4098-5"
+             sodipodi:role="line">W<tspan
+   style="font-size:3.52778px"
+   id="tspan5415">t</tspan></tspan></text>
+      </g>
+    </g>
+    <path
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       id="path5449"
+       d="m -12.500012,247.56684 h 9.8872516"
+       style="fill:none;stroke:#000000;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+    <path
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       id="path5451"
+       d="m -12.500012,235.4466 h 9.8872516"
+       style="fill:none;stroke:#000000;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+    <path
+       sodipodi:arc-type="arc"
+       style="display:inline;opacity:1;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.265;stroke-miterlimit:4;stroke-dasharray:0.795, 0.265;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal"
+       id="path5875"
+       sodipodi:type="arc"
+       sodipodi:cx="0"
+       sodipodi:cy="296.99997"
+       sodipodi:rx="91.67807"
+       sodipodi:ry="91.67807"
+       sodipodi:start="4.4466291"
+       sodipodi:end="4.5768786"
+       sodipodi:open="true"
+       d="m -24.078562,208.54042 a 91.67807,91.67807 0 0 1 11.693219,-2.37806" />
+    <path
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       id="path5878"
+       d="m -12.500012,213.23104 v -7.0392"
+       style="fill:none;stroke:#000000;stroke-width:0.264583;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:0.79375, 0.264583;stroke-dashoffset:0;stroke-opacity:1" />
+    <path
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       id="path5882"
+       d="m -12.385343,206.16235 h 9.7725826"
+       style="fill:none;stroke:#000000;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+    <g
+       transform="translate(-53.364328,27.478398)"
+       id="g4116-9-8"
+       style="display:inline">
+      <g
+         transform="translate(0,0.18708867)"
+         id="g5421-1">
+        <rect
+           y="197.24779"
+           x="42.65506"
+           height="5.928659"
+           width="7.7924948"
+           id="rect4104-4-4"
+           style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:0.256393;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal" />
+        <text
+           id="text4100-8-5"
+           y="202.17897"
+           x="43.456432"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+           xml:space="preserve"><tspan
+             style="stroke-width:0.264583"
+             y="202.17897"
+             x="43.456432"
+             id="tspan4098-5-6"
+             sodipodi:role="line"><tspan
+               style="font-size:3.52778px"
+               id="tspan5415-7"><tspan
+   id="tspan6615"
+   style="font-size:6.35px">L</tspan>t</tspan></tspan></text>
+      </g>
+    </g>
+    <g
+       transform="translate(-53.364328,40.708055)"
+       id="g4116-9-8-7"
+       style="display:inline">
+      <g
+         transform="translate(0,0.18708867)"
+         id="g5421-1-5">
+        <rect
+           y="197.24779"
+           x="42.65506"
+           height="5.928659"
+           width="7.7924948"
+           id="rect4104-4-4-1"
+           style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:0.256393;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal" />
+        <text
+           id="text4100-8-5-7"
+           y="202.17897"
+           x="43.456432"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+           xml:space="preserve"><tspan
+             style="stroke-width:0.264583"
+             y="202.17897"
+             x="43.456432"
+             id="tspan4098-5-6-6"
+             sodipodi:role="line"><tspan
+               style="font-size:3.52778px"
+               id="tspan5415-7-7"><tspan
+   id="tspan6580-5"
+   style="font-size:6.35px">L</tspan>tt</tspan></tspan></text>
+      </g>
+    </g>
+    <path
+       sodipodi:nodetypes="ccc"
+       inkscape:connector-curvature="0"
+       id="path4118-8"
+       d="m -28.486583,277.7367 h -2.000911 l -4.828646,-4.82865"
+       style="display:inline;fill:none;stroke:#000000;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#marker4128-8)" />
+    <text
+       id="text4094-6"
+       y="279.95316"
+       x="-28.468546"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+       xml:space="preserve"><tspan
+         style="stroke-width:0.264583"
+         y="279.95316"
+         x="-28.468546"
+         id="tspan4092-2"
+         sodipodi:role="line">D<tspan
+   id="tspan4096-9"
+   style="font-size:3.52778px;stroke-width:0.264583">or</tspan></tspan></text>
+    <path
+       inkscape:transform-center-y="-47.336963"
+       inkscape:transform-center-x="-0.53635573"
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       id="path6617"
+       d="m 0.49341607,252.4546 0.0643483,-5.62927"
+       style="display:inline;fill:none;stroke:#000000;stroke-width:0.204665px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-start:url(#marker6757);marker-end:url(#marker6627)" />
+    <text
+       id="text4100-8-5-7-6"
+       y="251.6891"
+       x="1.700698"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+       xml:space="preserve"><tspan
+         style="stroke-width:0.264583"
+         y="251.6891"
+         x="1.700698"
+         id="tspan4098-5-6-6-5"
+         sodipodi:role="line"><tspan
+           style="font-size:3.52778px"
+           id="tspan5415-7-7-3"><tspan
+   id="tspan6580-5-5"
+   style="font-size:6.35px">L</tspan>g</tspan></tspan></text>
+    <path
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       id="path15507"
+       d="m 21.000268,250.54698 h 8.688366"
+       style="fill:none;stroke:#000000;stroke-width:0.23934px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+    <path
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       id="path15509"
+       d="m 21.000268,243.94686 h 8.688366"
+       style="fill:none;stroke:#000000;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+    <text
+       id="text15513"
+       y="248.73111"
+       x="25.765221"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+       xml:space="preserve"><tspan
+         style="stroke-width:0.264583"
+         y="248.73111"
+         x="25.765221"
+         id="tspan15511"
+         sodipodi:role="line">s</tspan></text>
+    <path
+       inkscape:connector-curvature="0"
+       id="path15515"
+       d="m 27.057699,249.05852 v 0.97042"
+       style="fill:none;stroke:#000000;stroke-width:0.276484px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#marker15733)" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path15945"
+       d="m 27.060298,245.50384 v -1.05237"
+       style="fill:none;stroke:#000000;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#marker16235)" />
+  </g>
+  <g
+     style="display:inline"
+     inkscape:label="Annotations_2"
+     id="layer4"
+     inkscape:groupmode="layer"
+     transform="translate(-210.50915,-1.0784224)">
+    <g
+       transform="translate(125.42796,-33.89125)"
+       id="g4116-9-8-2-5"
+       style="display:inline">
+      <g
+         transform="translate(0,0.18708867)"
+         id="g5421-1-7-0">
+        <text
+           id="text4100-8-5-1-8"
+           y="202.24512"
+           x="42.629608"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+           xml:space="preserve"><tspan
+             style="stroke-width:0.264583"
+             y="0"
+             x="0"
+             id="tspan4098-5-6-1-3"
+             sodipodi:role="line"><tspan
+               style="font-size:3.52778px"
+               id="tspan5415-7-3-8"><tspan
+                 id="tspan6615-5-9"
+                 style="font-size:6.35px" /></tspan></tspan></text>
+      </g>
+    </g>
+    <path
+       d="M 340.51411,94.703528 H 325.23796"
+       style="fill:none;stroke:#b3b3b3;stroke-width:0.7;stroke-miterlimit:4;stroke-dasharray:none"
+       id="path1463" />
+    <path
+       d="m 325.23796,90.885498 h 15.27615"
+       style="fill:none;stroke:#b3b3b3;stroke-width:0.7;stroke-miterlimit:4;stroke-dasharray:none"
+       id="path1465" />
+    <path
+       d="m 327.17505,41.117561 -13.22954,7.635858"
+       style="fill:none;stroke:#b3b3b3;stroke-width:0.7;stroke-miterlimit:4;stroke-dasharray:none"
+       id="path1467" />
+    <path
+       d="M 312.03599,45.446937 325.26553,37.81108"
+       style="fill:none;stroke:#b3b3b3;stroke-width:0.7;stroke-miterlimit:4;stroke-dasharray:none"
+       id="path1469" />
+    <path
+       d="m 336.89522,120.4046 a 106.7076,106.6774 0 0 0 3.61889,-25.701072"
+       style="fill:none;stroke:#b3b3b3;stroke-width:0.7;stroke-miterlimit:4;stroke-dasharray:none"
+       id="path1511" />
+    <path
+       d="m 310.20434,92.794508 a 7.6380764,7.6359145 0 0 0 15.03362,1.90902"
+       style="fill:none;stroke:#b3b3b3;stroke-width:0.7;stroke-miterlimit:4;stroke-dasharray:none"
+       id="path1513" />
+    <path
+       d="m 325.23796,90.885498 a 7.6380764,7.6359145 0 0 0 -15.03362,1.90901"
+       style="fill:none;stroke:#b3b3b3;stroke-width:0.7;stroke-miterlimit:4;stroke-dasharray:none"
+       id="path1515-7" />
+    <path
+       d="M 340.51411,90.885498 A 106.7076,106.6774 0 0 0 336.89522,65.184403"
+       style="fill:none;stroke:#b3b3b3;stroke-width:0.7;stroke-miterlimit:4;stroke-dasharray:none"
+       id="path1517" />
+    <path
+       d="m 287.28999,92.794508 a 7.638115,7.6359531 0 0 0 15.27623,0"
+       style="fill:none;stroke:#000000;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none"
+       id="path1519" />
+    <path
+       d="m 302.56622,92.794508 a 7.638115,7.6359531 0 0 0 -15.27623,0"
+       style="fill:none;stroke:#000000;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none"
+       id="path1521" />
+    <path
+       d="M 336.89522,65.184403 A 106.7076,106.6774 0 0 0 327.17505,41.117561"
+       style="fill:none;stroke:#b3b3b3;stroke-width:0.7;stroke-miterlimit:4;stroke-dasharray:none"
+       id="path1523" />
+    <path
+       d="m 299.9712,54.614816 a 7.6380764,7.6359145 0 0 0 13.97431,-5.861397"
+       style="fill:none;stroke:#b3b3b3;stroke-width:0.7;stroke-miterlimit:4;stroke-dasharray:none"
+       id="path1525" />
+    <path
+       d="M 312.03599,45.446937 A 7.6380764,7.6359145 0 0 0 299.9712,54.614816"
+       style="fill:none;stroke:#b3b3b3;stroke-width:0.7;stroke-miterlimit:4;stroke-dasharray:none"
+       id="path1527" />
+    <path
+       d="M 325.26553,37.81108 A 106.7076,106.6774 0 0 0 309.27725,17.362255"
+       style="fill:none;stroke:#b3b3b3;stroke-width:0.7;stroke-miterlimit:4;stroke-dasharray:none"
+       id="path1529" />
+    <path
+       d="M 280.12679,66.068704 A 7.6380941,7.6359322 0 0 0 293.3564,58.432846"
+       style="fill:none;stroke:#b3b3b3;stroke-width:0.7;stroke-miterlimit:4;stroke-dasharray:none"
+       id="path1531" />
+    <path
+       d="m 293.3564,58.432846 a 7.6380941,7.6359322 0 0 0 -13.22961,7.635858"
+       style="fill:none;stroke:#b3b3b3;stroke-width:0.7;stroke-miterlimit:4;stroke-dasharray:none"
+       id="path1533" />
+    <path
+       d="M 309.27725,17.362255 A 106.7076,106.6774 0 0 0 288.82242,1.3783736"
+       style="fill:none;stroke:#b3b3b3;stroke-width:0.7;stroke-miterlimit:4;stroke-dasharray:none"
+       id="path1535" />
+    <path
+       d="m 327.17505,144.47144 a 106.7076,106.6774 0 0 0 9.72017,-24.06684"
+       style="fill:none;stroke:#b3b3b3;stroke-width:0.7;stroke-miterlimit:4;stroke-dasharray:none"
+       id="path1649" />
+    <path
+       d="m 256.7376,92.794508 a 22.914228,22.907742 0 0 0 -45.82845,0"
+       style="fill:none;stroke:#b3b3b3;stroke-width:0.7;stroke-miterlimit:4;stroke-dasharray:none"
+       id="path1655" />
+    <path
+       d="m 210.90915,92.794508 a 22.914228,22.907742 0 0 0 45.82845,0"
+       style="fill:none;stroke:#b3b3b3;stroke-width:0.7;stroke-miterlimit:4;stroke-dasharray:none"
+       id="path1657" />
+    <path
+       d="m 325.4805,92.794508 a 7.6380764,7.6359145 0 0 0 -0.24254,-1.90901"
+       style="fill:none;stroke:#b3b3b3;stroke-width:0.7;stroke-miterlimit:4;stroke-dasharray:none"
+       id="path1659" />
+    <path
+       d="m 325.23796,94.703528 a 7.6380764,7.6359145 0 0 0 0.24254,-1.90902"
+       style="fill:none;stroke:#b3b3b3;stroke-width:0.7;stroke-miterlimit:4;stroke-dasharray:none"
+       id="path1661" />
+    <path
+       d="m 313.2008,46.978958 a 7.6380764,7.6359145 0 0 0 -1.16481,-1.532021"
+       style="fill:none;stroke:#b3b3b3;stroke-width:0.7;stroke-miterlimit:4;stroke-dasharray:none"
+       id="path1663" />
+    <path
+       d="M 313.94551,48.753419 A 7.6380764,7.6359145 0 0 0 313.2008,46.978958"
+       style="fill:none;stroke:#b3b3b3;stroke-width:0.7;stroke-miterlimit:4;stroke-dasharray:none"
+       id="path1665" />
+    <g
+       id="g2547"
+       transform="translate(311.25152,-40.366636)"
+       style="stroke-width:0.8;stroke-miterlimit:4;stroke-dasharray:none">
+      <text
+         xml:space="preserve"
+         style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.23333px;line-height:1.25;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman, Italic';letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.8;stroke-miterlimit:4;stroke-dasharray:none"
+         x="-61.300587"
+         y="137.48808"
+         id="text2537"><tspan
+           sodipodi:role="line"
+           id="tspan2535"
+           x="-61.300587"
+           y="137.48808"
+           style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman, Italic';stroke-width:0.8;stroke-miterlimit:4;stroke-dasharray:none">x</tspan></text>
+      <text
+         xml:space="preserve"
+         style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:10.5833px;line-height:1.25;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman, Italic';letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.8;stroke-miterlimit:4;stroke-dasharray:none"
+         x="-81.795479"
+         y="117.64843"
+         id="text2541"><tspan
+           sodipodi:role="line"
+           id="tspan2539"
+           x="-81.795479"
+           y="117.64843"
+           style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman, Italic';stroke-width:0.8;stroke-miterlimit:4;stroke-dasharray:none">y</tspan></text>
+      <path
+         inkscape:connector-curvature="0"
+         id="path2543"
+         d="m -76.955365,132.96748 h 17.58635"
+         style="fill:none;stroke:#ff0000;stroke-width:0.8;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#marker2579)" />
+      <path
+         inkscape:transform-center-x="8.793175"
+         style="fill:none;stroke:#ff0000;stroke-width:0.8;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#marker2589)"
+         d="M -76.955365,132.96748 V 115.38113"
+         id="path2545"
+         inkscape:connector-curvature="0" />
+    </g>
+  </g>
+</svg>

--- a/mach_cad/model_obj/cross_sects/inner_rotor_round_slots_double_cage/CrossSectInnerRotorRoundSlotsDoubleCagePartial.svg
+++ b/mach_cad/model_obj/cross_sects/inner_rotor_round_slots_double_cage/CrossSectInnerRotorRoundSlotsDoubleCagePartial.svg
@@ -1,0 +1,1569 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   inkscape:export-ydpi="150"
+   inkscape:export-xdpi="150"
+   inkscape:export-filename="C:\Users\nheme\Documents\Research\Bearingless Motor\Bearinless_Parametrization_Rev1_wht_bckgrnd.png"
+   inkscape:version="1.0.1 (3bc2e813f5, 2020-09-07)"
+   sodipodi:docname="CrossSectInnerRotorRoundSlotsDoubleCagePartial.svg"
+   id="svg837"
+   version="1.1"
+   viewBox="0 0 154.32173 84.178518"
+   height="84.17852mm"
+   width="154.32173mm">
+  <defs
+     id="defs831">
+    <marker
+       inkscape:stockid="Arrow1Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker4217"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path4215"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker4207"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mstart">
+      <path
+         transform="matrix(0.4,0,0,0.4,4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path4205" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker3483"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path3481"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker3473"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mstart">
+      <path
+         transform="matrix(0.4,0,0,0.4,4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path3471" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker2589"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path2587"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#ff0000;fill-opacity:1;fill-rule:evenodd;stroke:#ff0000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker2579"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mend">
+      <path
+         transform="matrix(-0.4,0,0,-0.4,-4,0)"
+         style="fill:#ff0000;fill-opacity:1;fill-rule:evenodd;stroke:#ff0000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path2577" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker2569"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path2567"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker2559"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mstart">
+      <path
+         transform="matrix(0.4,0,0,0.4,4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path2557" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker6553"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path6551"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker5313"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mend">
+      <path
+         transform="matrix(-0.4,0,0,-0.4,-4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path5311" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker3363"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path3361"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mstart"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker2957"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path2955"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(0.4,0,0,0.4,4,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mstart"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker4727"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path4725"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(0.4,0,0,0.4,4,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mstart"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker4345"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path4343"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(0.4,0,0,0.4,4,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mstart"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker3969"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path3967"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(0.4,0,0,0.4,4,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mstart"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker3599"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path3597"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(0.4,0,0,0.4,4,0)" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker2905"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow2Send">
+      <path
+         transform="matrix(-0.3,0,0,-0.3,0.69,0)"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         id="path2903" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker3124"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow2Send">
+      <path
+         transform="matrix(-0.3,0,0,-0.3,0.69,0)"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         id="path3122" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow2Send"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker4852"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path4850"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         transform="matrix(-0.3,0,0,-0.3,0.69,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow2Send"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker3691"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path3689"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         transform="matrix(-0.3,0,0,-0.3,0.69,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Sstart"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker3429"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path3427"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(0.2,0,0,0.2,1.2,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow2Send"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker2019"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path2017"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         transform="matrix(-0.3,0,0,-0.3,0.69,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow2Sstart"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker1781"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path1779"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         transform="matrix(0.3,0,0,0.3,-0.69,0)" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker1488"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mend">
+      <path
+         transform="matrix(-0.4,0,0,-0.4,-4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path1486" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker1244"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mend">
+      <path
+         inkscape:connector-curvature="0"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path1242" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow2Send"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker16235"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path16233"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         transform="matrix(-0.3,0,0,-0.3,0.69,0)" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:stockid="Arrow2Send"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker15733"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path15731"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         transform="matrix(-0.3,0,0,-0.3,0.69,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker15525"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path15523"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker9500"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mend">
+      <path
+         transform="matrix(-0.4,0,0,-0.4,-4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path9498" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker8403"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mstart">
+      <path
+         transform="matrix(0.4,0,0,0.4,4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path8401" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker8209"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mend">
+      <path
+         transform="matrix(-0.4,0,0,-0.4,-4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path8207" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker8061"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mstart">
+      <path
+         transform="matrix(0.4,0,0,0.4,4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path8059" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker7820"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path7818"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mstart"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker7684"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path7682"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(0.4,0,0,0.4,4,0)" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:stockid="Arrow1Mstart"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker6757"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path6755"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(0.4,0,0,0.4,4,0)" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:stockid="Arrow1Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker6627"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path6625"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker6012"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mstart">
+      <path
+         transform="matrix(0.4,0,0,0.4,4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path6010" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker5894"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mend">
+      <path
+         transform="matrix(-0.4,0,0,-0.4,-4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path5892" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:stockid="Arrow1Mstart"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker5567"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path5565"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(0.4,0,0,0.4,4,0)" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:stockid="Arrow1Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker5461"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path5459"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:stockid="Arrow1Mstart"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker5080"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path5078"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(0.4,0,0,0.4,4,0)" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker4986"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mend">
+      <path
+         transform="matrix(-0.4,0,0,-0.4,-4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path4984" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker4450"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow2Send">
+      <path
+         transform="matrix(-0.3,0,0,-0.3,0.69,0)"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         id="path4448" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker4374"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path4372"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:stockid="Arrow1Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker4128"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path4126"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker3864"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mend">
+      <path
+         transform="matrix(-0.4,0,0,-0.4,-4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path3862" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="Arrow1Mstart"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mstart">
+      <path
+         transform="matrix(0.4,0,0,0.4,4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path1491" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="Arrow1Sstart"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Sstart">
+      <path
+         transform="matrix(0.2,0,0,0.2,1.2,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path1497" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker1939"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow2Send">
+      <path
+         transform="matrix(-0.3,0,0,-0.3,0.69,0)"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         id="path1937" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="Arrow2Sstart"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow2Sstart">
+      <path
+         transform="matrix(0.3,0,0,0.3,-0.69,0)"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         id="path1515" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="Arrow2Send"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow2Send">
+      <path
+         transform="matrix(-0.3,0,0,-0.3,0.69,0)"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         id="path1518" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="Arrow2Mstart"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow2Mstart">
+      <path
+         transform="scale(0.6)"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         id="path1509" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="Arrow1Mend"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mend">
+      <path
+         transform="matrix(-0.4,0,0,-0.4,-4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path1494" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:stockid="Arrow1Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker4128-8"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path4126-2"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow2Send"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker4852-2"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path4850-0"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         transform="matrix(-0.3,0,0,-0.3,0.69,0)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow2Send"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker4852-2-2"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path4850-0-3"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         transform="matrix(-0.3,0,0,-0.3,0.69,0)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       id="DistanceX"
+       orient="auto"
+       refX="0"
+       refY="0"
+       style="overflow:visible">
+      <path
+         d="M 3,-3 -3,3 M 0,-5 V 5"
+         style="stroke:#000000;stroke-width:0.5"
+         id="path1492" />
+    </marker>
+    <pattern
+       id="Hatch"
+       patternUnits="userSpaceOnUse"
+       width="8"
+       height="8"
+       x="0"
+       y="0">
+      <path
+         d="M8 4 l-4,4"
+         stroke="#000000"
+         stroke-width="0.25"
+         linecap="square"
+         id="path1495" />
+      <path
+         d="M6 2 l-4,4"
+         stroke="#000000"
+         stroke-width="0.25"
+         linecap="square"
+         id="path1497-9" />
+      <path
+         d="M4 0 l-4,4"
+         stroke="#000000"
+         stroke-width="0.25"
+         linecap="square"
+         id="path1499" />
+    </pattern>
+    <marker
+       id="DistanceX-7"
+       orient="auto"
+       refX="0"
+       refY="0"
+       style="overflow:visible">
+      <path
+         d="M 3,-3 -3,3 M 0,-5 V 5"
+         style="stroke:#000000;stroke-width:0.5"
+         id="path1451" />
+    </marker>
+    <pattern
+       id="Hatch-3"
+       patternUnits="userSpaceOnUse"
+       width="8"
+       height="8"
+       x="0"
+       y="0">
+      <path
+         d="M8 4 l-4,4"
+         stroke="#000000"
+         stroke-width="0.25"
+         linecap="square"
+         id="path1454" />
+      <path
+         d="M6 2 l-4,4"
+         stroke="#000000"
+         stroke-width="0.25"
+         linecap="square"
+         id="path1456" />
+      <path
+         d="M4 0 l-4,4"
+         stroke="#000000"
+         stroke-width="0.25"
+         linecap="square"
+         id="path1458" />
+    </pattern>
+    <marker
+       id="DistanceX-78"
+       orient="auto"
+       refX="0"
+       refY="0"
+       style="overflow:visible">
+      <path
+         d="M 3,-3 -3,3 M 0,-5 V 5"
+         style="stroke:#000000;stroke-width:0.5"
+         id="path1509-3" />
+    </marker>
+    <pattern
+       id="Hatch-6"
+       patternUnits="userSpaceOnUse"
+       width="8"
+       height="8"
+       x="0"
+       y="0">
+      <path
+         d="M8 4 l-4,4"
+         stroke="#000000"
+         stroke-width="0.25"
+         linecap="square"
+         id="path1512" />
+      <path
+         d="M6 2 l-4,4"
+         stroke="#000000"
+         stroke-width="0.25"
+         linecap="square"
+         id="path1514" />
+      <path
+         d="M4 0 l-4,4"
+         stroke="#000000"
+         stroke-width="0.25"
+         linecap="square"
+         id="path1516" />
+    </pattern>
+    <symbol
+       id="*Model_Space" />
+    <symbol
+       id="*Paper_Space" />
+    <symbol
+       id="*Paper_Space0" />
+    <marker
+       inkscape:collect="always"
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker1387"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mend">
+      <path
+         transform="matrix(-0.4,0,0,-0.4,-4,0)"
+         style="fill:#ff0000;fill-opacity:1;fill-rule:evenodd;stroke:#ff0000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path1385" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker1741"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path1739"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#ff0000;fill-opacity:1;fill-rule:evenodd;stroke:#ff0000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)" />
+    </marker>
+  </defs>
+  <sodipodi:namedview
+     height="281mm"
+     inkscape:document-rotation="0"
+     inkscape:snap-to-guides="true"
+     inkscape:snap-global="true"
+     inkscape:snap-bbox="false"
+     inkscape:object-paths="true"
+     inkscape:snap-intersection-paths="true"
+     inkscape:snap-object-midpoints="true"
+     inkscape:snap-others="true"
+     inkscape:snap-smooth-nodes="true"
+     inkscape:snap-midpoints="true"
+     inkscape:snap-center="true"
+     inkscape:window-maximized="1"
+     inkscape:window-y="-6"
+     inkscape:window-x="-6"
+     inkscape:window-height="650"
+     inkscape:window-width="1280"
+     inkscape:guide-bbox="true"
+     showguides="false"
+     showborder="true"
+     showgrid="false"
+     inkscape:current-layer="layer4"
+     inkscape:document-units="mm"
+     inkscape:cy="69.047855"
+     inkscape:cx="145.66246"
+     inkscape:zoom="0.7071068"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     borderopacity="1.0"
+     bordercolor="#666666"
+     pagecolor="#ffffff"
+     id="base" />
+  <metadata
+     id="metadata834">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     style="display:none"
+     inkscape:label="Background"
+     id="layer5"
+     inkscape:groupmode="layer"
+     transform="translate(-247.20682,-64.364775)" />
+  <g
+     style="display:none"
+     id="layer1"
+     inkscape:groupmode="layer"
+     inkscape:label="Total_Motor"
+     transform="translate(-247.20682,-64.364775)">
+    <path
+       inkscape:connector-curvature="0"
+       id="path1388"
+       transform="scale(0.26458333)"
+       d="M 0,650.07812 A 472.4409,472.4409 0 0 0 -472.44141,1122.5195 472.4409,472.4409 0 0 0 0,1594.9609 472.4409,472.4409 0 0 0 472.44141,1122.5195 472.4409,472.4409 0 0 0 0,650.07812 Z m -62.580078,131.7168 c 2.119773,-0.0633 4.238058,0.0941 6.103516,0.6543 2.541358,0.7632 4.943413,2.47682 6.457031,4.65625 1.450551,2.08861 2.260179,4.14371 2.77539,6.56445 v 96.20703 l -32.126953,32.12696 v 25.01171 A 192.85715,192.85715 0 0 1 0,929.66211 192.85715,192.85715 0 0 1 79.371094,946.94922 V 922.00391 L 47.244141,889.87695 v -96.1914 c 0.515003,-2.42755 1.32369,-4.487 2.777343,-6.58008 1.513618,-2.17943 3.915677,-3.89305 6.457032,-4.65625 1.645518,-0.49416 3.491159,-0.65631 5.357422,-0.64844 A 347.10338,347.10338 0 0 1 262.25586,895.70703 c 1.75673,2.4167 3.37685,5.15152 4.01758,7.86524 0.60972,2.58247 0.32595,5.51939 -0.80469,7.91992 -1.08536,2.30442 -2.46502,4.03425 -4.30859,5.69336 l -83.3086,48.09765 -43.88476,-11.75781 -21.66211,12.50586 a 192.85715,192.85715 0 0 1 54.71484,60.06055 192.85715,192.85715 0 0 1 24.71485,77.3809 L 213.33789,1091 l 11.75781,-43.8867 83.31055,-48.09963 c 2.35704,-0.76605 4.54514,-1.093 7.08203,-0.88086 2.64428,0.2211 5.33009,1.4444 7.26172,3.26369 1.49012,1.4034 2.72559,3.2743 3.76172,5.248 a 347.10338,347.10338 0 0 1 20.5918,115.875 347.10338,347.10338 0 0 1 -20.0625,114.8164 c -1.13505,2.3551 -2.53462,4.6543 -4.28907,6.3067 -1.93162,1.8193 -4.61553,3.0425 -7.25976,3.2636 -2.5387,0.2123 -4.72893,-0.1155 -7.08789,-0.8828 l -83.3086,-48.0976 -11.75781,-43.8848 -21.66211,-12.5058 a 192.85715,192.85715 0 0 1 -24.65625,77.414 192.85715,192.85715 0 0 1 -54.65625,60.0938 l 21.60352,12.4726 43.88476,-11.7597 83.30664,48.0976 c 1.84358,1.6591 3.22324,3.3889 4.3086,5.6934 1.13066,2.4005 1.41246,5.3374 0.80273,7.9199 -0.38563,1.6333 -1.14266,3.2715 -2.05273,4.8496 A 347.10338,347.10338 0 0 1 63.15625,1463.209 c -2.309571,0.1107 -4.639833,-0.01 -6.673828,-0.6192 -2.541351,-0.7632 -4.94539,-2.4748 -6.458984,-4.6543 -1.45523,-2.0953 -2.264404,-4.1588 -2.779297,-6.5898 v -96.1836 l 32.126953,-32.1269 v -25.0118 A 192.85715,192.85715 0 0 1 0,1315.377 192.85715,192.85715 0 0 1 -79.371094,1298.0898 v 24.9454 l 32.126953,32.1269 v 96.1914 c -0.514998,2.4276 -1.323687,4.489 -2.777343,6.582 -1.513614,2.1795 -3.915681,3.8911 -6.457032,4.6543 -1.645521,0.4942 -3.491159,0.6564 -5.357422,0.6485 A 347.10338,347.10338 0 0 1 -262.22656,1349.3672 c -1.76655,-2.4252 -3.39721,-5.1736 -4.04102,-7.9004 -0.60972,-2.5825 -0.32791,-5.5194 0.80274,-7.9199 1.08656,-2.307 2.46775,-4.0385 4.31445,-5.6992 l 83.29883,-48.0918 43.88476,11.7597 21.66211,-12.5058 a 192.85715,192.85715 0 0 1 -54.71484,-60.0606 192.85715,192.85715 0 0 1 -24.71485,-77.3808 l -21.60351,12.4726 -11.75781,43.8848 -83.31055,48.0996 c -2.35704,0.766 -4.54513,1.093 -7.08203,0.8808 -2.64427,-0.2211 -5.33009,-1.4443 -7.26172,-3.2636 -1.49012,-1.4035 -2.72559,-3.2744 -3.76172,-5.2481 a 347.10338,347.10338 0 0 1 -20.5918,-115.875 347.10338,347.10338 0 0 1 20.04688,-114.7754 c 1.13845,-2.3696 2.54575,-4.6855 4.31055,-6.3476 1.93163,-1.81929 4.61551,-3.04259 7.25976,-3.26369 2.53416,-0.21191 4.7201,0.11466 7.07422,0.87891 l 83.31641,48.10158 11.75781,43.8867 21.66211,12.5059 a 192.85715,192.85715 0 0 1 24.65625,-77.4141 192.85715,192.85715 0 0 1 54.65625,-60.09571 l -21.60352,-12.4707 -43.88476,11.75781 -83.30664,-48.09765 c -1.84358,-1.65911 -3.22324,-3.38894 -4.3086,-5.69336 -1.13063,-2.40057 -1.41246,-5.33745 -0.80273,-7.91992 0.3858,-1.63403 1.14211,-3.27284 2.05273,-4.85157 A 347.10338,347.10338 0 0 1 -63.158203,781.83008 c 0.193318,-0.009 0.38466,-0.0294 0.578125,-0.0352 z"
+       style="opacity:1;fill:#008000;fill-opacity:1;stroke:#000000;stroke-width:3.77953;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+    <circle
+       r="43.733097"
+       cy="297"
+       cx="0"
+       id="path1390"
+       style="opacity:1;fill:#ff0000;fill-opacity:1;stroke:#000000;stroke-width:1.09333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+  </g>
+  <g
+     style="display:none"
+     inkscape:label="Motor_Cutaway"
+     id="layer2"
+     inkscape:groupmode="layer"
+     transform="translate(-247.20682,-64.364775)" />
+  <g
+     style="display:none"
+     inkscape:label="Annotations_1"
+     id="layer3"
+     inkscape:groupmode="layer"
+     transform="translate(-247.20682,-64.364775)">
+    <path
+       inkscape:connector-curvature="0"
+       id="path5884"
+       d="M -7.5563861,234.90369 V 206.70526"
+       style="fill:none;stroke:#000000;stroke-width:0.259632px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-start:url(#marker6012);marker-end:url(#marker5894)" />
+    <rect
+       y="218.84871"
+       x="-8.3674479"
+       height="2.2158854"
+       width="1.5875"
+       id="rect6524"
+       style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.264583;stroke-miterlimit:4;stroke-dasharray:0.79375, 0.264583;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal" />
+    <path
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       id="path1464"
+       d="M -0.02743323,297.01265 35.30925,221.27907"
+       style="fill:none;stroke:#000000;stroke-width:0.202531;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:0.810125, 0.202531;stroke-dashoffset:0;stroke-opacity:1" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.202531;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:0.810125, 0.202531;stroke-dashoffset:0;stroke-opacity:1"
+       d="M 0,297 -35.336683,221.26642"
+       id="path1466"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cc" />
+    <path
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       id="path1470"
+       d="M -21.000268,250.56454 V 221.26642"
+       style="fill:none;stroke:#000000;stroke-width:0.264583;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:0.79375, 0.264583;stroke-dashoffset:0;stroke-opacity:1" />
+    <path
+       sodipodi:nodetypes="csc"
+       inkscape:connector-curvature="0"
+       id="path1482"
+       d="m -11.797594,270.57892 c 3.5813579,-1.66871 7.5752744,-2.60053 11.78682858,-2.60053 4.23356982,0 8.24722062,0.94159 11.84295942,2.62676"
+       style="opacity:1;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.264583;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-start:url(#Arrow2Sstart);marker-end:url(#Arrow2Send);paint-order:normal" />
+    <g
+       transform="translate(-23.187493,-34.196779)"
+       id="g1919">
+      <rect
+         style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.264583;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal"
+         id="rect1907"
+         width="6.160902"
+         height="5.5858846"
+         x="20.12562"
+         y="299.38223" />
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+         x="20.947077"
+         y="304.3931"
+         id="text1895"><tspan
+           sodipodi:role="line"
+           id="tspan1893"
+           x="20.947077"
+           y="304.3931"
+           style="stroke-width:0.264583">θ<tspan
+   style="font-size:3.52778px"
+   id="tspan1897">t</tspan></tspan></text>
+    </g>
+    <flowRoot
+       transform="scale(0.26458333)"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:24px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none"
+       id="flowRoot1899"
+       xml:space="preserve"><flowRegion
+         id="flowRegion1901"><rect
+           y="1122.5197"
+           x="61.473213"
+           height="49.675323"
+           width="50.91721"
+           id="rect1903" /></flowRegion><flowPara
+         id="flowPara1905" /></flowRoot>
+    <path
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       id="path1934"
+       d="m -29.626283,232.40708 c 2.447086,-1.23671 5.213559,-1.9334 8.142751,-1.9334"
+       style="display:inline;opacity:1;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.236671;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-start:url(#Arrow1Sstart);marker-end:url(#marker1939);paint-order:normal" />
+    <rect
+       y="229.11623"
+       x="-27.407322"
+       height="3.6542518"
+       width="3.6240244"
+       id="rect1927"
+       style="display:inline;opacity:1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.13113;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal" />
+    <text
+       id="text1923"
+       y="232.42699"
+       x="-27.561081"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+       xml:space="preserve"><tspan
+         style="stroke-width:0.264583"
+         y="232.42699"
+         x="-27.561081"
+         id="tspan1921"
+         sodipodi:role="line">α</tspan></text>
+    <path
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       id="path3542"
+       d="m 25.501249,208.12668 8.748058,-30.47166"
+       style="fill:none;stroke:#000000;stroke-width:0.251839px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-start:url(#Arrow1Mstart);marker-end:url(#marker3864)" />
+    <text
+       id="text4090"
+       y="162.72395"
+       x="57.811459"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+       xml:space="preserve"><tspan
+         style="stroke-width:0.264583"
+         y="162.72395"
+         x="57.811459"
+         id="tspan4088"
+         sodipodi:role="line" /></text>
+    <path
+       inkscape:connector-curvature="0"
+       id="path3528"
+       d="M -12.500012,236.16224 V 246.8512"
+       style="display:inline;fill:none;stroke:#000000;stroke-width:0.24847px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-start:url(#marker5567);marker-end:url(#marker5461)" />
+    <text
+       id="text4094"
+       y="173.58723"
+       x="-52.318027"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+       xml:space="preserve"><tspan
+         style="stroke-width:0.264583"
+         y="173.58723"
+         x="-52.318027"
+         id="tspan4092"
+         sodipodi:role="line">D<tspan
+   id="tspan4096"
+   style="font-size:3.52778px">os</tspan></tspan></text>
+    <g
+       transform="translate(-16.559098,-7.3212701)"
+       id="g4116">
+      <rect
+         style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:0.237103;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal"
+         id="rect4104"
+         width="6.6424799"
+         height="5.9479485"
+         x="43.113136"
+         y="197.23814" />
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+         x="43.78854"
+         y="202.14687"
+         id="text4100"><tspan
+           sodipodi:role="line"
+           id="tspan4098"
+           x="43.78854"
+           y="202.14687"
+           style="stroke-width:0.264583">T<tspan
+   style="font-size:3.52778px"
+   id="tspan4102">s</tspan></tspan></text>
+    </g>
+    <path
+       sodipodi:nodetypes="ccc"
+       inkscape:connector-curvature="0"
+       id="path4118"
+       d="m -44.334244,171.98437 h 2.000911 l 4.828646,4.82865"
+       style="fill:none;stroke:#000000;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#marker4128)" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path4364"
+       d="m 15.718783,210.03594 -1.547002,-1.79208"
+       style="fill:none;stroke:#000000;stroke-width:0.191617;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:0.383234, 0.191617;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker4450)" />
+    <text
+       id="text4634"
+       y="212.41602"
+       x="15.941146"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+       xml:space="preserve"><tspan
+         style="stroke-width:0.264583"
+         y="212.41602"
+         x="15.941146"
+         id="tspan4632"
+         sodipodi:role="line">r</tspan></text>
+    <path
+       inkscape:connector-curvature="0"
+       id="path4976"
+       d="M -11.547554,219.80781 H 11.547554"
+       style="fill:none;stroke:#000000;stroke-width:0.254303px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-start:url(#marker5080);marker-end:url(#marker4986)" />
+    <g
+       transform="translate(-43.306146,19.473489)"
+       id="g4116-9">
+      <g
+         transform="translate(0,0.18708867)"
+         id="g5421">
+        <rect
+           y="197.24779"
+           x="42.65506"
+           height="5.928659"
+           width="7.7924948"
+           id="rect4104-4"
+           style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:0.256393;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal" />
+        <text
+           id="text4100-8"
+           y="202.70813"
+           x="42.993412"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+           xml:space="preserve"><tspan
+             style="stroke-width:0.264583"
+             y="202.70813"
+             x="42.993412"
+             id="tspan4098-5"
+             sodipodi:role="line">W<tspan
+   style="font-size:3.52778px"
+   id="tspan5415">t</tspan></tspan></text>
+      </g>
+    </g>
+    <path
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       id="path5449"
+       d="m -12.500012,247.56684 h 9.8872516"
+       style="fill:none;stroke:#000000;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+    <path
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       id="path5451"
+       d="m -12.500012,235.4466 h 9.8872516"
+       style="fill:none;stroke:#000000;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+    <path
+       sodipodi:arc-type="arc"
+       style="display:inline;opacity:1;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.265;stroke-miterlimit:4;stroke-dasharray:0.795, 0.265;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal"
+       id="path5875"
+       sodipodi:type="arc"
+       sodipodi:cx="0"
+       sodipodi:cy="296.99997"
+       sodipodi:rx="91.67807"
+       sodipodi:ry="91.67807"
+       sodipodi:start="4.4466291"
+       sodipodi:end="4.5768786"
+       sodipodi:open="true"
+       d="m -24.078562,208.54042 a 91.67807,91.67807 0 0 1 11.693219,-2.37806" />
+    <path
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       id="path5878"
+       d="m -12.500012,213.23104 v -7.0392"
+       style="fill:none;stroke:#000000;stroke-width:0.264583;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:0.79375, 0.264583;stroke-dashoffset:0;stroke-opacity:1" />
+    <path
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       id="path5882"
+       d="m -12.385343,206.16235 h 9.7725826"
+       style="fill:none;stroke:#000000;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+    <g
+       transform="translate(-53.364328,27.478398)"
+       id="g4116-9-8"
+       style="display:inline">
+      <g
+         transform="translate(0,0.18708867)"
+         id="g5421-1">
+        <rect
+           y="197.24779"
+           x="42.65506"
+           height="5.928659"
+           width="7.7924948"
+           id="rect4104-4-4"
+           style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:0.256393;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal" />
+        <text
+           id="text4100-8-5"
+           y="202.17897"
+           x="43.456432"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+           xml:space="preserve"><tspan
+             style="stroke-width:0.264583"
+             y="202.17897"
+             x="43.456432"
+             id="tspan4098-5-6"
+             sodipodi:role="line"><tspan
+               style="font-size:3.52778px"
+               id="tspan5415-7"><tspan
+   id="tspan6615"
+   style="font-size:6.35px">L</tspan>t</tspan></tspan></text>
+      </g>
+    </g>
+    <g
+       transform="translate(-53.364328,40.708055)"
+       id="g4116-9-8-7"
+       style="display:inline">
+      <g
+         transform="translate(0,0.18708867)"
+         id="g5421-1-5">
+        <rect
+           y="197.24779"
+           x="42.65506"
+           height="5.928659"
+           width="7.7924948"
+           id="rect4104-4-4-1"
+           style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:0.256393;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal" />
+        <text
+           id="text4100-8-5-7"
+           y="202.17897"
+           x="43.456432"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+           xml:space="preserve"><tspan
+             style="stroke-width:0.264583"
+             y="202.17897"
+             x="43.456432"
+             id="tspan4098-5-6-6"
+             sodipodi:role="line"><tspan
+               style="font-size:3.52778px"
+               id="tspan5415-7-7"><tspan
+   id="tspan6580-5"
+   style="font-size:6.35px">L</tspan>tt</tspan></tspan></text>
+      </g>
+    </g>
+    <path
+       sodipodi:nodetypes="ccc"
+       inkscape:connector-curvature="0"
+       id="path4118-8"
+       d="m -28.486583,277.7367 h -2.000911 l -4.828646,-4.82865"
+       style="display:inline;fill:none;stroke:#000000;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#marker4128-8)" />
+    <text
+       id="text4094-6"
+       y="279.95316"
+       x="-28.468546"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+       xml:space="preserve"><tspan
+         style="stroke-width:0.264583"
+         y="279.95316"
+         x="-28.468546"
+         id="tspan4092-2"
+         sodipodi:role="line">D<tspan
+   id="tspan4096-9"
+   style="font-size:3.52778px;stroke-width:0.264583">or</tspan></tspan></text>
+    <path
+       inkscape:transform-center-y="-47.336963"
+       inkscape:transform-center-x="-0.53635573"
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       id="path6617"
+       d="m 0.49341607,252.4546 0.0643483,-5.62927"
+       style="display:inline;fill:none;stroke:#000000;stroke-width:0.204665px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-start:url(#marker6757);marker-end:url(#marker6627)" />
+    <text
+       id="text4100-8-5-7-6"
+       y="251.6891"
+       x="1.700698"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+       xml:space="preserve"><tspan
+         style="stroke-width:0.264583"
+         y="251.6891"
+         x="1.700698"
+         id="tspan4098-5-6-6-5"
+         sodipodi:role="line"><tspan
+           style="font-size:3.52778px"
+           id="tspan5415-7-7-3"><tspan
+   id="tspan6580-5-5"
+   style="font-size:6.35px">L</tspan>g</tspan></tspan></text>
+    <path
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       id="path15507"
+       d="m 21.000268,250.54698 h 8.688366"
+       style="fill:none;stroke:#000000;stroke-width:0.23934px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+    <path
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       id="path15509"
+       d="m 21.000268,243.94686 h 8.688366"
+       style="fill:none;stroke:#000000;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+    <text
+       id="text15513"
+       y="248.73111"
+       x="25.765221"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+       xml:space="preserve"><tspan
+         style="stroke-width:0.264583"
+         y="248.73111"
+         x="25.765221"
+         id="tspan15511"
+         sodipodi:role="line">s</tspan></text>
+    <path
+       inkscape:connector-curvature="0"
+       id="path15515"
+       d="m 27.057699,249.05852 v 0.97042"
+       style="fill:none;stroke:#000000;stroke-width:0.276484px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#marker15733)" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path15945"
+       d="m 27.060298,245.50384 v -1.05237"
+       style="fill:none;stroke:#000000;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#marker16235)" />
+  </g>
+  <g
+     style="display:inline"
+     inkscape:label="Annotations_2"
+     id="layer4"
+     inkscape:groupmode="layer"
+     transform="translate(-247.20682,-64.364775)">
+    <g
+       transform="translate(125.42796,-33.89125)"
+       id="g4116-9-8-2-5"
+       style="display:inline">
+      <g
+         transform="translate(0,0.18708867)"
+         id="g5421-1-7-0">
+        <text
+           id="text4100-8-5-1-8"
+           y="202.24512"
+           x="42.629608"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+           xml:space="preserve"><tspan
+             style="stroke-width:0.264583"
+             y="0"
+             x="0"
+             id="tspan4098-5-6-1-3"
+             sodipodi:role="line"><tspan
+               style="font-size:3.52778px"
+               id="tspan5415-7-3-8"><tspan
+                 id="tspan6615-5-9"
+                 style="font-size:6.35px" /></tspan></tspan></text>
+      </g>
+    </g>
+    <g
+       id="g1580"
+       transform="matrix(3.0180942,0,0,3.0514018,241.79544,-3318.8046)"
+       style="stroke-width:0.263617;stroke-miterlimit:4;stroke-dasharray:none">
+      <g
+         inkscape:label="0"
+         id="g1524"
+         style="stroke-width:0.263617;stroke-miterlimit:4;stroke-dasharray:none" />
+      <g
+         inkscape:label="RotorCore"
+         id="g1548"
+         style="stroke-width:0.263617;stroke-miterlimit:4;stroke-dasharray:none">
+        <path
+           d="M 52.79337,1123.4646 H 45.234315"
+           style="fill:none;stroke:#000000;stroke-width:0.263617;stroke-miterlimit:4;stroke-dasharray:none"
+           id="path1526" />
+        <path
+           d="M 45.234315,1121.5748 H 52.79337"
+           style="fill:none;stroke:#000000;stroke-width:0.263617;stroke-miterlimit:4;stroke-dasharray:none"
+           id="path1528" />
+        <path
+           d="M 51.002646,1136.1858 10.95223,1125.4543"
+           style="fill:none;stroke:#000000;stroke-width:0.263617;stroke-miterlimit:4;stroke-dasharray:none"
+           id="path1530" />
+        <path
+           d="M 51.002646,1108.8536 10.95223,1119.585"
+           style="fill:none;stroke:#000000;stroke-width:0.263617;stroke-miterlimit:4;stroke-dasharray:none"
+           id="path1532" />
+        <path
+           d="m 51.002646,1136.1858 a 52.801825,52.801825 0 0 0 1.790724,-12.7212"
+           style="fill:none;stroke:#000000;stroke-width:0.263617;stroke-miterlimit:4;stroke-dasharray:none"
+           id="path1534" />
+        <path
+           d="m 37.795276,1122.5197 a 3.779528,3.779528 0 0 0 7.439039,0.9449"
+           style="fill:none;stroke:#000000;stroke-width:0.263617;stroke-miterlimit:4;stroke-dasharray:none"
+           id="path1536" />
+        <path
+           d="m 45.234315,1121.5748 a 3.779528,3.779528 0 0 0 -7.439039,0.9449"
+           style="fill:none;stroke:#000000;stroke-width:0.263617;stroke-miterlimit:4;stroke-dasharray:none"
+           id="path1538" />
+        <path
+           d="m 52.79337,1121.5748 a 52.801825,52.801825 0 0 0 -1.790724,-12.7212"
+           style="fill:none;stroke:#000000;stroke-width:0.263617;stroke-miterlimit:4;stroke-dasharray:none"
+           id="path1540" />
+        <path
+           d="m 26.456693,1122.5197 a 3.779528,3.779528 0 0 0 7.559055,0"
+           style="fill:none;stroke:#000000;stroke-width:0.263617;stroke-miterlimit:4;stroke-dasharray:none"
+           id="path1542" />
+        <path
+           d="m 34.015748,1122.5197 a 3.779528,3.779528 0 0 0 -7.559055,0"
+           style="fill:none;stroke:#000000;stroke-width:0.263617;stroke-miterlimit:4;stroke-dasharray:none"
+           id="path1544" />
+        <path
+           d="m 10.95223,1125.4543 a 11.338583,11.338583 0 0 0 0,-5.8693"
+           style="fill:none;stroke:#000000;stroke-width:0.263617;stroke-miterlimit:4;stroke-dasharray:none"
+           id="path1546" />
+      </g>
+    </g>
+    <text
+       xml:space="preserve"
+       style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.23333px;line-height:1.25;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman, Italic';letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+       x="269.86362"
+       y="108.92393"
+       id="text2115"><tspan
+         sodipodi:role="line"
+         id="tspan2113"
+         x="269.86362"
+         y="108.92393"
+         style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman, Italic';stroke-width:0.264583">x</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:10.5833px;line-height:1.25;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman, Italic';letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+       x="247.71532"
+       y="86.372345"
+       id="text2145"><tspan
+         sodipodi:role="line"
+         id="tspan2143"
+         x="247.71532"
+         y="86.372345"
+         style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman, Italic';stroke-width:0.264583">y</tspan></text>
+    <g
+       style="display:inline;stroke:#ff0000"
+       id="g2173"
+       transform="rotate(90,220.49243,326.94631)">
+      <path
+         inkscape:connector-curvature="0"
+         id="path1377"
+         d="M 0,297 V 279.41365"
+         style="fill:none;stroke:#ff0000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#marker1387)" />
+      <path
+         inkscape:transform-center-x="8.793175"
+         style="fill:none;stroke:#ff0000;stroke-width:0.5;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#marker1741)"
+         d="M 0,297 H -17.58635"
+         id="path1737"
+         inkscape:connector-curvature="0" />
+    </g>
+  </g>
+</svg>

--- a/mach_cad/model_obj/cross_sects/inner_rotor_round_slots_double_cage/__init__.py
+++ b/mach_cad/model_obj/cross_sects/inner_rotor_round_slots_double_cage/__init__.py
@@ -1,0 +1,532 @@
+import numpy as np
+
+from ...dimensions import DimRadian
+from ...dimensions import DimMillimeter
+from ...dimensions.dim_linear import DimLinear
+
+from ..cross_sect_base import CrossSectBase, CrossSectToken
+
+__all__ = ['CrossSectInnerRotorRoundSlotsDoubleCage', 
+        'CrossSectInnerRotorRoundSlotsDoubleCagePartial', 
+        'CrossSectInnerRotorRoundSlotsDoubleCageBar1',
+        'CrossSectInnerRotorRoundSlotsDoubleCageBar2'
+        ]
+
+
+class CrossSectInnerRotorRoundSlotsDoubleCage(CrossSectBase):
+
+    def __init__(self, **kwargs: any) -> None:
+        '''
+        Intialization function for CrossSectInnerRotorRoundSlotsDoubleCage class. This function takes in
+        arguments and saves the information passed to private variable to make
+        them read-only
+        Parameters
+        ----------
+        **kwargs : any
+            DESCRIPTION. Keyword arguments provided to the initialization function.
+            The following argument names have to be included in order for the code
+            to execute:  name, dim_l, dim_t, dim_theta, location.
+            
+        Returns
+        -------
+        None
+        '''
+        self._create_attr(kwargs)
+
+        super()._validate_attr()
+        self._validate_attr()
+
+    @property
+    def dim_r_ri(self):
+        return self._dim_r_ri
+
+    @property
+    def dim_d_ri(self):
+        return self._dim_d_ri
+
+    @property
+    def dim_d_rb(self):
+        return self._dim_d_rb
+
+    @property
+    def dim_r_rb(self):
+        return self._dim_r_rb
+
+    @property
+    def dim_d_so(self):
+        return self._dim_d_so
+
+    @property
+    def dim_w_so(self):
+        return self._dim_w_so
+
+    @property
+    def Qr(self):
+        return self._Qr
+
+    def draw(self, drawer):
+
+        r_ri = self.dim_r_ri
+        d_ri = self.dim_d_ri
+        d_rb = self.dim_d_rb
+        r_rb = self.dim_r_rb
+        d_so = self.dim_d_so
+        w_so = self.dim_w_so
+        Qr = self.Qr
+
+        alpha_u = DimRadian(2 * np.pi / Qr)
+        r1 = r_ri + d_ri + r_rb * 2 + d_rb + r_rb + DimMillimeter(np.sqrt(r_rb ** 2 - (w_so / 2) ** 2)) + d_so
+        r2 = w_so / 2
+        r_ro = DimMillimeter(np.sqrt(r1 ** 2 + r2 ** 2))
+
+        x1 = r_ro * np.cos(alpha_u / 2)
+        y1 = - r_ro * np.sin(alpha_u / 2)
+
+        x2 = DimMillimeter(np.sqrt(r_ro ** 2 - (w_so / 2) ** 2))
+        y2 = - w_so / 2
+
+        x3 = x2 - d_so
+        y3 = y2
+
+        x4 = r_ri + d_ri + r_rb * 2 + d_rb
+        y4 = DimMillimeter(0)
+
+        x5 = x3
+        y5 = - y3
+
+        x6 = x2
+        y6 = - y2
+
+        x7 = x1
+        y7 = - y1
+
+        center_rotor_bar1 = [(x4 + r_rb), DimMillimeter(0)]
+
+        x8 = r_ri + d_ri + r_rb * 2
+        y8 = DimMillimeter(0)
+
+        x9 = r_ri + d_ri
+        y9 = DimMillimeter(0)
+
+        center_rotor_bar2 = [(r_ri + d_ri + r_rb), DimMillimeter(0)]
+
+        x_arr = [x1, x2, x3, x4, x5, x6, x7, center_rotor_bar1[0], x8, x9, center_rotor_bar2[0]]
+        y_arr = [y1, y2, y3, y4, y5, y6, y7, center_rotor_bar1[1], y8, y9, center_rotor_bar2[1]]
+
+        arc1 = []
+        arc2 = []
+        arc3 = []
+        arc4 = []
+        arc5 = []
+        arc6 = []
+        arc7 = []
+        arc8 = []
+        seg1 = []
+        seg2 = []
+
+        # transpose list
+        coords = [x_arr, y_arr]
+        coords = list(zip(*coords))
+        coords = [list(sublist) for sublist in coords]
+
+        for i in range(0, Qr):
+            p = self.location.transform_coords(coords, alpha_u * i)
+
+            arc1.append(drawer.draw_arc(self.location.anchor_xy, p[0], p[1]))
+            seg1.append(drawer.draw_line(p[1], p[2]))
+            arc2.append(drawer.draw_arc(p[7], p[3], p[2]))
+            arc3.append(drawer.draw_arc(p[7], p[4], p[3]))
+            seg2.append(drawer.draw_line(p[4], p[5]))
+            arc4.append(drawer.draw_arc(self.location.anchor_xy, p[5], p[6]))
+            arc7.append(drawer.draw_arc(p[10], p[9], p[8]))
+            arc8.append(drawer.draw_arc(p[10], p[8], p[9]))
+
+        arc5.append(drawer.draw_arc(self.location.anchor_xy,
+            [r_ri, DimMillimeter(0)], [- r_ri, DimMillimeter(0)]))
+        arc6.append(drawer.draw_arc(self.location.anchor_xy,
+            [- r_ri, DimMillimeter(0)], [r_ri, DimMillimeter(0)]))
+
+        rad = (r_ri + x9) / 2
+        inner_coord = self.location.transform_coords([[rad, 0]])
+        segments = [arc1, seg1, arc2, arc3, seg2, arc4, arc5, arc6, arc7, arc8]
+        segs = [x for segment in segments for x in segment]
+        cs_token = CrossSectToken(inner_coord[0], segs)
+        return cs_token
+
+    def _validate_attr(self):
+
+        if isinstance(self._dim_r_ri, DimLinear):
+            pass
+        else:
+            raise TypeError("dim_r_ri not of type DimLinear")
+
+        if isinstance(self._dim_d_ri, DimLinear):
+            pass
+        else:
+            raise TypeError("dim_d_ri not of type DimLinear")
+
+        if isinstance(self._dim_d_rb, DimLinear):
+            pass
+        else:
+            raise TypeError("dim_d_rb not of type DimLinear")
+
+        if isinstance(self._dim_r_rb, DimLinear):
+            pass
+        else:
+            raise TypeError("dim_r_rb not of type DimLinear")
+
+        if isinstance(self._dim_d_so, DimLinear):
+            pass
+        else:
+            raise TypeError("dim_d_so not of type DimLinear")
+
+        if isinstance(self._dim_w_so, DimLinear):
+            pass
+        else:
+            raise TypeError("dim_w_so not of type DimLinear")
+
+        if isinstance(self._Qr, int):
+            pass
+        else:
+            raise TypeError("Qr not of type int")
+
+class CrossSectInnerRotorRoundSlotsDoubleCagePartial(CrossSectBase):
+
+    def __init__(self, **kwargs: any) -> None:
+        '''
+        Intialization function for CrossSectInnerRotorRoundSlotsDoubleCagePartial class. This function takes in
+        arguments and saves the information passed to private variable to make
+        them read-only
+        Parameters
+        ----------
+        **kwargs : any
+            DESCRIPTION. Keyword arguments provided to the initialization function.
+            The following argument names have to be included in order for the code
+            to execute:  name, dim_l, dim_t, dim_theta, location.
+            
+        Returns
+        -------
+        None
+        '''
+        self._create_attr(kwargs)
+
+        super()._validate_attr()
+        self._validate_attr()
+
+    @property
+    def dim_r_ri(self):
+        return self._dim_r_ri
+
+    @property
+    def dim_d_ri(self):
+        return self._dim_d_ri
+
+    @property
+    def dim_d_rb(self):
+        return self._dim_d_rb
+
+    @property
+    def dim_r_rb(self):
+        return self._dim_r_rb
+
+    @property
+    def dim_d_so(self):
+        return self._dim_d_so
+
+    @property
+    def dim_w_so(self):
+        return self._dim_w_so
+
+    @property
+    def Qr(self):
+        return self._Qr
+
+    def draw(self, drawer):
+
+        r_ri = self.dim_r_ri
+        d_ri = self.dim_d_ri
+        d_rb = self.dim_d_rb
+        r_rb = self.dim_r_rb
+        d_so = self.dim_d_so
+        w_so = self.dim_w_so
+        Qr = self.Qr
+
+        alpha_u = DimRadian(2 * np.pi / Qr)
+        r1 = r_ri + d_ri + r_rb * 2 + d_rb + r_rb + DimMillimeter(np.sqrt(r_rb ** 2 - (w_so / 2) ** 2)) + d_so
+        r2 = w_so / 2
+        r_ro = DimMillimeter(np.sqrt(r1 ** 2 + r2 ** 2))
+
+        x1 = r_ro * np.cos(alpha_u / 2)
+        y1 = - r_ro * np.sin(alpha_u / 2)
+
+        x2 = DimMillimeter(np.sqrt(r_ro ** 2 - (w_so / 2) ** 2))
+        y2 = - w_so / 2
+
+        x3 = x2 - d_so
+        y3 = y2
+
+        x4 = r_ri + d_ri + r_rb * 2 + d_rb
+        y4 = DimMillimeter(0)
+
+        x5 = x3
+        y5 = - y3
+
+        x6 = x2
+        y6 = - y2
+
+        x7 = x1
+        y7 = - y1
+
+        center_rotor_bar1 = [(x4 + r_rb), DimMillimeter(0)]
+
+        x8 = r_ri + d_ri + r_rb * 2
+        y8 = DimMillimeter(0)
+
+        x9 = r_ri + d_ri
+        y9 = DimMillimeter(0)
+
+        center_rotor_bar2 = [(r_ri + d_ri + r_rb), DimMillimeter(0)]
+
+        x_arr = [x1, x2, x3, x4, x5, x6, x7, center_rotor_bar1[0], x8, x9, center_rotor_bar2[0]]
+        y_arr = [y1, y2, y3, y4, y5, y6, y7, center_rotor_bar1[1], y8, y9, center_rotor_bar2[1]]
+
+        arc1 = []
+        arc2 = []
+        arc3 = []
+        arc4 = []
+        arc5 = []
+        arc6 = []
+        arc7 = []
+        seg1 = []
+        seg2 = []
+        seg3 = []
+        seg4 = []
+
+        # transpose list
+        coords = [x_arr, y_arr]
+        coords = list(zip(*coords))
+        coords = [list(sublist) for sublist in coords]
+
+        p = self.location.transform_coords(coords, 0)
+
+        arc1.append(drawer.draw_arc(self.location.anchor_xy, p[0], p[1]))
+        seg1.append(drawer.draw_line(p[1], p[2]))
+        arc2.append(drawer.draw_arc(p[7], p[3], p[2]))
+        arc3.append(drawer.draw_arc(p[7], p[4], p[3]))
+        seg2.append(drawer.draw_line(p[4], p[5]))
+        arc4.append(drawer.draw_arc(self.location.anchor_xy, p[5], p[6]))
+        arc6.append(drawer.draw_arc(p[10], p[9], p[8]))
+        arc7.append(drawer.draw_arc(p[10], p[8], p[9]))
+
+        x10 = r_ri * np.cos(alpha_u / 2)
+        y10 = - r_ri * np.sin(alpha_u / 2)
+        x11 = x10
+        y11 = - y10
+        arc5.append(drawer.draw_arc(self.location.anchor_xy,
+            [x10, y10], [x11, y11]))
+        seg3.append(drawer.draw_line(p[0], [x10, y10]))
+        seg4.append(drawer.draw_line(p[6], [x11, y11]))   
+
+        rad = (r_ri + x9) / 2
+        inner_coord = self.location.transform_coords([[rad, 0]])
+        segments = [arc1, seg1, arc2, arc3, seg2, arc4, arc5, arc6, arc7, seg3, seg4]
+        segs = [x for segment in segments for x in segment]
+        cs_token = CrossSectToken(inner_coord[0], segs)
+        return cs_token
+
+    def _validate_attr(self):
+
+        if isinstance(self._dim_r_ri, DimLinear):
+            pass
+        else:
+            raise TypeError("dim_r_ri not of type DimLinear")
+
+        if isinstance(self._dim_d_ri, DimLinear):
+            pass
+        else:
+            raise TypeError("dim_d_ri not of type DimLinear")
+
+        if isinstance(self._dim_d_rb, DimLinear):
+            pass
+        else:
+            raise TypeError("dim_d_rb not of type DimLinear")
+
+        if isinstance(self._dim_r_rb, DimLinear):
+            pass
+        else:
+            raise TypeError("dim_r_rb not of type DimLinear")
+
+        if isinstance(self._dim_d_so, DimLinear):
+            pass
+        else:
+            raise TypeError("dim_d_so not of type DimLinear")
+
+        if isinstance(self._dim_w_so, DimLinear):
+            pass
+        else:
+            raise TypeError("dim_w_so not of type DimLinear")
+
+        if isinstance(self._Qr, int):
+            pass
+        else:
+            raise TypeError("Qr not of type int")
+
+
+class CrossSectInnerRotorRoundSlotsDoubleCageBar1(CrossSectBase):
+
+    def __init__(self, **kwargs: any) -> None:
+        '''
+        Intialization function for RoundBar class. This function takes in
+        arguments and saves the information passed to private variable to make
+        them read-only
+        Parameters
+        ----------
+        **kwargs : any
+            DESCRIPTION. Keyword arguments provided to the initialization function.
+            The following argument names have to be included in order for the code
+            to execute: name, dim_t, dim_r_o, location. 
+            
+        Returns
+        -------
+        None
+        '''
+        self._create_attr(kwargs)
+
+        super()._validate_attr()
+        self._validate_attr()
+
+    @property
+    def rotor_core(self):
+        return self._rotor_core
+
+    def draw(self, drawer):
+
+        r_ri = self.rotor_core.dim_r_ri
+        d_ri = self.rotor_core.dim_d_ri
+        d_rb = self.rotor_core.dim_d_rb
+        r_rb = self.rotor_core.dim_r_rb
+        Qr = self.rotor_core.Qr
+
+        alpha_u = DimRadian(2 * np.pi / Qr)
+        r_b = r_ri + d_ri + r_rb * 2 + d_rb + r_rb
+
+        x1 = r_b + r_rb
+        y1 = DimMillimeter(0)
+
+        x2 = r_b - r_rb
+        y2 = DimMillimeter(0)
+
+        center_rotor_bar1 = [r_b, DimMillimeter(0)]
+
+        x_arr = [x1, x2, center_rotor_bar1[0]]
+        y_arr = [y1, y2, center_rotor_bar1[1]]
+
+        arc1 = []
+        arc2 = []
+
+        # transpose list
+        coords = [x_arr, y_arr]
+        coords = list(zip(*coords))
+        coords = [list(sublist) for sublist in coords]
+
+        p = self.location.transform_coords(coords, 0)
+
+        arc1.append(drawer.draw_arc(p[2], p[0], p[1]))
+        arc1.append(drawer.draw_arc(p[2], p[1], p[0]))
+
+        inner_coord = self.location.transform_coords([center_rotor_bar1])
+        segments = [arc1, arc2]
+        segs = [x for segment in segments for x in segment]
+        cs_token = CrossSectToken(inner_coord[0], segs)
+
+        return cs_token
+
+    def _validate_attr(self):
+
+        if (
+            isinstance(self.rotor_core, CrossSectInnerRotorRoundSlotsDoubleCage) or
+            isinstance(self.rotor_core, CrossSectInnerRotorRoundSlotsDoubleCagePartial)
+        ):
+            pass
+        else:
+            raise TypeError("rotor_core not of type CrossSectInnerRotorRoundSlotsDoubleCage")
+
+
+class CrossSectInnerRotorRoundSlotsDoubleCageBar2(CrossSectBase):
+
+    def __init__(self, **kwargs: any) -> None:
+        '''
+        Intialization function for RoundBar class. This function takes in
+        arguments and saves the information passed to private variable to make
+        them read-only
+        Parameters
+        ----------
+        **kwargs : any
+            DESCRIPTION. Keyword arguments provided to the initialization function.
+            The following argument names have to be included in order for the code
+            to execute: name, dim_t, dim_r_o, location. 
+            
+        Returns
+        -------
+        None
+        '''
+        self._create_attr(kwargs)
+
+        super()._validate_attr()
+        self._validate_attr()
+
+    @property
+    def rotor_core(self):
+        return self._rotor_core
+
+    def draw(self, drawer):
+
+        r_ri = self.rotor_core.dim_r_ri
+        d_ri = self.rotor_core.dim_d_ri
+        d_rb = self.rotor_core.dim_d_rb
+        r_rb = self.rotor_core.dim_r_rb
+        Qr = self.rotor_core.Qr
+
+        alpha_u = DimRadian(2 * np.pi / Qr)
+        r_b = r_ri + d_ri + r_rb
+
+        x1 = r_b + r_rb
+        y1 = DimMillimeter(0)
+
+        x2 = r_b - r_rb
+        y2 = DimMillimeter(0)
+
+        center_rotor_bar1 = [r_b, DimMillimeter(0)]
+
+        x_arr = [x1, x2, center_rotor_bar1[0]]
+        y_arr = [y1, y2, center_rotor_bar1[1]]
+
+        arc1 = []
+        arc2 = []
+
+        # transpose list
+        coords = [x_arr, y_arr]
+        coords = list(zip(*coords))
+        coords = [list(sublist) for sublist in coords]
+
+        p = self.location.transform_coords(coords, 0)
+
+        arc1.append(drawer.draw_arc(p[2], p[0], p[1]))
+        arc1.append(drawer.draw_arc(p[2], p[1], p[0]))
+
+        inner_coord = self.location.transform_coords([center_rotor_bar1])
+        segments = [arc1, arc2]
+        segs = [x for segment in segments for x in segment]
+        cs_token = CrossSectToken(inner_coord[0], segs)
+
+        return cs_token
+
+    def _validate_attr(self):
+
+        if (
+            isinstance(self.rotor_core, CrossSectInnerRotorRoundSlotsDoubleCage) or
+            isinstance(self.rotor_core, CrossSectInnerRotorRoundSlotsDoubleCagePartial)
+        ):
+            pass
+        else:
+            raise TypeError("rotor_core not of type CrossSectInnerRotorRoundSlotsDoubleCage")

--- a/mach_cad/model_obj/cross_sects/inner_rotor_stator/CrossSectInnerRotorStatorLeftSlot.svg
+++ b/mach_cad/model_obj/cross_sects/inner_rotor_stator/CrossSectInnerRotorStatorLeftSlot.svg
@@ -1,0 +1,1401 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   inkscape:export-ydpi="150"
+   inkscape:export-xdpi="150"
+   inkscape:export-filename="C:\Users\nheme\Documents\Research\Bearingless Motor\Bearinless_Parametrization_Rev1_wht_bckgrnd.png"
+   inkscape:version="1.0.1 (3bc2e813f5, 2020-09-07)"
+   sodipodi:docname="CrossSectInnerRotorStatorLeftSlot.svg"
+   id="svg837"
+   version="1.1"
+   viewBox="0 0 180 243"
+   height="243mm"
+   width="180mm">
+  <defs
+     id="defs831">
+    <marker
+       inkscape:stockid="Arrow1Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker3363"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path3361"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mstart"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker2957"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path2955"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(0.4,0,0,0.4,4,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker2473"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path2471"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker2091"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mstart">
+      <path
+         transform="matrix(0.4,0,0,0.4,4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path2089" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mstart"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker4727"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path4725"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(0.4,0,0,0.4,4,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mstart"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker4345"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path4343"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(0.4,0,0,0.4,4,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mstart"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker3969"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path3967"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(0.4,0,0,0.4,4,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mstart"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker3599"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path3597"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(0.4,0,0,0.4,4,0)" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker2905"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow2Send">
+      <path
+         transform="matrix(-0.3,0,0,-0.3,0.69,0)"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         id="path2903" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker3124"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow2Send">
+      <path
+         transform="matrix(-0.3,0,0,-0.3,0.69,0)"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         id="path3122" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker1741"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path1739"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#ff0000;fill-opacity:1;fill-rule:evenodd;stroke:#ff0000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker1387"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mend">
+      <path
+         transform="matrix(-0.4,0,0,-0.4,-4,0)"
+         style="fill:#ff0000;fill-opacity:1;fill-rule:evenodd;stroke:#ff0000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path1385" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow2Send"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker4852"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path4850"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         transform="matrix(-0.3,0,0,-0.3,0.69,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow2Send"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker3691"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path3689"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         transform="matrix(-0.3,0,0,-0.3,0.69,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Sstart"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker3429"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path3427"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(0.2,0,0,0.2,1.2,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow2Send"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker2019"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path2017"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         transform="matrix(-0.3,0,0,-0.3,0.69,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow2Sstart"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker1781"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path1779"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         transform="matrix(0.3,0,0,0.3,-0.69,0)" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker1488"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mend">
+      <path
+         transform="matrix(-0.4,0,0,-0.4,-4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path1486" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker1244"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mend">
+      <path
+         inkscape:connector-curvature="0"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path1242" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow2Send"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker16235"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path16233"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         transform="matrix(-0.3,0,0,-0.3,0.69,0)" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:stockid="Arrow2Send"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker15733"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path15731"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         transform="matrix(-0.3,0,0,-0.3,0.69,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker15525"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path15523"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker9500"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mend">
+      <path
+         transform="matrix(-0.4,0,0,-0.4,-4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path9498" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker8403"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mstart">
+      <path
+         transform="matrix(0.4,0,0,0.4,4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path8401" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker8209"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mend">
+      <path
+         transform="matrix(-0.4,0,0,-0.4,-4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path8207" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker8061"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mstart">
+      <path
+         transform="matrix(0.4,0,0,0.4,4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path8059" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker7820"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path7818"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mstart"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker7684"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path7682"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(0.4,0,0,0.4,4,0)" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:stockid="Arrow1Mstart"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker6757"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path6755"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(0.4,0,0,0.4,4,0)" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:stockid="Arrow1Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker6627"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path6625"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker6012"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mstart">
+      <path
+         transform="matrix(0.4,0,0,0.4,4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path6010" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker5894"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mend">
+      <path
+         transform="matrix(-0.4,0,0,-0.4,-4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path5892" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:stockid="Arrow1Mstart"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker5567"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path5565"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(0.4,0,0,0.4,4,0)" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:stockid="Arrow1Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker5461"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path5459"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:stockid="Arrow1Mstart"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker5080"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path5078"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(0.4,0,0,0.4,4,0)" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker4986"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mend">
+      <path
+         transform="matrix(-0.4,0,0,-0.4,-4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path4984" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker4450"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow2Send">
+      <path
+         transform="matrix(-0.3,0,0,-0.3,0.69,0)"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         id="path4448" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker4374"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path4372"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:stockid="Arrow1Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker4128"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path4126"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker3864"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mend">
+      <path
+         transform="matrix(-0.4,0,0,-0.4,-4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path3862" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="Arrow1Mstart"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mstart">
+      <path
+         transform="matrix(0.4,0,0,0.4,4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path1491" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="Arrow1Sstart"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Sstart">
+      <path
+         transform="matrix(0.2,0,0,0.2,1.2,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path1497" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker1939"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow2Send">
+      <path
+         transform="matrix(-0.3,0,0,-0.3,0.69,0)"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         id="path1937" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="Arrow2Sstart"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow2Sstart">
+      <path
+         transform="matrix(0.3,0,0,0.3,-0.69,0)"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         id="path1515" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="Arrow2Send"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow2Send">
+      <path
+         transform="matrix(-0.3,0,0,-0.3,0.69,0)"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         id="path1518" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="Arrow2Mstart"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow2Mstart">
+      <path
+         transform="scale(0.6)"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         id="path1509" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="Arrow1Mend"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mend">
+      <path
+         transform="matrix(-0.4,0,0,-0.4,-4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path1494" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:stockid="Arrow1Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker4128-8"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path4126-2"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow2Send"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker4852-2"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path4850-0"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         transform="matrix(-0.3,0,0,-0.3,0.69,0)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow2Send"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker4852-2-2"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path4850-0-3"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         transform="matrix(-0.3,0,0,-0.3,0.69,0)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       id="DistanceX"
+       orient="auto"
+       refX="0.0"
+       refY="0.0"
+       style="overflow:visible">
+      <path
+         d="M 3,-3 L -3,3 M 0,-5 L  0,5"
+         style="stroke:#000000; stroke-width:0.5"
+         id="path1483" />
+    </marker>
+    <pattern
+       id="Hatch"
+       patternUnits="userSpaceOnUse"
+       width="8"
+       height="8"
+       x="0"
+       y="0">
+      <path
+         d="M8 4 l-4,4"
+         stroke="#000000"
+         stroke-width="0.25"
+         linecap="square"
+         id="path1486-4" />
+      <path
+         d="M6 2 l-4,4"
+         stroke="#000000"
+         stroke-width="0.25"
+         linecap="square"
+         id="path1488" />
+      <path
+         d="M4 0 l-4,4"
+         stroke="#000000"
+         stroke-width="0.25"
+         linecap="square"
+         id="path1490" />
+    </pattern>
+  </defs>
+  <sodipodi:namedview
+     height="281mm"
+     inkscape:document-rotation="0"
+     inkscape:snap-to-guides="true"
+     inkscape:snap-global="true"
+     inkscape:snap-bbox="false"
+     inkscape:object-paths="true"
+     inkscape:snap-intersection-paths="true"
+     inkscape:snap-object-midpoints="true"
+     inkscape:snap-others="true"
+     inkscape:snap-smooth-nodes="true"
+     inkscape:snap-midpoints="true"
+     inkscape:snap-center="true"
+     inkscape:window-maximized="1"
+     inkscape:window-y="-8"
+     inkscape:window-x="-8"
+     inkscape:window-height="1017"
+     inkscape:window-width="1920"
+     inkscape:guide-bbox="true"
+     showguides="false"
+     showborder="true"
+     showgrid="false"
+     inkscape:current-layer="g1476"
+     inkscape:document-units="mm"
+     inkscape:cy="319.62999"
+     inkscape:cx="378.59025"
+     inkscape:zoom="1.0000001"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     borderopacity="1.0"
+     bordercolor="#666666"
+     pagecolor="#ffffff"
+     id="base" />
+  <metadata
+     id="metadata834">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     style="display:none"
+     inkscape:label="Background"
+     id="layer5"
+     inkscape:groupmode="layer" />
+  <g
+     style="display:none"
+     id="layer1"
+     inkscape:groupmode="layer"
+     inkscape:label="Total_Motor">
+    <path
+       inkscape:connector-curvature="0"
+       id="path1388"
+       transform="scale(0.26458333)"
+       d="M 0,650.07812 A 472.4409,472.4409 0 0 0 -472.44141,1122.5195 472.4409,472.4409 0 0 0 0,1594.9609 472.4409,472.4409 0 0 0 472.44141,1122.5195 472.4409,472.4409 0 0 0 0,650.07812 Z m -62.580078,131.7168 c 2.119773,-0.0633 4.238058,0.0941 6.103516,0.6543 2.541358,0.7632 4.943413,2.47682 6.457031,4.65625 1.450551,2.08861 2.260179,4.14371 2.77539,6.56445 v 96.20703 l -32.126953,32.12696 v 25.01171 A 192.85715,192.85715 0 0 1 0,929.66211 192.85715,192.85715 0 0 1 79.371094,946.94922 V 922.00391 L 47.244141,889.87695 v -96.1914 c 0.515003,-2.42755 1.32369,-4.487 2.777343,-6.58008 1.513618,-2.17943 3.915677,-3.89305 6.457032,-4.65625 1.645518,-0.49416 3.491159,-0.65631 5.357422,-0.64844 A 347.10338,347.10338 0 0 1 262.25586,895.70703 c 1.75673,2.4167 3.37685,5.15152 4.01758,7.86524 0.60972,2.58247 0.32595,5.51939 -0.80469,7.91992 -1.08536,2.30442 -2.46502,4.03425 -4.30859,5.69336 l -83.3086,48.09765 -43.88476,-11.75781 -21.66211,12.50586 a 192.85715,192.85715 0 0 1 54.71484,60.06055 192.85715,192.85715 0 0 1 24.71485,77.3809 L 213.33789,1091 l 11.75781,-43.8867 83.31055,-48.09963 c 2.35704,-0.76605 4.54514,-1.093 7.08203,-0.88086 2.64428,0.2211 5.33009,1.4444 7.26172,3.26369 1.49012,1.4034 2.72559,3.2743 3.76172,5.248 a 347.10338,347.10338 0 0 1 20.5918,115.875 347.10338,347.10338 0 0 1 -20.0625,114.8164 c -1.13505,2.3551 -2.53462,4.6543 -4.28907,6.3067 -1.93162,1.8193 -4.61553,3.0425 -7.25976,3.2636 -2.5387,0.2123 -4.72893,-0.1155 -7.08789,-0.8828 l -83.3086,-48.0976 -11.75781,-43.8848 -21.66211,-12.5058 a 192.85715,192.85715 0 0 1 -24.65625,77.414 192.85715,192.85715 0 0 1 -54.65625,60.0938 l 21.60352,12.4726 43.88476,-11.7597 83.30664,48.0976 c 1.84358,1.6591 3.22324,3.3889 4.3086,5.6934 1.13066,2.4005 1.41246,5.3374 0.80273,7.9199 -0.38563,1.6333 -1.14266,3.2715 -2.05273,4.8496 A 347.10338,347.10338 0 0 1 63.15625,1463.209 c -2.309571,0.1107 -4.639833,-0.01 -6.673828,-0.6192 -2.541351,-0.7632 -4.94539,-2.4748 -6.458984,-4.6543 -1.45523,-2.0953 -2.264404,-4.1588 -2.779297,-6.5898 v -96.1836 l 32.126953,-32.1269 v -25.0118 A 192.85715,192.85715 0 0 1 0,1315.377 192.85715,192.85715 0 0 1 -79.371094,1298.0898 v 24.9454 l 32.126953,32.1269 v 96.1914 c -0.514998,2.4276 -1.323687,4.489 -2.777343,6.582 -1.513614,2.1795 -3.915681,3.8911 -6.457032,4.6543 -1.645521,0.4942 -3.491159,0.6564 -5.357422,0.6485 A 347.10338,347.10338 0 0 1 -262.22656,1349.3672 c -1.76655,-2.4252 -3.39721,-5.1736 -4.04102,-7.9004 -0.60972,-2.5825 -0.32791,-5.5194 0.80274,-7.9199 1.08656,-2.307 2.46775,-4.0385 4.31445,-5.6992 l 83.29883,-48.0918 43.88476,11.7597 21.66211,-12.5058 a 192.85715,192.85715 0 0 1 -54.71484,-60.0606 192.85715,192.85715 0 0 1 -24.71485,-77.3808 l -21.60351,12.4726 -11.75781,43.8848 -83.31055,48.0996 c -2.35704,0.766 -4.54513,1.093 -7.08203,0.8808 -2.64427,-0.2211 -5.33009,-1.4443 -7.26172,-3.2636 -1.49012,-1.4035 -2.72559,-3.2744 -3.76172,-5.2481 a 347.10338,347.10338 0 0 1 -20.5918,-115.875 347.10338,347.10338 0 0 1 20.04688,-114.7754 c 1.13845,-2.3696 2.54575,-4.6855 4.31055,-6.3476 1.93163,-1.81929 4.61551,-3.04259 7.25976,-3.26369 2.53416,-0.21191 4.7201,0.11466 7.07422,0.87891 l 83.31641,48.10158 11.75781,43.8867 21.66211,12.5059 a 192.85715,192.85715 0 0 1 24.65625,-77.4141 192.85715,192.85715 0 0 1 54.65625,-60.09571 l -21.60352,-12.4707 -43.88476,11.75781 -83.30664,-48.09765 c -1.84358,-1.65911 -3.22324,-3.38894 -4.3086,-5.69336 -1.13063,-2.40057 -1.41246,-5.33745 -0.80273,-7.91992 0.3858,-1.63403 1.14211,-3.27284 2.05273,-4.85157 A 347.10338,347.10338 0 0 1 -63.158203,781.83008 c 0.193318,-0.009 0.38466,-0.0294 0.578125,-0.0352 z"
+       style="opacity:1;fill:#008000;fill-opacity:1;stroke:#000000;stroke-width:3.77953;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+    <circle
+       r="43.733097"
+       cy="297"
+       cx="0"
+       id="path1390"
+       style="opacity:1;fill:#ff0000;fill-opacity:1;stroke:#000000;stroke-width:1.09333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+  </g>
+  <g
+     style="display:none"
+     inkscape:label="Motor_Cutaway"
+     id="layer2"
+     inkscape:groupmode="layer" />
+  <g
+     style="display:none"
+     inkscape:label="Annotations_1"
+     id="layer3"
+     inkscape:groupmode="layer">
+    <path
+       inkscape:connector-curvature="0"
+       id="path5884"
+       d="M -7.5563861,234.90369 V 206.70526"
+       style="fill:none;stroke:#000000;stroke-width:0.259632px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-start:url(#marker6012);marker-end:url(#marker5894)" />
+    <rect
+       y="218.84871"
+       x="-8.3674479"
+       height="2.2158854"
+       width="1.5875"
+       id="rect6524"
+       style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.264583;stroke-miterlimit:4;stroke-dasharray:0.79375, 0.264583;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal" />
+    <path
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       id="path1464"
+       d="M -0.02743323,297.01265 35.30925,221.27907"
+       style="fill:none;stroke:#000000;stroke-width:0.202531;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:0.810125, 0.202531;stroke-dashoffset:0;stroke-opacity:1" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.202531;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:0.810125, 0.202531;stroke-dashoffset:0;stroke-opacity:1"
+       d="M 0,297 -35.336683,221.26642"
+       id="path1466"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cc" />
+    <path
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       id="path1470"
+       d="M -21.000268,250.56454 V 221.26642"
+       style="fill:none;stroke:#000000;stroke-width:0.264583;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:0.79375, 0.264583;stroke-dashoffset:0;stroke-opacity:1" />
+    <path
+       sodipodi:nodetypes="csc"
+       inkscape:connector-curvature="0"
+       id="path1482"
+       d="m -11.797594,270.57892 c 3.5813579,-1.66871 7.5752744,-2.60053 11.78682858,-2.60053 4.23356982,0 8.24722062,0.94159 11.84295942,2.62676"
+       style="opacity:1;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.264583;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-start:url(#Arrow2Sstart);marker-end:url(#Arrow2Send);paint-order:normal" />
+    <g
+       transform="translate(-23.187493,-34.196779)"
+       id="g1919">
+      <rect
+         style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.264583;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal"
+         id="rect1907"
+         width="6.160902"
+         height="5.5858846"
+         x="20.12562"
+         y="299.38223" />
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+         x="20.947077"
+         y="304.3931"
+         id="text1895"><tspan
+           sodipodi:role="line"
+           id="tspan1893"
+           x="20.947077"
+           y="304.3931"
+           style="stroke-width:0.264583">θ<tspan
+   style="font-size:3.52778px"
+   id="tspan1897">t</tspan></tspan></text>
+    </g>
+    <flowRoot
+       transform="scale(0.26458333)"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:24px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none"
+       id="flowRoot1899"
+       xml:space="preserve"><flowRegion
+         id="flowRegion1901"><rect
+           y="1122.5197"
+           x="61.473213"
+           height="49.675323"
+           width="50.91721"
+           id="rect1903" /></flowRegion><flowPara
+         id="flowPara1905" /></flowRoot>
+    <path
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       id="path1934"
+       d="m -29.626283,232.40708 c 2.447086,-1.23671 5.213559,-1.9334 8.142751,-1.9334"
+       style="display:inline;opacity:1;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.236671;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-start:url(#Arrow1Sstart);marker-end:url(#marker1939);paint-order:normal" />
+    <rect
+       y="229.11623"
+       x="-27.407322"
+       height="3.6542518"
+       width="3.6240244"
+       id="rect1927"
+       style="display:inline;opacity:1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.13113;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal" />
+    <text
+       id="text1923"
+       y="232.42699"
+       x="-27.561081"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+       xml:space="preserve"><tspan
+         style="stroke-width:0.264583"
+         y="232.42699"
+         x="-27.561081"
+         id="tspan1921"
+         sodipodi:role="line">α</tspan></text>
+    <path
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       id="path3542"
+       d="m 25.501249,208.12668 8.748058,-30.47166"
+       style="fill:none;stroke:#000000;stroke-width:0.251839px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-start:url(#Arrow1Mstart);marker-end:url(#marker3864)" />
+    <text
+       id="text4090"
+       y="162.72395"
+       x="57.811459"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+       xml:space="preserve"><tspan
+         style="stroke-width:0.264583"
+         y="162.72395"
+         x="57.811459"
+         id="tspan4088"
+         sodipodi:role="line" /></text>
+    <path
+       inkscape:connector-curvature="0"
+       id="path3528"
+       d="M -12.500012,236.16224 V 246.8512"
+       style="display:inline;fill:none;stroke:#000000;stroke-width:0.24847px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-start:url(#marker5567);marker-end:url(#marker5461)" />
+    <text
+       id="text4094"
+       y="173.58723"
+       x="-52.318027"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+       xml:space="preserve"><tspan
+         style="stroke-width:0.264583"
+         y="173.58723"
+         x="-52.318027"
+         id="tspan4092"
+         sodipodi:role="line">D<tspan
+   id="tspan4096"
+   style="font-size:3.52778px">os</tspan></tspan></text>
+    <g
+       transform="translate(-16.559098,-7.3212701)"
+       id="g4116">
+      <rect
+         style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:0.237103;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal"
+         id="rect4104"
+         width="6.6424799"
+         height="5.9479485"
+         x="43.113136"
+         y="197.23814" />
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+         x="43.78854"
+         y="202.14687"
+         id="text4100"><tspan
+           sodipodi:role="line"
+           id="tspan4098"
+           x="43.78854"
+           y="202.14687"
+           style="stroke-width:0.264583">T<tspan
+   style="font-size:3.52778px"
+   id="tspan4102">s</tspan></tspan></text>
+    </g>
+    <path
+       sodipodi:nodetypes="ccc"
+       inkscape:connector-curvature="0"
+       id="path4118"
+       d="m -44.334244,171.98437 h 2.000911 l 4.828646,4.82865"
+       style="fill:none;stroke:#000000;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#marker4128)" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path4364"
+       d="m 15.718783,210.03594 -1.547002,-1.79208"
+       style="fill:none;stroke:#000000;stroke-width:0.191617;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:0.383234, 0.191617;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker4450)" />
+    <text
+       id="text4634"
+       y="212.41602"
+       x="15.941146"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+       xml:space="preserve"><tspan
+         style="stroke-width:0.264583"
+         y="212.41602"
+         x="15.941146"
+         id="tspan4632"
+         sodipodi:role="line">r</tspan></text>
+    <path
+       inkscape:connector-curvature="0"
+       id="path4976"
+       d="M -11.547554,219.80781 H 11.547554"
+       style="fill:none;stroke:#000000;stroke-width:0.254303px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-start:url(#marker5080);marker-end:url(#marker4986)" />
+    <g
+       transform="translate(-43.306146,19.473489)"
+       id="g4116-9">
+      <g
+         transform="translate(0,0.18708867)"
+         id="g5421">
+        <rect
+           y="197.24779"
+           x="42.65506"
+           height="5.928659"
+           width="7.7924948"
+           id="rect4104-4"
+           style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:0.256393;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal" />
+        <text
+           id="text4100-8"
+           y="202.70813"
+           x="42.993412"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+           xml:space="preserve"><tspan
+             style="stroke-width:0.264583"
+             y="202.70813"
+             x="42.993412"
+             id="tspan4098-5"
+             sodipodi:role="line">W<tspan
+   style="font-size:3.52778px"
+   id="tspan5415">t</tspan></tspan></text>
+      </g>
+    </g>
+    <path
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       id="path5449"
+       d="m -12.500012,247.56684 h 9.8872516"
+       style="fill:none;stroke:#000000;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+    <path
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       id="path5451"
+       d="m -12.500012,235.4466 h 9.8872516"
+       style="fill:none;stroke:#000000;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+    <path
+       sodipodi:arc-type="arc"
+       style="display:inline;opacity:1;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.265;stroke-miterlimit:4;stroke-dasharray:0.795, 0.265;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal"
+       id="path5875"
+       sodipodi:type="arc"
+       sodipodi:cx="0"
+       sodipodi:cy="296.99997"
+       sodipodi:rx="91.67807"
+       sodipodi:ry="91.67807"
+       sodipodi:start="4.4466291"
+       sodipodi:end="4.5768786"
+       sodipodi:open="true"
+       d="m -24.078562,208.54042 a 91.67807,91.67807 0 0 1 11.693219,-2.37806" />
+    <path
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       id="path5878"
+       d="m -12.500012,213.23104 v -7.0392"
+       style="fill:none;stroke:#000000;stroke-width:0.264583;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:0.79375, 0.264583;stroke-dashoffset:0;stroke-opacity:1" />
+    <path
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       id="path5882"
+       d="m -12.385343,206.16235 h 9.7725826"
+       style="fill:none;stroke:#000000;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+    <g
+       transform="translate(-53.364328,27.478398)"
+       id="g4116-9-8"
+       style="display:inline">
+      <g
+         transform="translate(0,0.18708867)"
+         id="g5421-1">
+        <rect
+           y="197.24779"
+           x="42.65506"
+           height="5.928659"
+           width="7.7924948"
+           id="rect4104-4-4"
+           style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:0.256393;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal" />
+        <text
+           id="text4100-8-5"
+           y="202.17897"
+           x="43.456432"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+           xml:space="preserve"><tspan
+             style="stroke-width:0.264583"
+             y="202.17897"
+             x="43.456432"
+             id="tspan4098-5-6"
+             sodipodi:role="line"><tspan
+               style="font-size:3.52778px"
+               id="tspan5415-7"><tspan
+   id="tspan6615"
+   style="font-size:6.35px">L</tspan>t</tspan></tspan></text>
+      </g>
+    </g>
+    <g
+       transform="translate(-53.364328,40.708055)"
+       id="g4116-9-8-7"
+       style="display:inline">
+      <g
+         transform="translate(0,0.18708867)"
+         id="g5421-1-5">
+        <rect
+           y="197.24779"
+           x="42.65506"
+           height="5.928659"
+           width="7.7924948"
+           id="rect4104-4-4-1"
+           style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:0.256393;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal" />
+        <text
+           id="text4100-8-5-7"
+           y="202.17897"
+           x="43.456432"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+           xml:space="preserve"><tspan
+             style="stroke-width:0.264583"
+             y="202.17897"
+             x="43.456432"
+             id="tspan4098-5-6-6"
+             sodipodi:role="line"><tspan
+               style="font-size:3.52778px"
+               id="tspan5415-7-7"><tspan
+   id="tspan6580-5"
+   style="font-size:6.35px">L</tspan>tt</tspan></tspan></text>
+      </g>
+    </g>
+    <path
+       sodipodi:nodetypes="ccc"
+       inkscape:connector-curvature="0"
+       id="path4118-8"
+       d="m -28.486583,277.7367 h -2.000911 l -4.828646,-4.82865"
+       style="display:inline;fill:none;stroke:#000000;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#marker4128-8)" />
+    <text
+       id="text4094-6"
+       y="279.95316"
+       x="-28.468546"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+       xml:space="preserve"><tspan
+         style="stroke-width:0.264583"
+         y="279.95316"
+         x="-28.468546"
+         id="tspan4092-2"
+         sodipodi:role="line">D<tspan
+   id="tspan4096-9"
+   style="font-size:3.52778px;stroke-width:0.264583">or</tspan></tspan></text>
+    <path
+       inkscape:transform-center-y="-47.336963"
+       inkscape:transform-center-x="-0.53635573"
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       id="path6617"
+       d="m 0.49341607,252.4546 0.0643483,-5.62927"
+       style="display:inline;fill:none;stroke:#000000;stroke-width:0.204665px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-start:url(#marker6757);marker-end:url(#marker6627)" />
+    <text
+       id="text4100-8-5-7-6"
+       y="251.6891"
+       x="1.700698"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+       xml:space="preserve"><tspan
+         style="stroke-width:0.264583"
+         y="251.6891"
+         x="1.700698"
+         id="tspan4098-5-6-6-5"
+         sodipodi:role="line"><tspan
+           style="font-size:3.52778px"
+           id="tspan5415-7-7-3"><tspan
+   id="tspan6580-5-5"
+   style="font-size:6.35px">L</tspan>g</tspan></tspan></text>
+    <path
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       id="path15507"
+       d="m 21.000268,250.54698 h 8.688366"
+       style="fill:none;stroke:#000000;stroke-width:0.23934px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+    <path
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       id="path15509"
+       d="m 21.000268,243.94686 h 8.688366"
+       style="fill:none;stroke:#000000;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+    <text
+       id="text15513"
+       y="248.73111"
+       x="25.765221"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+       xml:space="preserve"><tspan
+         style="stroke-width:0.264583"
+         y="248.73111"
+         x="25.765221"
+         id="tspan15511"
+         sodipodi:role="line">s</tspan></text>
+    <path
+       inkscape:connector-curvature="0"
+       id="path15515"
+       d="m 27.057699,249.05852 v 0.97042"
+       style="fill:none;stroke:#000000;stroke-width:0.276484px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#marker15733)" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path15945"
+       d="m 27.060298,245.50384 v -1.05237"
+       style="fill:none;stroke:#000000;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#marker16235)" />
+  </g>
+  <g
+     style="display:inline"
+     inkscape:label="Annotations_2"
+     id="layer4"
+     inkscape:groupmode="layer">
+    <g
+       transform="translate(-20.688286,17.424232)"
+       id="g4116-9-8-2-5"
+       style="display:inline">
+      <g
+         transform="translate(0,0.18708867)"
+         id="g5421-1-7-0">
+        <text
+           id="text4100-8-5-1-8"
+           y="202.24512"
+           x="42.629608"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+           xml:space="preserve"><tspan
+             style="stroke-width:0.264583"
+             y="0"
+             x="0"
+             id="tspan4098-5-6-1-3"
+             sodipodi:role="line"><tspan
+               style="font-size:3.52778px"
+               id="tspan5415-7-3-8"><tspan
+                 id="tspan6615-5-9"
+                 style="font-size:6.35px" /></tspan></tspan></text>
+      </g>
+    </g>
+    <g
+       transform="translate(104.775,-83.608331)"
+       id="g1476">
+      <text
+         xml:space="preserve"
+         style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.23333px;line-height:1.25;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman, Italic';letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+         x="-63.495491"
+         y="237.22881"
+         id="text2115"><tspan
+           sodipodi:role="line"
+           id="tspan2113"
+           x="-63.495491"
+           y="237.22881"
+           style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman, Italic';stroke-width:0.264583">x</tspan></text>
+      <text
+         xml:space="preserve"
+         style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:10.5833px;line-height:1.25;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman,  Italic';letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+         x="-85.644028"
+         y="214.6772"
+         id="text2145"><tspan
+           sodipodi:role="line"
+           id="tspan2143"
+           x="-85.644028"
+           y="214.6772"
+           style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman, Italic';stroke-width:0.264583">y</tspan></text>
+      <path
+         inkscape:connector-curvature="0"
+         id="path1377"
+         d="m -82.920578,234.75873 h 17.586349"
+         style="fill:none;stroke:#ff0000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#marker1387)" />
+      <path
+         inkscape:transform-center-x="8.793175"
+         style="fill:none;stroke:#ff0000;stroke-width:0.5;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#marker1741)"
+         d="M -82.920578,234.75873 V 217.17238"
+         id="path1737"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m -32.338941,213.53187 9.843868,-0.47277"
+         style="fill:none;stroke:#b3b3b3;stroke-width:0.700001;stroke-miterlimit:4;stroke-dasharray:none"
+         id="path1495" />
+      <path
+         d="m -22.495073,213.0591 7.669539,5.70525"
+         style="fill:none;stroke:#b3b3b3;stroke-width:0.7;stroke-miterlimit:4;stroke-dasharray:none"
+         id="path1497-4" />
+      <path
+         d="M -14.825534,218.76435 H 26.959691"
+         style="fill:none;stroke:#b3b3b3;stroke-width:0.7;stroke-miterlimit:4;stroke-dasharray:none"
+         id="path1499" />
+      <path
+         d="M 26.959691,251.81136 H -14.825534"
+         style="fill:none;stroke:#b3b3b3;stroke-width:0.700001;stroke-miterlimit:4;stroke-dasharray:none"
+         id="path1501" />
+      <path
+         d="m -14.825534,251.81136 -7.669539,5.70522"
+         style="fill:none;stroke:#b3b3b3;stroke-width:0.700001;stroke-miterlimit:4;stroke-dasharray:none"
+         id="path1503" />
+      <path
+         d="m -22.495073,257.51658 -9.843868,-0.47266"
+         style="fill:none;stroke:#b3b3b3;stroke-width:0.700001;stroke-miterlimit:4;stroke-dasharray:none"
+         id="path1505" />
+      <path
+         d="m -74.520694,184.00456 4.512441,-8.75878"
+         style="fill:none;stroke:#b3b3b3;stroke-width:0.700001;stroke-miterlimit:4;stroke-dasharray:none"
+         id="path1507" />
+      <path
+         d="m -70.008253,175.24578 8.777102,-3.78751"
+         style="fill:none;stroke:#b3b3b3;stroke-width:0.700001;stroke-miterlimit:4;stroke-dasharray:none"
+         id="path1509-9" />
+      <path
+         d="M -61.231151,171.45827 -40.3385,135.28189"
+         style="fill:none;stroke:#b3b3b3;stroke-width:0.700001;stroke-miterlimit:4;stroke-dasharray:none"
+         id="path1511" />
+      <path
+         d="m -11.710483,151.80538 -20.892612,36.17634"
+         style="fill:none;stroke:#000000;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none"
+         id="path1513" />
+      <path
+         d="m -32.603095,187.98172 1.107524,9.49275"
+         style="fill:none;stroke:#000000;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none"
+         id="path1515-9" />
+      <path
+         d="m -31.495571,197.47447 -5.331415,8.28623"
+         style="fill:none;stroke:#b3b3b3;stroke-width:0.700001;stroke-miterlimit:4;stroke-dasharray:none"
+         id="path1517" />
+      <path
+         d="M 13.872215,181.67888 -26.414514,204.9316"
+         style="fill:#000000;stroke:#000000;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none"
+         id="path1567" />
+      <path
+         d="m -32.338941,257.04392 a 51.49439,51.479187 0 0 0 0,-43.51205"
+         style="fill:none;stroke:#b3b3b3;stroke-width:0.700001;stroke-miterlimit:4;stroke-dasharray:none"
+         id="path1579" />
+      <path
+         d="M 26.959717,218.76435 A 107.24968,107.21801 0 0 0 13.872215,181.67888"
+         style="fill:none;stroke:#b3b3b3;stroke-width:0.7;stroke-miterlimit:4;stroke-dasharray:none"
+         id="path1581" />
+      <path
+         d="m 42.216801,305.25677 a 139.97917,139.93784 0 0 0 0,-139.93783"
+         style="fill:none;stroke:#b3b3b3;stroke-width:0.700001;stroke-miterlimit:4;stroke-dasharray:none"
+         id="path1583" />
+      <path
+         d="M 13.872215,288.89692 A 107.24968,107.21801 0 0 0 26.959717,251.81136"
+         style="fill:none;stroke:#b3b3b3;stroke-width:0.700001;stroke-miterlimit:4;stroke-dasharray:none"
+         id="path1585" />
+      <path
+         d="M -36.826986,205.7607 A 51.49439,51.479187 0 0 0 -74.520668,184.00456"
+         style="fill:none;stroke:#b3b3b3;stroke-width:0.700001;stroke-miterlimit:4;stroke-dasharray:none"
+         id="path1587" />
+      <path
+         d="m -40.3385,135.28189 a 107.24968,107.21801 0 0 0 -38.670213,-7.21203"
+         style="fill:none;stroke:#b3b3b3;stroke-width:0.700001;stroke-miterlimit:4;stroke-dasharray:none"
+         id="path1589" />
+      <path
+         d="M 42.216801,165.31894 A 139.97917,139.93784 0 0 0 -79.008713,95.350051"
+         style="fill:none;stroke:#b3b3b3;stroke-width:0.700001;stroke-miterlimit:4;stroke-dasharray:none"
+         id="path1591" />
+      <path
+         d="m 13.872215,181.67888 a 107.24968,107.21801 0 0 0 -25.582698,-29.8735"
+         style="fill:none;stroke:#000000;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none"
+         id="path1593" />
+      <path
+         d="m -26.065615,205.30018 a 84.085017,58.466869 0 0 0 -5.426696,-7.82688"
+         style="fill:none;stroke:#000000;stroke-width:0.999996;stroke-miterlimit:4;stroke-dasharray:none"
+         id="path1627" />
+    </g>
+  </g>
+</svg>

--- a/mach_cad/model_obj/cross_sects/inner_rotor_stator/CrossSectInnerRotorStatorPartial.svg
+++ b/mach_cad/model_obj/cross_sects/inner_rotor_stator/CrossSectInnerRotorStatorPartial.svg
@@ -1,0 +1,1405 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   inkscape:export-ydpi="150"
+   inkscape:export-xdpi="150"
+   inkscape:export-filename="C:\Users\nheme\Documents\Research\Bearingless Motor\Bearinless_Parametrization_Rev1_wht_bckgrnd.png"
+   inkscape:version="1.0.1 (3bc2e813f5, 2020-09-07)"
+   sodipodi:docname="CrossSectInnerRotorStatorPartial.svg"
+   id="svg837"
+   version="1.1"
+   viewBox="0 0 197.02745 214.52913"
+   height="214.52913mm"
+   width="197.02745mm">
+  <defs
+     id="defs831">
+    <marker
+       inkscape:stockid="Arrow1Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker3363"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path3361"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mstart"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker2957"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path2955"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(0.4,0,0,0.4,4,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker2473"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path2471"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker2091"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mstart">
+      <path
+         transform="matrix(0.4,0,0,0.4,4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path2089" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mstart"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker4727"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path4725"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(0.4,0,0,0.4,4,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mstart"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker4345"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path4343"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(0.4,0,0,0.4,4,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mstart"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker3969"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path3967"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(0.4,0,0,0.4,4,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mstart"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker3599"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path3597"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(0.4,0,0,0.4,4,0)" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker2905"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow2Send">
+      <path
+         transform="matrix(-0.3,0,0,-0.3,0.69,0)"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         id="path2903" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker3124"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow2Send">
+      <path
+         transform="matrix(-0.3,0,0,-0.3,0.69,0)"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         id="path3122" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker1741"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path1739"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#ff0000;fill-opacity:1;fill-rule:evenodd;stroke:#ff0000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow2Send"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker4852"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path4850"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         transform="matrix(-0.3,0,0,-0.3,0.69,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow2Send"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker3691"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path3689"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         transform="matrix(-0.3,0,0,-0.3,0.69,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Sstart"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker3429"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path3427"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(0.2,0,0,0.2,1.2,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow2Send"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker2019"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path2017"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         transform="matrix(-0.3,0,0,-0.3,0.69,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow2Sstart"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker1781"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path1779"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         transform="matrix(0.3,0,0,0.3,-0.69,0)" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker1488"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mend">
+      <path
+         transform="matrix(-0.4,0,0,-0.4,-4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path1486" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker1244"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mend">
+      <path
+         inkscape:connector-curvature="0"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path1242" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow2Send"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker16235"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path16233"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         transform="matrix(-0.3,0,0,-0.3,0.69,0)" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:stockid="Arrow2Send"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker15733"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path15731"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         transform="matrix(-0.3,0,0,-0.3,0.69,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker15525"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path15523"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker9500"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mend">
+      <path
+         transform="matrix(-0.4,0,0,-0.4,-4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path9498" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker8403"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mstart">
+      <path
+         transform="matrix(0.4,0,0,0.4,4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path8401" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker8209"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mend">
+      <path
+         transform="matrix(-0.4,0,0,-0.4,-4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path8207" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker8061"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mstart">
+      <path
+         transform="matrix(0.4,0,0,0.4,4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path8059" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker7820"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path7818"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mstart"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker7684"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path7682"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(0.4,0,0,0.4,4,0)" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:stockid="Arrow1Mstart"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker6757"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path6755"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(0.4,0,0,0.4,4,0)" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:stockid="Arrow1Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker6627"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path6625"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker6012"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mstart">
+      <path
+         transform="matrix(0.4,0,0,0.4,4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path6010" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker5894"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mend">
+      <path
+         transform="matrix(-0.4,0,0,-0.4,-4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path5892" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:stockid="Arrow1Mstart"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker5567"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path5565"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(0.4,0,0,0.4,4,0)" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:stockid="Arrow1Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker5461"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path5459"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:stockid="Arrow1Mstart"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker5080"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path5078"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(0.4,0,0,0.4,4,0)" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker4986"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mend">
+      <path
+         transform="matrix(-0.4,0,0,-0.4,-4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path4984" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker4450"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow2Send">
+      <path
+         transform="matrix(-0.3,0,0,-0.3,0.69,0)"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         id="path4448" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker4374"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path4372"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:stockid="Arrow1Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker4128"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path4126"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker3864"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mend">
+      <path
+         transform="matrix(-0.4,0,0,-0.4,-4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path3862" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="Arrow1Mstart"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mstart">
+      <path
+         transform="matrix(0.4,0,0,0.4,4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path1491" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="Arrow1Sstart"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Sstart">
+      <path
+         transform="matrix(0.2,0,0,0.2,1.2,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path1497" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker1939"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow2Send">
+      <path
+         transform="matrix(-0.3,0,0,-0.3,0.69,0)"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         id="path1937" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="Arrow2Sstart"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow2Sstart">
+      <path
+         transform="matrix(0.3,0,0,0.3,-0.69,0)"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         id="path1515" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="Arrow2Send"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow2Send">
+      <path
+         transform="matrix(-0.3,0,0,-0.3,0.69,0)"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         id="path1518" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="Arrow2Mstart"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow2Mstart">
+      <path
+         transform="scale(0.6)"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         id="path1509" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="Arrow1Mend"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mend">
+      <path
+         transform="matrix(-0.4,0,0,-0.4,-4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path1494" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:stockid="Arrow1Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker4128-8"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path4126-2"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow2Send"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker4852-2"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path4850-0"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         transform="matrix(-0.3,0,0,-0.3,0.69,0)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow2Send"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker4852-2-2"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path4850-0-3"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         transform="matrix(-0.3,0,0,-0.3,0.69,0)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       id="DistanceX"
+       orient="auto"
+       refX="0"
+       refY="0"
+       style="overflow:visible">
+      <path
+         d="M 3,-3 -3,3 M 0,-5 V 5"
+         style="stroke:#000000;stroke-width:0.5"
+         id="path1492" />
+    </marker>
+    <pattern
+       id="Hatch"
+       patternUnits="userSpaceOnUse"
+       width="8"
+       height="8"
+       x="0"
+       y="0">
+      <path
+         d="M8 4 l-4,4"
+         stroke="#000000"
+         stroke-width="0.25"
+         linecap="square"
+         id="path1495" />
+      <path
+         d="M6 2 l-4,4"
+         stroke="#000000"
+         stroke-width="0.25"
+         linecap="square"
+         id="path1497-8" />
+      <path
+         d="M4 0 l-4,4"
+         stroke="#000000"
+         stroke-width="0.25"
+         linecap="square"
+         id="path1499" />
+    </pattern>
+    <symbol
+       id="*Model_Space" />
+    <symbol
+       id="*Paper_Space" />
+    <symbol
+       id="*Paper_Space0" />
+    <marker
+       inkscape:collect="always"
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker1387"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mend">
+      <path
+         transform="matrix(-0.4,0,0,-0.4,-4,0)"
+         style="fill:#ff0000;fill-opacity:1;fill-rule:evenodd;stroke:#ff0000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path1385" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker1741-3"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path1739-7"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#ff0000;fill-opacity:1;fill-rule:evenodd;stroke:#ff0000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)" />
+    </marker>
+  </defs>
+  <sodipodi:namedview
+     height="281mm"
+     inkscape:document-rotation="0"
+     inkscape:snap-to-guides="true"
+     inkscape:snap-global="true"
+     inkscape:snap-bbox="false"
+     inkscape:object-paths="true"
+     inkscape:snap-intersection-paths="true"
+     inkscape:snap-object-midpoints="true"
+     inkscape:snap-others="true"
+     inkscape:snap-smooth-nodes="true"
+     inkscape:snap-midpoints="true"
+     inkscape:snap-center="true"
+     inkscape:window-maximized="1"
+     inkscape:window-y="-6"
+     inkscape:window-x="-6"
+     inkscape:window-height="650"
+     inkscape:window-width="1280"
+     inkscape:guide-bbox="true"
+     showguides="false"
+     showborder="true"
+     showgrid="false"
+     inkscape:current-layer="g1476"
+     inkscape:document-units="mm"
+     inkscape:cy="339.30601"
+     inkscape:cx="56.857208"
+     inkscape:zoom="0.50000003"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     borderopacity="1.0"
+     bordercolor="#666666"
+     pagecolor="#ffffff"
+     id="base" />
+  <metadata
+     id="metadata834">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     style="display:none"
+     inkscape:label="Background"
+     id="layer5"
+     inkscape:groupmode="layer"
+     transform="translate(-156.49905,-38.664582)" />
+  <g
+     style="display:none"
+     id="layer1"
+     inkscape:groupmode="layer"
+     inkscape:label="Total_Motor"
+     transform="translate(-156.49905,-38.664582)">
+    <path
+       inkscape:connector-curvature="0"
+       id="path1388"
+       transform="scale(0.26458333)"
+       d="M 0,650.07812 A 472.4409,472.4409 0 0 0 -472.44141,1122.5195 472.4409,472.4409 0 0 0 0,1594.9609 472.4409,472.4409 0 0 0 472.44141,1122.5195 472.4409,472.4409 0 0 0 0,650.07812 Z m -62.580078,131.7168 c 2.119773,-0.0633 4.238058,0.0941 6.103516,0.6543 2.541358,0.7632 4.943413,2.47682 6.457031,4.65625 1.450551,2.08861 2.260179,4.14371 2.77539,6.56445 v 96.20703 l -32.126953,32.12696 v 25.01171 A 192.85715,192.85715 0 0 1 0,929.66211 192.85715,192.85715 0 0 1 79.371094,946.94922 V 922.00391 L 47.244141,889.87695 v -96.1914 c 0.515003,-2.42755 1.32369,-4.487 2.777343,-6.58008 1.513618,-2.17943 3.915677,-3.89305 6.457032,-4.65625 1.645518,-0.49416 3.491159,-0.65631 5.357422,-0.64844 A 347.10338,347.10338 0 0 1 262.25586,895.70703 c 1.75673,2.4167 3.37685,5.15152 4.01758,7.86524 0.60972,2.58247 0.32595,5.51939 -0.80469,7.91992 -1.08536,2.30442 -2.46502,4.03425 -4.30859,5.69336 l -83.3086,48.09765 -43.88476,-11.75781 -21.66211,12.50586 a 192.85715,192.85715 0 0 1 54.71484,60.06055 192.85715,192.85715 0 0 1 24.71485,77.3809 L 213.33789,1091 l 11.75781,-43.8867 83.31055,-48.09963 c 2.35704,-0.76605 4.54514,-1.093 7.08203,-0.88086 2.64428,0.2211 5.33009,1.4444 7.26172,3.26369 1.49012,1.4034 2.72559,3.2743 3.76172,5.248 a 347.10338,347.10338 0 0 1 20.5918,115.875 347.10338,347.10338 0 0 1 -20.0625,114.8164 c -1.13505,2.3551 -2.53462,4.6543 -4.28907,6.3067 -1.93162,1.8193 -4.61553,3.0425 -7.25976,3.2636 -2.5387,0.2123 -4.72893,-0.1155 -7.08789,-0.8828 l -83.3086,-48.0976 -11.75781,-43.8848 -21.66211,-12.5058 a 192.85715,192.85715 0 0 1 -24.65625,77.414 192.85715,192.85715 0 0 1 -54.65625,60.0938 l 21.60352,12.4726 43.88476,-11.7597 83.30664,48.0976 c 1.84358,1.6591 3.22324,3.3889 4.3086,5.6934 1.13066,2.4005 1.41246,5.3374 0.80273,7.9199 -0.38563,1.6333 -1.14266,3.2715 -2.05273,4.8496 A 347.10338,347.10338 0 0 1 63.15625,1463.209 c -2.309571,0.1107 -4.639833,-0.01 -6.673828,-0.6192 -2.541351,-0.7632 -4.94539,-2.4748 -6.458984,-4.6543 -1.45523,-2.0953 -2.264404,-4.1588 -2.779297,-6.5898 v -96.1836 l 32.126953,-32.1269 v -25.0118 A 192.85715,192.85715 0 0 1 0,1315.377 192.85715,192.85715 0 0 1 -79.371094,1298.0898 v 24.9454 l 32.126953,32.1269 v 96.1914 c -0.514998,2.4276 -1.323687,4.489 -2.777343,6.582 -1.513614,2.1795 -3.915681,3.8911 -6.457032,4.6543 -1.645521,0.4942 -3.491159,0.6564 -5.357422,0.6485 A 347.10338,347.10338 0 0 1 -262.22656,1349.3672 c -1.76655,-2.4252 -3.39721,-5.1736 -4.04102,-7.9004 -0.60972,-2.5825 -0.32791,-5.5194 0.80274,-7.9199 1.08656,-2.307 2.46775,-4.0385 4.31445,-5.6992 l 83.29883,-48.0918 43.88476,11.7597 21.66211,-12.5058 a 192.85715,192.85715 0 0 1 -54.71484,-60.0606 192.85715,192.85715 0 0 1 -24.71485,-77.3808 l -21.60351,12.4726 -11.75781,43.8848 -83.31055,48.0996 c -2.35704,0.766 -4.54513,1.093 -7.08203,0.8808 -2.64427,-0.2211 -5.33009,-1.4443 -7.26172,-3.2636 -1.49012,-1.4035 -2.72559,-3.2744 -3.76172,-5.2481 a 347.10338,347.10338 0 0 1 -20.5918,-115.875 347.10338,347.10338 0 0 1 20.04688,-114.7754 c 1.13845,-2.3696 2.54575,-4.6855 4.31055,-6.3476 1.93163,-1.81929 4.61551,-3.04259 7.25976,-3.26369 2.53416,-0.21191 4.7201,0.11466 7.07422,0.87891 l 83.31641,48.10158 11.75781,43.8867 21.66211,12.5059 a 192.85715,192.85715 0 0 1 24.65625,-77.4141 192.85715,192.85715 0 0 1 54.65625,-60.09571 l -21.60352,-12.4707 -43.88476,11.75781 -83.30664,-48.09765 c -1.84358,-1.65911 -3.22324,-3.38894 -4.3086,-5.69336 -1.13063,-2.40057 -1.41246,-5.33745 -0.80273,-7.91992 0.3858,-1.63403 1.14211,-3.27284 2.05273,-4.85157 A 347.10338,347.10338 0 0 1 -63.158203,781.83008 c 0.193318,-0.009 0.38466,-0.0294 0.578125,-0.0352 z"
+       style="opacity:1;fill:#008000;fill-opacity:1;stroke:#000000;stroke-width:3.77953;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+    <circle
+       r="43.733097"
+       cy="297"
+       cx="0"
+       id="path1390"
+       style="opacity:1;fill:#ff0000;fill-opacity:1;stroke:#000000;stroke-width:1.09333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+  </g>
+  <g
+     style="display:none"
+     inkscape:label="Motor_Cutaway"
+     id="layer2"
+     inkscape:groupmode="layer"
+     transform="translate(-156.49905,-38.664582)" />
+  <g
+     style="display:none"
+     inkscape:label="Annotations_1"
+     id="layer3"
+     inkscape:groupmode="layer"
+     transform="translate(-156.49905,-38.664582)">
+    <path
+       inkscape:connector-curvature="0"
+       id="path5884"
+       d="M -7.5563861,234.90369 V 206.70526"
+       style="fill:none;stroke:#000000;stroke-width:0.259632px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-start:url(#marker6012);marker-end:url(#marker5894)" />
+    <rect
+       y="218.84871"
+       x="-8.3674479"
+       height="2.2158854"
+       width="1.5875"
+       id="rect6524"
+       style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.264583;stroke-miterlimit:4;stroke-dasharray:0.79375, 0.264583;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal" />
+    <path
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       id="path1464"
+       d="M -0.02743323,297.01265 35.30925,221.27907"
+       style="fill:none;stroke:#000000;stroke-width:0.202531;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:0.810125, 0.202531;stroke-dashoffset:0;stroke-opacity:1" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.202531;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:0.810125, 0.202531;stroke-dashoffset:0;stroke-opacity:1"
+       d="M 0,297 -35.336683,221.26642"
+       id="path1466"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cc" />
+    <path
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       id="path1470"
+       d="M -21.000268,250.56454 V 221.26642"
+       style="fill:none;stroke:#000000;stroke-width:0.264583;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:0.79375, 0.264583;stroke-dashoffset:0;stroke-opacity:1" />
+    <path
+       sodipodi:nodetypes="csc"
+       inkscape:connector-curvature="0"
+       id="path1482"
+       d="m -11.797594,270.57892 c 3.5813579,-1.66871 7.5752744,-2.60053 11.78682858,-2.60053 4.23356982,0 8.24722062,0.94159 11.84295942,2.62676"
+       style="opacity:1;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.264583;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-start:url(#Arrow2Sstart);marker-end:url(#Arrow2Send);paint-order:normal" />
+    <g
+       transform="translate(-23.187493,-34.196779)"
+       id="g1919">
+      <rect
+         style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.264583;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal"
+         id="rect1907"
+         width="6.160902"
+         height="5.5858846"
+         x="20.12562"
+         y="299.38223" />
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+         x="20.947077"
+         y="304.3931"
+         id="text1895"><tspan
+           sodipodi:role="line"
+           id="tspan1893"
+           x="20.947077"
+           y="304.3931"
+           style="stroke-width:0.264583">θ<tspan
+   style="font-size:3.52778px"
+   id="tspan1897">t</tspan></tspan></text>
+    </g>
+    <flowRoot
+       transform="scale(0.26458333)"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:24px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none"
+       id="flowRoot1899"
+       xml:space="preserve"><flowRegion
+         id="flowRegion1901"><rect
+           y="1122.5197"
+           x="61.473213"
+           height="49.675323"
+           width="50.91721"
+           id="rect1903" /></flowRegion><flowPara
+         id="flowPara1905" /></flowRoot>
+    <path
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       id="path1934"
+       d="m -29.626283,232.40708 c 2.447086,-1.23671 5.213559,-1.9334 8.142751,-1.9334"
+       style="display:inline;opacity:1;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.236671;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-start:url(#Arrow1Sstart);marker-end:url(#marker1939);paint-order:normal" />
+    <rect
+       y="229.11623"
+       x="-27.407322"
+       height="3.6542518"
+       width="3.6240244"
+       id="rect1927"
+       style="display:inline;opacity:1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.13113;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal" />
+    <text
+       id="text1923"
+       y="232.42699"
+       x="-27.561081"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+       xml:space="preserve"><tspan
+         style="stroke-width:0.264583"
+         y="232.42699"
+         x="-27.561081"
+         id="tspan1921"
+         sodipodi:role="line">α</tspan></text>
+    <path
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       id="path3542"
+       d="m 25.501249,208.12668 8.748058,-30.47166"
+       style="fill:none;stroke:#000000;stroke-width:0.251839px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-start:url(#Arrow1Mstart);marker-end:url(#marker3864)" />
+    <text
+       id="text4090"
+       y="162.72395"
+       x="57.811459"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+       xml:space="preserve"><tspan
+         style="stroke-width:0.264583"
+         y="162.72395"
+         x="57.811459"
+         id="tspan4088"
+         sodipodi:role="line" /></text>
+    <path
+       inkscape:connector-curvature="0"
+       id="path3528"
+       d="M -12.500012,236.16224 V 246.8512"
+       style="display:inline;fill:none;stroke:#000000;stroke-width:0.24847px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-start:url(#marker5567);marker-end:url(#marker5461)" />
+    <text
+       id="text4094"
+       y="173.58723"
+       x="-52.318027"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+       xml:space="preserve"><tspan
+         style="stroke-width:0.264583"
+         y="173.58723"
+         x="-52.318027"
+         id="tspan4092"
+         sodipodi:role="line">D<tspan
+   id="tspan4096"
+   style="font-size:3.52778px">os</tspan></tspan></text>
+    <g
+       transform="translate(-16.559098,-7.3212701)"
+       id="g4116">
+      <rect
+         style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:0.237103;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal"
+         id="rect4104"
+         width="6.6424799"
+         height="5.9479485"
+         x="43.113136"
+         y="197.23814" />
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+         x="43.78854"
+         y="202.14687"
+         id="text4100"><tspan
+           sodipodi:role="line"
+           id="tspan4098"
+           x="43.78854"
+           y="202.14687"
+           style="stroke-width:0.264583">T<tspan
+   style="font-size:3.52778px"
+   id="tspan4102">s</tspan></tspan></text>
+    </g>
+    <path
+       sodipodi:nodetypes="ccc"
+       inkscape:connector-curvature="0"
+       id="path4118"
+       d="m -44.334244,171.98437 h 2.000911 l 4.828646,4.82865"
+       style="fill:none;stroke:#000000;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#marker4128)" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path4364"
+       d="m 15.718783,210.03594 -1.547002,-1.79208"
+       style="fill:none;stroke:#000000;stroke-width:0.191617;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:0.383234, 0.191617;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker4450)" />
+    <text
+       id="text4634"
+       y="212.41602"
+       x="15.941146"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+       xml:space="preserve"><tspan
+         style="stroke-width:0.264583"
+         y="212.41602"
+         x="15.941146"
+         id="tspan4632"
+         sodipodi:role="line">r</tspan></text>
+    <path
+       inkscape:connector-curvature="0"
+       id="path4976"
+       d="M -11.547554,219.80781 H 11.547554"
+       style="fill:none;stroke:#000000;stroke-width:0.254303px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-start:url(#marker5080);marker-end:url(#marker4986)" />
+    <g
+       transform="translate(-43.306146,19.473489)"
+       id="g4116-9">
+      <g
+         transform="translate(0,0.18708867)"
+         id="g5421">
+        <rect
+           y="197.24779"
+           x="42.65506"
+           height="5.928659"
+           width="7.7924948"
+           id="rect4104-4"
+           style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:0.256393;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal" />
+        <text
+           id="text4100-8"
+           y="202.70813"
+           x="42.993412"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+           xml:space="preserve"><tspan
+             style="stroke-width:0.264583"
+             y="202.70813"
+             x="42.993412"
+             id="tspan4098-5"
+             sodipodi:role="line">W<tspan
+   style="font-size:3.52778px"
+   id="tspan5415">t</tspan></tspan></text>
+      </g>
+    </g>
+    <path
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       id="path5449"
+       d="m -12.500012,247.56684 h 9.8872516"
+       style="fill:none;stroke:#000000;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+    <path
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       id="path5451"
+       d="m -12.500012,235.4466 h 9.8872516"
+       style="fill:none;stroke:#000000;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+    <path
+       sodipodi:arc-type="arc"
+       style="display:inline;opacity:1;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.265;stroke-miterlimit:4;stroke-dasharray:0.795, 0.265;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal"
+       id="path5875"
+       sodipodi:type="arc"
+       sodipodi:cx="0"
+       sodipodi:cy="296.99997"
+       sodipodi:rx="91.67807"
+       sodipodi:ry="91.67807"
+       sodipodi:start="4.4466291"
+       sodipodi:end="4.5768786"
+       sodipodi:open="true"
+       d="m -24.078562,208.54042 a 91.67807,91.67807 0 0 1 11.693219,-2.37806" />
+    <path
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       id="path5878"
+       d="m -12.500012,213.23104 v -7.0392"
+       style="fill:none;stroke:#000000;stroke-width:0.264583;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:0.79375, 0.264583;stroke-dashoffset:0;stroke-opacity:1" />
+    <path
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       id="path5882"
+       d="m -12.385343,206.16235 h 9.7725826"
+       style="fill:none;stroke:#000000;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+    <g
+       transform="translate(-53.364328,27.478398)"
+       id="g4116-9-8"
+       style="display:inline">
+      <g
+         transform="translate(0,0.18708867)"
+         id="g5421-1">
+        <rect
+           y="197.24779"
+           x="42.65506"
+           height="5.928659"
+           width="7.7924948"
+           id="rect4104-4-4"
+           style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:0.256393;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal" />
+        <text
+           id="text4100-8-5"
+           y="202.17897"
+           x="43.456432"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+           xml:space="preserve"><tspan
+             style="stroke-width:0.264583"
+             y="202.17897"
+             x="43.456432"
+             id="tspan4098-5-6"
+             sodipodi:role="line"><tspan
+               style="font-size:3.52778px"
+               id="tspan5415-7"><tspan
+   id="tspan6615"
+   style="font-size:6.35px">L</tspan>t</tspan></tspan></text>
+      </g>
+    </g>
+    <g
+       transform="translate(-53.364328,40.708055)"
+       id="g4116-9-8-7"
+       style="display:inline">
+      <g
+         transform="translate(0,0.18708867)"
+         id="g5421-1-5">
+        <rect
+           y="197.24779"
+           x="42.65506"
+           height="5.928659"
+           width="7.7924948"
+           id="rect4104-4-4-1"
+           style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:0.256393;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal" />
+        <text
+           id="text4100-8-5-7"
+           y="202.17897"
+           x="43.456432"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+           xml:space="preserve"><tspan
+             style="stroke-width:0.264583"
+             y="202.17897"
+             x="43.456432"
+             id="tspan4098-5-6-6"
+             sodipodi:role="line"><tspan
+               style="font-size:3.52778px"
+               id="tspan5415-7-7"><tspan
+   id="tspan6580-5"
+   style="font-size:6.35px">L</tspan>tt</tspan></tspan></text>
+      </g>
+    </g>
+    <path
+       sodipodi:nodetypes="ccc"
+       inkscape:connector-curvature="0"
+       id="path4118-8"
+       d="m -28.486583,277.7367 h -2.000911 l -4.828646,-4.82865"
+       style="display:inline;fill:none;stroke:#000000;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#marker4128-8)" />
+    <text
+       id="text4094-6"
+       y="279.95316"
+       x="-28.468546"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+       xml:space="preserve"><tspan
+         style="stroke-width:0.264583"
+         y="279.95316"
+         x="-28.468546"
+         id="tspan4092-2"
+         sodipodi:role="line">D<tspan
+   id="tspan4096-9"
+   style="font-size:3.52778px;stroke-width:0.264583">or</tspan></tspan></text>
+    <path
+       inkscape:transform-center-y="-47.336963"
+       inkscape:transform-center-x="-0.53635573"
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       id="path6617"
+       d="m 0.49341607,252.4546 0.0643483,-5.62927"
+       style="display:inline;fill:none;stroke:#000000;stroke-width:0.204665px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-start:url(#marker6757);marker-end:url(#marker6627)" />
+    <text
+       id="text4100-8-5-7-6"
+       y="251.6891"
+       x="1.700698"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+       xml:space="preserve"><tspan
+         style="stroke-width:0.264583"
+         y="251.6891"
+         x="1.700698"
+         id="tspan4098-5-6-6-5"
+         sodipodi:role="line"><tspan
+           style="font-size:3.52778px"
+           id="tspan5415-7-7-3"><tspan
+   id="tspan6580-5-5"
+   style="font-size:6.35px">L</tspan>g</tspan></tspan></text>
+    <path
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       id="path15507"
+       d="m 21.000268,250.54698 h 8.688366"
+       style="fill:none;stroke:#000000;stroke-width:0.23934px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+    <path
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       id="path15509"
+       d="m 21.000268,243.94686 h 8.688366"
+       style="fill:none;stroke:#000000;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+    <text
+       id="text15513"
+       y="248.73111"
+       x="25.765221"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+       xml:space="preserve"><tspan
+         style="stroke-width:0.264583"
+         y="248.73111"
+         x="25.765221"
+         id="tspan15511"
+         sodipodi:role="line">s</tspan></text>
+    <path
+       inkscape:connector-curvature="0"
+       id="path15515"
+       d="m 27.057699,249.05852 v 0.97042"
+       style="fill:none;stroke:#000000;stroke-width:0.276484px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#marker15733)" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path15945"
+       d="m 27.060298,245.50384 v -1.05237"
+       style="fill:none;stroke:#000000;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#marker16235)" />
+  </g>
+  <g
+     style="display:inline"
+     inkscape:label="Annotations_2"
+     id="layer4"
+     inkscape:groupmode="layer"
+     transform="translate(-156.49905,-38.664582)">
+    <g
+       transform="translate(-20.688286,17.424232)"
+       id="g4116-9-8-2-5"
+       style="display:inline">
+      <g
+         transform="translate(0,0.18708867)"
+         id="g5421-1-7-0">
+        <text
+           id="text4100-8-5-1-8"
+           y="202.24512"
+           x="42.629608"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+           xml:space="preserve"><tspan
+             style="stroke-width:0.264583"
+             y="0"
+             x="0"
+             id="tspan4098-5-6-1-3"
+             sodipodi:role="line"><tspan
+               style="font-size:3.52778px"
+               id="tspan5415-7-3-8"><tspan
+                 id="tspan6615-5-9"
+                 style="font-size:6.35px" /></tspan></tspan></text>
+      </g>
+    </g>
+    <g
+       transform="translate(104.775,-83.608331)"
+       id="g1476">
+      <g
+         id="g1566"
+         transform="matrix(1.4726321,0,0,1.4683645,33.965732,-1418.7306)"
+         style="stroke-width:0.680042;stroke-miterlimit:4;stroke-dasharray:none">
+        <g
+           inkscape:label="0"
+           id="g1507"
+           style="stroke-width:0.680042;stroke-miterlimit:4;stroke-dasharray:none" />
+        <path
+           d="m 48.50388,1099.902 10.230724,-0.4915"
+           style="fill:none;stroke:#000000;stroke-width:0.680042;stroke-miterlimit:4;stroke-dasharray:none"
+           id="path1509-1" />
+        <path
+           d="m 58.734604,1099.4105 7.990477,5.9312"
+           style="fill:none;stroke:#000000;stroke-width:0.680042;stroke-miterlimit:4;stroke-dasharray:none"
+           id="path1511" />
+        <path
+           d="M 66.725081,1105.3417 H 110.16483"
+           style="fill:none;stroke:#000000;stroke-width:0.680042;stroke-miterlimit:4;stroke-dasharray:none"
+           id="path1513" />
+        <path
+           d="M 110.16483,1139.6976 H 66.725081"
+           style="fill:none;stroke:#000000;stroke-width:0.680042;stroke-miterlimit:4;stroke-dasharray:none"
+           id="path1515-9" />
+        <path
+           d="m 66.725081,1139.6976 -7.990477,5.9312"
+           style="fill:none;stroke:#000000;stroke-width:0.680042;stroke-miterlimit:4;stroke-dasharray:none"
+           id="path1517" />
+        <path
+           d="M 58.734604,1145.6288 48.50388,1145.1374"
+           style="fill:none;stroke:#000000;stroke-width:0.680042;stroke-miterlimit:4;stroke-dasharray:none"
+           id="path1519" />
+        <path
+           d="m 96.558423,1066.7717 29.458507,-17.0079"
+           style="fill:none;stroke:#000000;stroke-width:0.680042;stroke-miterlimit:4;stroke-dasharray:none"
+           id="path1521" />
+        <path
+           d="M 126.01693,1195.2756 96.558423,1178.2677"
+           style="fill:none;stroke:#000000;stroke-width:0.680042;stroke-miterlimit:4;stroke-dasharray:none"
+           id="path1523" />
+        <path
+           d="m 48.50388,1145.1374 a 53.51811,53.51811 0 0 0 0,-45.2354"
+           style="fill:none;stroke:#000000;stroke-width:0.680042;stroke-miterlimit:4;stroke-dasharray:none"
+           id="path1525" />
+        <path
+           d="m 110.16483,1105.3417 a 111.49606,111.49606 0 0 0 -13.606407,-38.57"
+           style="fill:none;stroke:#000000;stroke-width:0.680042;stroke-miterlimit:4;stroke-dasharray:none"
+           id="path1527" />
+        <path
+           d="m 126.01693,1195.2756 a 145.51181,145.51181 0 0 0 0,-145.5118"
+           style="fill:none;stroke:#000000;stroke-width:0.680042;stroke-miterlimit:4;stroke-dasharray:none"
+           id="path1529" />
+        <path
+           d="m 96.558423,1178.2677 a 111.49606,111.49606 0 0 0 13.606407,-38.5701"
+           style="fill:none;stroke:#000000;stroke-width:0.680042;stroke-miterlimit:4;stroke-dasharray:none"
+           id="path1531" />
+      </g>
+      <g
+         id="g1874"
+         transform="matrix(1.4878528,0,0,1.4878528,-43.370013,-117.98717)"
+         style="stroke-width:0.6721095;stroke-miterlimit:4;stroke-dasharray:none">
+        <text
+           xml:space="preserve"
+           style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:5.41659px;line-height:1.25;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman, Italic';letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.6721095;stroke-miterlimit:4;stroke-dasharray:none"
+           x="92.903519"
+           y="236.86166"
+           id="text2115"><tspan
+             sodipodi:role="line"
+             id="tspan2113"
+             x="92.903519"
+             y="236.86166"
+             style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:8.12488px;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman, Italic';stroke-width:0.6721095;stroke-miterlimit:4;stroke-dasharray:none">x</tspan></text>
+        <text
+           xml:space="preserve"
+           style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:13.5414px;line-height:1.25;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman, Italic';letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.6721095;stroke-miterlimit:4;stroke-dasharray:none"
+           x="64.564247"
+           y="208.00667"
+           id="text2145"><tspan
+             sodipodi:role="line"
+             id="tspan2143"
+             x="64.564247"
+             y="208.00667"
+             style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:8.12488px;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman, Italic';stroke-width:0.6721095;stroke-miterlimit:4;stroke-dasharray:none">y</tspan></text>
+        <g
+           style="display:inline;stroke:#ff0000;stroke-width:0.52528688;stroke-miterlimit:4;stroke-dasharray:none"
+           id="g2173"
+           transform="matrix(0,1.2795094,-1.2795094,0,448.06324,233.70119)">
+          <path
+             inkscape:connector-curvature="0"
+             id="path1377"
+             d="M 0,297 V 279.41365"
+             style="fill:none;stroke:#ff0000;stroke-width:0.52528688;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#marker1387)" />
+          <path
+             inkscape:transform-center-x="8.793175"
+             style="fill:none;stroke:#ff0000;stroke-width:0.52528688;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#marker1741-3)"
+             d="M 0,297 H -17.58635"
+             id="path1737"
+             inkscape:connector-curvature="0" />
+        </g>
+      </g>
+    </g>
+  </g>
+</svg>

--- a/mach_cad/model_obj/cross_sects/inner_rotor_stator/CrossSectInnerRotorStatorRightSlot.svg
+++ b/mach_cad/model_obj/cross_sects/inner_rotor_stator/CrossSectInnerRotorStatorRightSlot.svg
@@ -1,0 +1,1406 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   inkscape:export-ydpi="150"
+   inkscape:export-xdpi="150"
+   inkscape:export-filename="C:\Users\nheme\Documents\Research\Bearingless Motor\Bearinless_Parametrization_Rev1_wht_bckgrnd.png"
+   inkscape:version="1.0.1 (3bc2e813f5, 2020-09-07)"
+   sodipodi:docname="CrossSectInnerRotorStatorRightSlot.svg"
+   id="svg837"
+   version="1.1"
+   viewBox="0 0 180 243"
+   height="243mm"
+   width="180mm">
+  <defs
+     id="defs831">
+    <marker
+       inkscape:stockid="Arrow1Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker3363"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path3361"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mstart"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker2957"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path2955"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(0.4,0,0,0.4,4,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker2473"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path2471"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker2091"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mstart">
+      <path
+         transform="matrix(0.4,0,0,0.4,4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path2089" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mstart"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker4727"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path4725"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(0.4,0,0,0.4,4,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mstart"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker4345"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path4343"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(0.4,0,0,0.4,4,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mstart"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker3969"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path3967"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(0.4,0,0,0.4,4,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mstart"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker3599"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path3597"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(0.4,0,0,0.4,4,0)" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker2905"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow2Send">
+      <path
+         transform="matrix(-0.3,0,0,-0.3,0.69,0)"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         id="path2903" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker3124"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow2Send">
+      <path
+         transform="matrix(-0.3,0,0,-0.3,0.69,0)"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         id="path3122" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker1741"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path1739"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#ff0000;fill-opacity:1;fill-rule:evenodd;stroke:#ff0000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker1387"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mend">
+      <path
+         transform="matrix(-0.4,0,0,-0.4,-4,0)"
+         style="fill:#ff0000;fill-opacity:1;fill-rule:evenodd;stroke:#ff0000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path1385" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow2Send"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker4852"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path4850"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         transform="matrix(-0.3,0,0,-0.3,0.69,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow2Send"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker3691"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path3689"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         transform="matrix(-0.3,0,0,-0.3,0.69,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Sstart"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker3429"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path3427"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(0.2,0,0,0.2,1.2,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow2Send"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker2019"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path2017"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         transform="matrix(-0.3,0,0,-0.3,0.69,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow2Sstart"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker1781"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path1779"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         transform="matrix(0.3,0,0,0.3,-0.69,0)" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker1488"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mend">
+      <path
+         transform="matrix(-0.4,0,0,-0.4,-4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path1486" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker1244"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mend">
+      <path
+         inkscape:connector-curvature="0"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path1242" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow2Send"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker16235"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path16233"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         transform="matrix(-0.3,0,0,-0.3,0.69,0)" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:stockid="Arrow2Send"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker15733"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path15731"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         transform="matrix(-0.3,0,0,-0.3,0.69,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker15525"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path15523"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker9500"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mend">
+      <path
+         transform="matrix(-0.4,0,0,-0.4,-4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path9498" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker8403"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mstart">
+      <path
+         transform="matrix(0.4,0,0,0.4,4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path8401" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker8209"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mend">
+      <path
+         transform="matrix(-0.4,0,0,-0.4,-4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path8207" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker8061"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mstart">
+      <path
+         transform="matrix(0.4,0,0,0.4,4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path8059" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker7820"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path7818"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mstart"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker7684"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path7682"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(0.4,0,0,0.4,4,0)" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:stockid="Arrow1Mstart"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker6757"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path6755"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(0.4,0,0,0.4,4,0)" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:stockid="Arrow1Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker6627"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path6625"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker6012"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mstart">
+      <path
+         transform="matrix(0.4,0,0,0.4,4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path6010" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker5894"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mend">
+      <path
+         transform="matrix(-0.4,0,0,-0.4,-4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path5892" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:stockid="Arrow1Mstart"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker5567"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path5565"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(0.4,0,0,0.4,4,0)" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:stockid="Arrow1Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker5461"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path5459"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:stockid="Arrow1Mstart"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker5080"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path5078"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(0.4,0,0,0.4,4,0)" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker4986"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mend">
+      <path
+         transform="matrix(-0.4,0,0,-0.4,-4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path4984" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker4450"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow2Send">
+      <path
+         transform="matrix(-0.3,0,0,-0.3,0.69,0)"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         id="path4448" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker4374"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path4372"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:stockid="Arrow1Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker4128"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path4126"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker3864"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mend">
+      <path
+         transform="matrix(-0.4,0,0,-0.4,-4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path3862" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="Arrow1Mstart"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mstart">
+      <path
+         transform="matrix(0.4,0,0,0.4,4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path1491" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="Arrow1Sstart"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Sstart">
+      <path
+         transform="matrix(0.2,0,0,0.2,1.2,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path1497" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker1939"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow2Send">
+      <path
+         transform="matrix(-0.3,0,0,-0.3,0.69,0)"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         id="path1937" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="Arrow2Sstart"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow2Sstart">
+      <path
+         transform="matrix(0.3,0,0,0.3,-0.69,0)"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         id="path1515" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="Arrow2Send"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow2Send">
+      <path
+         transform="matrix(-0.3,0,0,-0.3,0.69,0)"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         id="path1518" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="Arrow2Mstart"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow2Mstart">
+      <path
+         transform="scale(0.6)"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         id="path1509" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="Arrow1Mend"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mend">
+      <path
+         transform="matrix(-0.4,0,0,-0.4,-4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path1494" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:stockid="Arrow1Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker4128-8"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path4126-2"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow2Send"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker4852-2"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path4850-0"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         transform="matrix(-0.3,0,0,-0.3,0.69,0)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow2Send"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker4852-2-2"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path4850-0-3"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         transform="matrix(-0.3,0,0,-0.3,0.69,0)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       id="DistanceX"
+       orient="auto"
+       refX="0.0"
+       refY="0.0"
+       style="overflow:visible">
+      <path
+         d="M 3,-3 L -3,3 M 0,-5 L  0,5"
+         style="stroke:#000000; stroke-width:0.5"
+         id="path1483" />
+    </marker>
+    <pattern
+       id="Hatch"
+       patternUnits="userSpaceOnUse"
+       width="8"
+       height="8"
+       x="0"
+       y="0">
+      <path
+         d="M8 4 l-4,4"
+         stroke="#000000"
+         stroke-width="0.25"
+         linecap="square"
+         id="path1486-4" />
+      <path
+         d="M6 2 l-4,4"
+         stroke="#000000"
+         stroke-width="0.25"
+         linecap="square"
+         id="path1488" />
+      <path
+         d="M4 0 l-4,4"
+         stroke="#000000"
+         stroke-width="0.25"
+         linecap="square"
+         id="path1490" />
+    </pattern>
+  </defs>
+  <sodipodi:namedview
+     height="281mm"
+     inkscape:document-rotation="0"
+     inkscape:snap-to-guides="true"
+     inkscape:snap-global="true"
+     inkscape:snap-bbox="false"
+     inkscape:object-paths="true"
+     inkscape:snap-intersection-paths="true"
+     inkscape:snap-object-midpoints="true"
+     inkscape:snap-others="true"
+     inkscape:snap-smooth-nodes="true"
+     inkscape:snap-midpoints="true"
+     inkscape:snap-center="true"
+     inkscape:window-maximized="1"
+     inkscape:window-y="-8"
+     inkscape:window-x="-8"
+     inkscape:window-height="1017"
+     inkscape:window-width="1920"
+     inkscape:guide-bbox="true"
+     showguides="false"
+     showborder="true"
+     showgrid="false"
+     inkscape:current-layer="g1476"
+     inkscape:document-units="mm"
+     inkscape:cy="365.67832"
+     inkscape:cx="136.98057"
+     inkscape:zoom="0.70710682"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     borderopacity="1.0"
+     bordercolor="#666666"
+     pagecolor="#ffffff"
+     id="base" />
+  <metadata
+     id="metadata834">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     style="display:none"
+     inkscape:label="Background"
+     id="layer5"
+     inkscape:groupmode="layer" />
+  <g
+     style="display:none"
+     id="layer1"
+     inkscape:groupmode="layer"
+     inkscape:label="Total_Motor">
+    <path
+       inkscape:connector-curvature="0"
+       id="path1388"
+       transform="scale(0.26458333)"
+       d="M 0,650.07812 A 472.4409,472.4409 0 0 0 -472.44141,1122.5195 472.4409,472.4409 0 0 0 0,1594.9609 472.4409,472.4409 0 0 0 472.44141,1122.5195 472.4409,472.4409 0 0 0 0,650.07812 Z m -62.580078,131.7168 c 2.119773,-0.0633 4.238058,0.0941 6.103516,0.6543 2.541358,0.7632 4.943413,2.47682 6.457031,4.65625 1.450551,2.08861 2.260179,4.14371 2.77539,6.56445 v 96.20703 l -32.126953,32.12696 v 25.01171 A 192.85715,192.85715 0 0 1 0,929.66211 192.85715,192.85715 0 0 1 79.371094,946.94922 V 922.00391 L 47.244141,889.87695 v -96.1914 c 0.515003,-2.42755 1.32369,-4.487 2.777343,-6.58008 1.513618,-2.17943 3.915677,-3.89305 6.457032,-4.65625 1.645518,-0.49416 3.491159,-0.65631 5.357422,-0.64844 A 347.10338,347.10338 0 0 1 262.25586,895.70703 c 1.75673,2.4167 3.37685,5.15152 4.01758,7.86524 0.60972,2.58247 0.32595,5.51939 -0.80469,7.91992 -1.08536,2.30442 -2.46502,4.03425 -4.30859,5.69336 l -83.3086,48.09765 -43.88476,-11.75781 -21.66211,12.50586 a 192.85715,192.85715 0 0 1 54.71484,60.06055 192.85715,192.85715 0 0 1 24.71485,77.3809 L 213.33789,1091 l 11.75781,-43.8867 83.31055,-48.09963 c 2.35704,-0.76605 4.54514,-1.093 7.08203,-0.88086 2.64428,0.2211 5.33009,1.4444 7.26172,3.26369 1.49012,1.4034 2.72559,3.2743 3.76172,5.248 a 347.10338,347.10338 0 0 1 20.5918,115.875 347.10338,347.10338 0 0 1 -20.0625,114.8164 c -1.13505,2.3551 -2.53462,4.6543 -4.28907,6.3067 -1.93162,1.8193 -4.61553,3.0425 -7.25976,3.2636 -2.5387,0.2123 -4.72893,-0.1155 -7.08789,-0.8828 l -83.3086,-48.0976 -11.75781,-43.8848 -21.66211,-12.5058 a 192.85715,192.85715 0 0 1 -24.65625,77.414 192.85715,192.85715 0 0 1 -54.65625,60.0938 l 21.60352,12.4726 43.88476,-11.7597 83.30664,48.0976 c 1.84358,1.6591 3.22324,3.3889 4.3086,5.6934 1.13066,2.4005 1.41246,5.3374 0.80273,7.9199 -0.38563,1.6333 -1.14266,3.2715 -2.05273,4.8496 A 347.10338,347.10338 0 0 1 63.15625,1463.209 c -2.309571,0.1107 -4.639833,-0.01 -6.673828,-0.6192 -2.541351,-0.7632 -4.94539,-2.4748 -6.458984,-4.6543 -1.45523,-2.0953 -2.264404,-4.1588 -2.779297,-6.5898 v -96.1836 l 32.126953,-32.1269 v -25.0118 A 192.85715,192.85715 0 0 1 0,1315.377 192.85715,192.85715 0 0 1 -79.371094,1298.0898 v 24.9454 l 32.126953,32.1269 v 96.1914 c -0.514998,2.4276 -1.323687,4.489 -2.777343,6.582 -1.513614,2.1795 -3.915681,3.8911 -6.457032,4.6543 -1.645521,0.4942 -3.491159,0.6564 -5.357422,0.6485 A 347.10338,347.10338 0 0 1 -262.22656,1349.3672 c -1.76655,-2.4252 -3.39721,-5.1736 -4.04102,-7.9004 -0.60972,-2.5825 -0.32791,-5.5194 0.80274,-7.9199 1.08656,-2.307 2.46775,-4.0385 4.31445,-5.6992 l 83.29883,-48.0918 43.88476,11.7597 21.66211,-12.5058 a 192.85715,192.85715 0 0 1 -54.71484,-60.0606 192.85715,192.85715 0 0 1 -24.71485,-77.3808 l -21.60351,12.4726 -11.75781,43.8848 -83.31055,48.0996 c -2.35704,0.766 -4.54513,1.093 -7.08203,0.8808 -2.64427,-0.2211 -5.33009,-1.4443 -7.26172,-3.2636 -1.49012,-1.4035 -2.72559,-3.2744 -3.76172,-5.2481 a 347.10338,347.10338 0 0 1 -20.5918,-115.875 347.10338,347.10338 0 0 1 20.04688,-114.7754 c 1.13845,-2.3696 2.54575,-4.6855 4.31055,-6.3476 1.93163,-1.81929 4.61551,-3.04259 7.25976,-3.26369 2.53416,-0.21191 4.7201,0.11466 7.07422,0.87891 l 83.31641,48.10158 11.75781,43.8867 21.66211,12.5059 a 192.85715,192.85715 0 0 1 24.65625,-77.4141 192.85715,192.85715 0 0 1 54.65625,-60.09571 l -21.60352,-12.4707 -43.88476,11.75781 -83.30664,-48.09765 c -1.84358,-1.65911 -3.22324,-3.38894 -4.3086,-5.69336 -1.13063,-2.40057 -1.41246,-5.33745 -0.80273,-7.91992 0.3858,-1.63403 1.14211,-3.27284 2.05273,-4.85157 A 347.10338,347.10338 0 0 1 -63.158203,781.83008 c 0.193318,-0.009 0.38466,-0.0294 0.578125,-0.0352 z"
+       style="opacity:1;fill:#008000;fill-opacity:1;stroke:#000000;stroke-width:3.77953;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+    <circle
+       r="43.733097"
+       cy="297"
+       cx="0"
+       id="path1390"
+       style="opacity:1;fill:#ff0000;fill-opacity:1;stroke:#000000;stroke-width:1.09333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+  </g>
+  <g
+     style="display:none"
+     inkscape:label="Motor_Cutaway"
+     id="layer2"
+     inkscape:groupmode="layer" />
+  <g
+     style="display:none"
+     inkscape:label="Annotations_1"
+     id="layer3"
+     inkscape:groupmode="layer">
+    <path
+       inkscape:connector-curvature="0"
+       id="path5884"
+       d="M -7.5563861,234.90369 V 206.70526"
+       style="fill:none;stroke:#000000;stroke-width:0.259632px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-start:url(#marker6012);marker-end:url(#marker5894)" />
+    <rect
+       y="218.84871"
+       x="-8.3674479"
+       height="2.2158854"
+       width="1.5875"
+       id="rect6524"
+       style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.264583;stroke-miterlimit:4;stroke-dasharray:0.79375, 0.264583;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal" />
+    <path
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       id="path1464"
+       d="M -0.02743323,297.01265 35.30925,221.27907"
+       style="fill:none;stroke:#000000;stroke-width:0.202531;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:0.810125, 0.202531;stroke-dashoffset:0;stroke-opacity:1" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.202531;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:0.810125, 0.202531;stroke-dashoffset:0;stroke-opacity:1"
+       d="M 0,297 -35.336683,221.26642"
+       id="path1466"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cc" />
+    <path
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       id="path1470"
+       d="M -21.000268,250.56454 V 221.26642"
+       style="fill:none;stroke:#000000;stroke-width:0.264583;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:0.79375, 0.264583;stroke-dashoffset:0;stroke-opacity:1" />
+    <path
+       sodipodi:nodetypes="csc"
+       inkscape:connector-curvature="0"
+       id="path1482"
+       d="m -11.797594,270.57892 c 3.5813579,-1.66871 7.5752744,-2.60053 11.78682858,-2.60053 4.23356982,0 8.24722062,0.94159 11.84295942,2.62676"
+       style="opacity:1;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.264583;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-start:url(#Arrow2Sstart);marker-end:url(#Arrow2Send);paint-order:normal" />
+    <g
+       transform="translate(-23.187493,-34.196779)"
+       id="g1919">
+      <rect
+         style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.264583;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal"
+         id="rect1907"
+         width="6.160902"
+         height="5.5858846"
+         x="20.12562"
+         y="299.38223" />
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+         x="20.947077"
+         y="304.3931"
+         id="text1895"><tspan
+           sodipodi:role="line"
+           id="tspan1893"
+           x="20.947077"
+           y="304.3931"
+           style="stroke-width:0.264583">θ<tspan
+   style="font-size:3.52778px"
+   id="tspan1897">t</tspan></tspan></text>
+    </g>
+    <flowRoot
+       transform="scale(0.26458333)"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:24px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none"
+       id="flowRoot1899"
+       xml:space="preserve"><flowRegion
+         id="flowRegion1901"><rect
+           y="1122.5197"
+           x="61.473213"
+           height="49.675323"
+           width="50.91721"
+           id="rect1903" /></flowRegion><flowPara
+         id="flowPara1905" /></flowRoot>
+    <path
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       id="path1934"
+       d="m -29.626283,232.40708 c 2.447086,-1.23671 5.213559,-1.9334 8.142751,-1.9334"
+       style="display:inline;opacity:1;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.236671;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-start:url(#Arrow1Sstart);marker-end:url(#marker1939);paint-order:normal" />
+    <rect
+       y="229.11623"
+       x="-27.407322"
+       height="3.6542518"
+       width="3.6240244"
+       id="rect1927"
+       style="display:inline;opacity:1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.13113;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal" />
+    <text
+       id="text1923"
+       y="232.42699"
+       x="-27.561081"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+       xml:space="preserve"><tspan
+         style="stroke-width:0.264583"
+         y="232.42699"
+         x="-27.561081"
+         id="tspan1921"
+         sodipodi:role="line">α</tspan></text>
+    <path
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       id="path3542"
+       d="m 25.501249,208.12668 8.748058,-30.47166"
+       style="fill:none;stroke:#000000;stroke-width:0.251839px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-start:url(#Arrow1Mstart);marker-end:url(#marker3864)" />
+    <text
+       id="text4090"
+       y="162.72395"
+       x="57.811459"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+       xml:space="preserve"><tspan
+         style="stroke-width:0.264583"
+         y="162.72395"
+         x="57.811459"
+         id="tspan4088"
+         sodipodi:role="line" /></text>
+    <path
+       inkscape:connector-curvature="0"
+       id="path3528"
+       d="M -12.500012,236.16224 V 246.8512"
+       style="display:inline;fill:none;stroke:#000000;stroke-width:0.24847px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-start:url(#marker5567);marker-end:url(#marker5461)" />
+    <text
+       id="text4094"
+       y="173.58723"
+       x="-52.318027"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+       xml:space="preserve"><tspan
+         style="stroke-width:0.264583"
+         y="173.58723"
+         x="-52.318027"
+         id="tspan4092"
+         sodipodi:role="line">D<tspan
+   id="tspan4096"
+   style="font-size:3.52778px">os</tspan></tspan></text>
+    <g
+       transform="translate(-16.559098,-7.3212701)"
+       id="g4116">
+      <rect
+         style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:0.237103;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal"
+         id="rect4104"
+         width="6.6424799"
+         height="5.9479485"
+         x="43.113136"
+         y="197.23814" />
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+         x="43.78854"
+         y="202.14687"
+         id="text4100"><tspan
+           sodipodi:role="line"
+           id="tspan4098"
+           x="43.78854"
+           y="202.14687"
+           style="stroke-width:0.264583">T<tspan
+   style="font-size:3.52778px"
+   id="tspan4102">s</tspan></tspan></text>
+    </g>
+    <path
+       sodipodi:nodetypes="ccc"
+       inkscape:connector-curvature="0"
+       id="path4118"
+       d="m -44.334244,171.98437 h 2.000911 l 4.828646,4.82865"
+       style="fill:none;stroke:#000000;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#marker4128)" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path4364"
+       d="m 15.718783,210.03594 -1.547002,-1.79208"
+       style="fill:none;stroke:#000000;stroke-width:0.191617;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:0.383234, 0.191617;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker4450)" />
+    <text
+       id="text4634"
+       y="212.41602"
+       x="15.941146"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+       xml:space="preserve"><tspan
+         style="stroke-width:0.264583"
+         y="212.41602"
+         x="15.941146"
+         id="tspan4632"
+         sodipodi:role="line">r</tspan></text>
+    <path
+       inkscape:connector-curvature="0"
+       id="path4976"
+       d="M -11.547554,219.80781 H 11.547554"
+       style="fill:none;stroke:#000000;stroke-width:0.254303px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-start:url(#marker5080);marker-end:url(#marker4986)" />
+    <g
+       transform="translate(-43.306146,19.473489)"
+       id="g4116-9">
+      <g
+         transform="translate(0,0.18708867)"
+         id="g5421">
+        <rect
+           y="197.24779"
+           x="42.65506"
+           height="5.928659"
+           width="7.7924948"
+           id="rect4104-4"
+           style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:0.256393;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal" />
+        <text
+           id="text4100-8"
+           y="202.70813"
+           x="42.993412"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+           xml:space="preserve"><tspan
+             style="stroke-width:0.264583"
+             y="202.70813"
+             x="42.993412"
+             id="tspan4098-5"
+             sodipodi:role="line">W<tspan
+   style="font-size:3.52778px"
+   id="tspan5415">t</tspan></tspan></text>
+      </g>
+    </g>
+    <path
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       id="path5449"
+       d="m -12.500012,247.56684 h 9.8872516"
+       style="fill:none;stroke:#000000;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+    <path
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       id="path5451"
+       d="m -12.500012,235.4466 h 9.8872516"
+       style="fill:none;stroke:#000000;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+    <path
+       sodipodi:arc-type="arc"
+       style="display:inline;opacity:1;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.265;stroke-miterlimit:4;stroke-dasharray:0.795, 0.265;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal"
+       id="path5875"
+       sodipodi:type="arc"
+       sodipodi:cx="0"
+       sodipodi:cy="296.99997"
+       sodipodi:rx="91.67807"
+       sodipodi:ry="91.67807"
+       sodipodi:start="4.4466291"
+       sodipodi:end="4.5768786"
+       sodipodi:open="true"
+       d="m -24.078562,208.54042 a 91.67807,91.67807 0 0 1 11.693219,-2.37806" />
+    <path
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       id="path5878"
+       d="m -12.500012,213.23104 v -7.0392"
+       style="fill:none;stroke:#000000;stroke-width:0.264583;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:0.79375, 0.264583;stroke-dashoffset:0;stroke-opacity:1" />
+    <path
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       id="path5882"
+       d="m -12.385343,206.16235 h 9.7725826"
+       style="fill:none;stroke:#000000;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+    <g
+       transform="translate(-53.364328,27.478398)"
+       id="g4116-9-8"
+       style="display:inline">
+      <g
+         transform="translate(0,0.18708867)"
+         id="g5421-1">
+        <rect
+           y="197.24779"
+           x="42.65506"
+           height="5.928659"
+           width="7.7924948"
+           id="rect4104-4-4"
+           style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:0.256393;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal" />
+        <text
+           id="text4100-8-5"
+           y="202.17897"
+           x="43.456432"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+           xml:space="preserve"><tspan
+             style="stroke-width:0.264583"
+             y="202.17897"
+             x="43.456432"
+             id="tspan4098-5-6"
+             sodipodi:role="line"><tspan
+               style="font-size:3.52778px"
+               id="tspan5415-7"><tspan
+   id="tspan6615"
+   style="font-size:6.35px">L</tspan>t</tspan></tspan></text>
+      </g>
+    </g>
+    <g
+       transform="translate(-53.364328,40.708055)"
+       id="g4116-9-8-7"
+       style="display:inline">
+      <g
+         transform="translate(0,0.18708867)"
+         id="g5421-1-5">
+        <rect
+           y="197.24779"
+           x="42.65506"
+           height="5.928659"
+           width="7.7924948"
+           id="rect4104-4-4-1"
+           style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:0.256393;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal" />
+        <text
+           id="text4100-8-5-7"
+           y="202.17897"
+           x="43.456432"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+           xml:space="preserve"><tspan
+             style="stroke-width:0.264583"
+             y="202.17897"
+             x="43.456432"
+             id="tspan4098-5-6-6"
+             sodipodi:role="line"><tspan
+               style="font-size:3.52778px"
+               id="tspan5415-7-7"><tspan
+   id="tspan6580-5"
+   style="font-size:6.35px">L</tspan>tt</tspan></tspan></text>
+      </g>
+    </g>
+    <path
+       sodipodi:nodetypes="ccc"
+       inkscape:connector-curvature="0"
+       id="path4118-8"
+       d="m -28.486583,277.7367 h -2.000911 l -4.828646,-4.82865"
+       style="display:inline;fill:none;stroke:#000000;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#marker4128-8)" />
+    <text
+       id="text4094-6"
+       y="279.95316"
+       x="-28.468546"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+       xml:space="preserve"><tspan
+         style="stroke-width:0.264583"
+         y="279.95316"
+         x="-28.468546"
+         id="tspan4092-2"
+         sodipodi:role="line">D<tspan
+   id="tspan4096-9"
+   style="font-size:3.52778px;stroke-width:0.264583">or</tspan></tspan></text>
+    <path
+       inkscape:transform-center-y="-47.336963"
+       inkscape:transform-center-x="-0.53635573"
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       id="path6617"
+       d="m 0.49341607,252.4546 0.0643483,-5.62927"
+       style="display:inline;fill:none;stroke:#000000;stroke-width:0.204665px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-start:url(#marker6757);marker-end:url(#marker6627)" />
+    <text
+       id="text4100-8-5-7-6"
+       y="251.6891"
+       x="1.700698"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+       xml:space="preserve"><tspan
+         style="stroke-width:0.264583"
+         y="251.6891"
+         x="1.700698"
+         id="tspan4098-5-6-6-5"
+         sodipodi:role="line"><tspan
+           style="font-size:3.52778px"
+           id="tspan5415-7-7-3"><tspan
+   id="tspan6580-5-5"
+   style="font-size:6.35px">L</tspan>g</tspan></tspan></text>
+    <path
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       id="path15507"
+       d="m 21.000268,250.54698 h 8.688366"
+       style="fill:none;stroke:#000000;stroke-width:0.23934px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+    <path
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       id="path15509"
+       d="m 21.000268,243.94686 h 8.688366"
+       style="fill:none;stroke:#000000;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+    <text
+       id="text15513"
+       y="248.73111"
+       x="25.765221"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+       xml:space="preserve"><tspan
+         style="stroke-width:0.264583"
+         y="248.73111"
+         x="25.765221"
+         id="tspan15511"
+         sodipodi:role="line">s</tspan></text>
+    <path
+       inkscape:connector-curvature="0"
+       id="path15515"
+       d="m 27.057699,249.05852 v 0.97042"
+       style="fill:none;stroke:#000000;stroke-width:0.276484px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#marker15733)" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path15945"
+       d="m 27.060298,245.50384 v -1.05237"
+       style="fill:none;stroke:#000000;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#marker16235)" />
+  </g>
+  <g
+     style="display:inline"
+     inkscape:label="Annotations_2"
+     id="layer4"
+     inkscape:groupmode="layer">
+    <g
+       transform="translate(-20.688286,17.424232)"
+       id="g4116-9-8-2-5"
+       style="display:inline">
+      <g
+         transform="translate(0,0.18708867)"
+         id="g5421-1-7-0">
+        <text
+           id="text4100-8-5-1-8"
+           y="202.24512"
+           x="42.629608"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+           xml:space="preserve"><tspan
+             style="stroke-width:0.264583"
+             y="0"
+             x="0"
+             id="tspan4098-5-6-1-3"
+             sodipodi:role="line"><tspan
+               style="font-size:3.52778px"
+               id="tspan5415-7-3-8"><tspan
+                 id="tspan6615-5-9"
+                 style="font-size:6.35px" /></tspan></tspan></text>
+      </g>
+    </g>
+    <g
+       transform="translate(104.775,-83.608331)"
+       id="g1476">
+      <text
+         xml:space="preserve"
+         style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.23333px;line-height:1.25;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman, Italic';letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+         x="-63.495491"
+         y="237.22881"
+         id="text2115"><tspan
+           sodipodi:role="line"
+           id="tspan2113"
+           x="-63.495491"
+           y="237.22881"
+           style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman, Italic';stroke-width:0.264583">x</tspan></text>
+      <text
+         xml:space="preserve"
+         style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:10.5833px;line-height:1.25;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman,  Italic';letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+         x="-85.644028"
+         y="214.6772"
+         id="text2145"><tspan
+           sodipodi:role="line"
+           id="tspan2143"
+           x="-85.644028"
+           y="214.6772"
+           style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman, Italic';stroke-width:0.264583">y</tspan></text>
+      <path
+         inkscape:connector-curvature="0"
+         id="path1377"
+         d="m -82.920578,234.75873 h 17.586349"
+         style="fill:none;stroke:#ff0000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#marker1387)" />
+      <path
+         inkscape:transform-center-x="8.793175"
+         style="fill:none;stroke:#ff0000;stroke-width:0.5;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#marker1741)"
+         d="M -82.920578,234.75873 V 217.17238"
+         id="path1737"
+         inkscape:connector-curvature="0" />
+      <g
+         id="g2975"
+         transform="matrix(1.2894382,0,0,1.2890575,17.559639,-52.41122)"
+         style="stroke-width:0.775646">
+        <path
+           d="m -38.697923,206.30817 7.63423,-0.36676"
+           style="fill:none;stroke:#b3b3b3;stroke-width:0.542953;stroke-miterlimit:4;stroke-dasharray:none"
+           id="path1495" />
+        <path
+           d="m -31.063693,205.94141 5.94797,4.42591"
+           style="fill:none;stroke:#000000;stroke-width:0.775646;stroke-miterlimit:4;stroke-dasharray:none"
+           id="path1497-4" />
+        <path
+           d="M -25.115723,210.36732 H 7.2900367"
+           style="fill:none;stroke:#000000;stroke-width:0.775646;stroke-miterlimit:4;stroke-dasharray:none"
+           id="path1499" />
+        <path
+           d="M 7.2900367,236.00389 H -25.115723"
+           style="fill:none;stroke:#b3b3b3;stroke-width:0.542953;stroke-miterlimit:4;stroke-dasharray:none"
+           id="path1501" />
+        <path
+           d="m -25.115723,236.00389 -5.94797,4.42588"
+           style="fill:none;stroke:#b3b3b3;stroke-width:0.542953;stroke-miterlimit:4;stroke-dasharray:none"
+           id="path1503" />
+        <path
+           d="m -31.063693,240.42977 -7.63423,-0.36667"
+           style="fill:none;stroke:#b3b3b3;stroke-width:0.542953;stroke-miterlimit:4;stroke-dasharray:none"
+           id="path1505" />
+        <path
+           d="m -71.411203,183.40204 3.49954,-6.79471"
+           style="fill:none;stroke:#b3b3b3;stroke-width:0.542953;stroke-miterlimit:4;stroke-dasharray:none"
+           id="path1507" />
+        <path
+           d="m -67.911663,176.60733 6.80692,-2.9382"
+           style="fill:none;stroke:#b3b3b3;stroke-width:0.542953;stroke-miterlimit:4;stroke-dasharray:none"
+           id="path1509-9" />
+        <path
+           d="m -61.104743,173.66913 16.20291,-28.06421"
+           style="fill:none;stroke:#b3b3b3;stroke-width:0.542953;stroke-miterlimit:4;stroke-dasharray:none"
+           id="path1511" />
+        <path
+           d="m -22.699903,158.42319 -16.20288,28.06418"
+           style="fill:none;stroke:#b3b3b3;stroke-width:0.542953;stroke-miterlimit:4;stroke-dasharray:none"
+           id="path1513" />
+        <path
+           d="m -38.902783,186.48737 0.85892,7.3641"
+           style="fill:none;stroke:#b3b3b3;stroke-width:0.542953;stroke-miterlimit:4;stroke-dasharray:none"
+           id="path1515-9" />
+        <path
+           d="m -38.043863,193.85147 -4.13468,6.42813"
+           style="fill:none;stroke:#b3b3b3;stroke-width:0.542953;stroke-miterlimit:4;stroke-dasharray:none"
+           id="path1517" />
+        <path
+           d="M -2.8597133,181.59787 -34.103343,199.63642"
+           style="fill:#000000;stroke:#000000;stroke-width:0.775646;stroke-miterlimit:4;stroke-dasharray:none"
+           id="path1567" />
+        <path
+           d="m -38.697923,240.0631 a 39.935524,39.935524 0 0 0 0,-33.75493"
+           style="fill:none;stroke:#b3b3b3;stroke-width:0.542953;stroke-miterlimit:4;stroke-dasharray:none"
+           id="path1579" />
+        <path
+           d="m 7.2900567,210.36732 a 83.175508,83.175508 0 0 0 -10.14977,-28.76945"
+           style="fill:none;stroke:#000000;stroke-width:0.775646;stroke-miterlimit:4;stroke-dasharray:none"
+           id="path1581" />
+        <path
+           d="m 19.122407,277.46473 a 108.55826,108.55826 0 0 0 0,-108.55825"
+           style="fill:none;stroke:#b3b3b3;stroke-width:0.542953;stroke-miterlimit:4;stroke-dasharray:none"
+           id="path1583" />
+        <path
+           d="m -2.8597133,264.7734 a 83.175508,83.175508 0 0 0 10.14977,-28.76951"
+           style="fill:none;stroke:#b3b3b3;stroke-width:0.542953;stroke-miterlimit:4;stroke-dasharray:none"
+           id="path1585" />
+        <path
+           d="m -42.178543,200.2796 a 39.935524,39.935524 0 0 0 -29.23264,-16.87756"
+           style="fill:none;stroke:#b3b3b3;stroke-width:0.542953;stroke-miterlimit:4;stroke-dasharray:none"
+           id="path1587" />
+        <path
+           d="m -44.901833,145.60492 a 83.175508,83.175508 0 0 0 -29.98997,-5.59481"
+           style="fill:none;stroke:#b3b3b3;stroke-width:0.542953;stroke-miterlimit:4;stroke-dasharray:none"
+           id="path1589" />
+        <path
+           d="m 19.122407,168.90648 a 108.55826,108.55826 0 0 0 -94.01421,-54.27911"
+           style="fill:none;stroke:#b3b3b3;stroke-width:0.542953;stroke-miterlimit:4;stroke-dasharray:none"
+           id="path1591" />
+        <path
+           d="M -2.8597133,181.59787 A 83.175508,83.175508 0 0 0 -22.699903,158.42319"
+           style="fill:none;stroke:#b3b3b3;stroke-width:0.542953;stroke-miterlimit:4;stroke-dasharray:none"
+           id="path1593" />
+        <path
+           d="m -31.063693,205.94141 a 47.098454,47.098454 0 0 0 -3.03965,-6.30499"
+           style="fill:none;stroke:#000000;stroke-width:0.775646;stroke-miterlimit:4;stroke-dasharray:none"
+           id="path1627" />
+      </g>
+    </g>
+  </g>
+</svg>

--- a/mach_cad/model_obj/cross_sects/inner_rotor_stator/__init__.py
+++ b/mach_cad/model_obj/cross_sects/inner_rotor_stator/__init__.py
@@ -5,7 +5,7 @@ from ...dimensions.dim_linear import DimLinear
 from ...dimensions.dim_angular import DimAngular
 from ..cross_sect_base import CrossSectBase, CrossSectToken
 
-__all__ = ['CrossSectInnerRotorStator']
+__all__ = ['CrossSectInnerRotorStator', 'CrossSectInnerRotorStatorPartial', 'CrossSectInnerRotorStatorRightSlot', 'CrossSectInnerRotorStatorLeftSlot']
 
 
 class CrossSectInnerRotorStator(CrossSectBase):
@@ -216,3 +216,440 @@ class CrossSectInnerRotorStator(CrossSectBase):
             pass
         else:
             raise TypeError("Q not of type int")
+
+
+class CrossSectInnerRotorStatorPartial(CrossSectBase):
+
+    def __init__(self, **kwargs: any) -> None:
+        '''
+        Intialization function for HollowCylinder class. This function takes in
+        arguments and saves the information passed to private variable to make
+        them read-only
+        Parameters
+        ----------
+        **kwargs : any
+            DESCRIPTION. Keyword arguments provided to the initialization funcntion.
+            The following argument names have to be included in order for the code
+            to execute: name, dim_t, dim_r_o, location. 
+            
+        Returns
+        -------
+        None
+        '''
+        self._create_attr(kwargs)
+
+        super()._validate_attr()
+        self._validate_attr()
+
+    @property
+    def dim_alpha_st(self):
+        return self._dim_alpha_st
+
+    @property
+    def dim_alpha_so(self):
+        return self._dim_alpha_so
+
+    @property
+    def dim_r_si(self):
+        return self._dim_r_si
+
+    @property
+    def dim_d_so(self):
+        return self._dim_d_so
+
+    @property
+    def dim_d_sp(self):
+        return self._dim_d_sp
+
+    @property
+    def dim_d_st(self):
+        return self._dim_d_st
+
+    @property
+    def dim_d_sy(self):
+        return self._dim_d_sy
+
+    @property
+    def dim_w_st(self):
+        return self._dim_w_st
+
+    @property
+    def dim_r_st(self):
+        return self._dim_r_st
+
+    @property
+    def dim_r_sf(self):
+        return self._dim_r_sf
+
+    @property
+    def dim_r_sb(self):
+        return self._dim_r_sb
+
+    @property
+    def Q(self):
+        return self._Q
+
+    def draw(self, drawer):
+
+        alpha_st = DimRadian(self.dim_alpha_st)
+        alpha_so = DimRadian(self.dim_alpha_so)
+        r_si = self.dim_r_si
+        d_so = self.dim_d_so
+        d_sp = self.dim_d_sp
+        d_st = self.dim_d_st
+        d_sy = self.dim_d_sy
+        w_st = self.dim_w_st
+        r_st = self.dim_r_st
+        r_sf = self.dim_r_sf
+        r_sb = self.dim_r_sb
+        Q = self.Q
+
+        alpha_total = DimRadian(2 * np.pi / Q)
+
+        x1 = r_si * np.cos(alpha_st / 2)
+        beta2 = alpha_st / 2 - alpha_so
+        x2 = x1 + d_so * np.cos(beta2)
+        r3 = r_si + d_sp
+        beta3 = np.arcsin((w_st / 2) / r3)
+        x3 = r3 * np.cos(beta3)
+        r4 = r3 + d_st
+        beta4 = np.arcsin((w_st / 2) / r4)
+        x4 = r4 * np.cos(beta4)
+        x5 = r4 * np.cos(alpha_total / 2)
+        x6 = (r4 + d_sy) * np.cos(alpha_total / 2)
+
+        y1 = r_si * np.sin(alpha_st / 2)
+        y2 = y1 + d_so * np.sin(beta2)
+        y3 = w_st / 2
+        y4 = w_st / 2
+        y5 = r4 * np.sin(alpha_total / 2)
+        y6 = (r4 + d_sy) * np.sin(alpha_total / 2)
+
+        x_arr = [x1, x1, x2, x3, x4, x5, x6, x6, x5, x4, x3, x2]
+        y_arr = [-y1, y1, y2, y3, y4, y5, y6, -y6, -y5, -y4, -y3, -y2]
+
+        arc1 = []
+        arc2 = []
+        arc3 = []
+        arc4 = []
+        seg1 = []
+        seg2 = []
+        seg3 = []
+        seg4 = []
+        seg5 = []
+        seg6 = []
+        seg7 = []
+        seg8 = []
+
+        # transpose list
+        coords = [x_arr, y_arr]
+        coords = list(zip(*coords))
+        coords = [list(sublist) for sublist in coords]
+
+        for i in range(0, 1):
+            p = self.location.transform_coords(coords, alpha_total * i)
+
+            arc1.append(drawer.draw_arc(self.location.anchor_xy, p[0], p[1]))
+            seg1.append(drawer.draw_line(p[1], p[2]))
+            seg2.append(drawer.draw_line(p[2], p[3]))
+            seg3.append(drawer.draw_line(p[3], p[4]))
+            arc2.append(drawer.draw_arc(self.location.anchor_xy, p[4], p[5]))
+            arc3.append(drawer.draw_arc(self.location.anchor_xy, p[7], p[6]))
+            arc4.append(drawer.draw_arc(self.location.anchor_xy, p[8], p[9]))
+            seg4.append(drawer.draw_line(p[9], p[10]))
+            seg5.append(drawer.draw_line(p[10], p[11]))
+            seg6.append(drawer.draw_line(p[11], p[0]))
+            seg7.append(drawer.draw_line(p[5], p[6]))
+            seg8.append(drawer.draw_line(p[7], p[8]))
+
+        rad = (x3 + x4) / 2
+        inner_coord = self.location.transform_coords([[rad, 0]])
+        segments = [arc1, seg1, seg2, seg3, arc2, arc3, arc4, seg4, seg5, seg6, seg7, seg8]
+        segs = [x for segment in segments for x in segment]
+        cs_token = CrossSectToken(inner_coord[0], segs)
+        return cs_token
+
+    def _validate_attr(self):
+
+        if isinstance(self._dim_alpha_st, DimAngular):
+            pass
+        else:
+            raise TypeError("dim_alpha_st not of type DimAngular")
+
+        if isinstance(self._dim_alpha_so, DimAngular):
+            pass
+        else:
+            raise TypeError("dim_alpha_so not of type DimAngular")
+
+        if isinstance(self._dim_r_si, DimLinear):
+            pass
+        else:
+            raise TypeError("dim_r_si not of type DimLinear")
+
+        if isinstance(self._dim_d_so, DimLinear):
+            pass
+        else:
+            raise TypeError("dim_d_so not of type DimLinear")
+
+        if isinstance(self._dim_d_sp, DimLinear):
+            pass
+        else:
+            raise TypeError("dim_d_sp not of type DimLinear")
+
+        if isinstance(self._dim_d_st, DimLinear):
+            pass
+        else:
+            raise TypeError("dim_d_st not of type DimLinear")
+
+        if isinstance(self._dim_d_sy, DimLinear):
+            pass
+        else:
+            raise TypeError("dim_d_sy not of type DimLinear")
+
+        if isinstance(self._dim_w_st, DimLinear):
+            pass
+        else:
+            raise TypeError("dim_w_st not of type DimLinear")
+
+        if isinstance(self._dim_r_sf, DimLinear):
+            pass
+        else:
+            raise TypeError("dim_r_sf not of type DimLinear")
+
+        if isinstance(self._dim_r_st, DimLinear):
+            pass
+        else:
+            raise TypeError("dim_r_st not of type DimLinear")
+
+        if isinstance(self._dim_r_sb, DimLinear):
+            pass
+        else:
+            raise TypeError("dim_r_sb not of type DimLinear")
+
+        if isinstance(self._Q, int):
+            pass
+        else:
+            raise TypeError("Q not of type int")
+
+
+class CrossSectInnerRotorStatorRightSlot(CrossSectBase):
+
+    def __init__(self, **kwargs: any) -> None:
+        '''
+        Intialization function for HalfSlot class. This function takes in
+        arguments and saves the information passed to private variable to make
+        them read-only
+        Parameters
+        ----------
+        **kwargs : any
+            DESCRIPTION. Keyword arguments provided to the initialization funcntion.
+            The following argument names have to be included in order for the code
+            to execute: name, dim_t, dim_r_o, location. 
+            
+        Returns
+        -------
+        None
+        '''
+        self._create_attr(kwargs)
+
+        super()._validate_attr()
+        self._validate_attr()
+
+    @property
+    def stator_core(self):
+        return self._stator_core
+
+    def draw(self, drawer):
+
+        alpha_st = DimRadian(self.stator_core.dim_alpha_st)
+        alpha_so = DimRadian(self.stator_core.dim_alpha_so)
+        r_si = self.stator_core.dim_r_si
+        d_so = self.stator_core.dim_d_so
+        d_sp = self.stator_core.dim_d_sp
+        d_st = self.stator_core.dim_d_st
+        d_sy = self.stator_core.dim_d_sy
+        w_st = self.stator_core.dim_w_st
+        r_st = self.stator_core.dim_r_st
+        r_sf = self.stator_core.dim_r_sf
+        r_sb = self.stator_core.dim_r_sb
+        Q = self.stator_core.Q
+
+        alpha_total = DimRadian(2 * np.pi / Q)
+
+        x1 = r_si * np.cos(alpha_st / 2)
+        beta2 = alpha_st / 2 - alpha_so
+        x2 = x1 + d_so * np.cos(beta2)
+        r3 = r_si + d_sp
+        beta3 = np.arcsin((w_st / 2) / r3)
+        x3 = r3 * np.cos(beta3)
+        r4 = r3 + d_st
+        beta4 = np.arcsin((w_st / 2) / r4)
+        x4 = r4 * np.cos(beta4)
+        x5 = r4 * np.cos(alpha_total / 2)
+
+        y1 = r_si * np.sin(alpha_st / 2)
+        y2 = y1 + d_so * np.sin(beta2)
+        y3 = w_st / 2
+        y4 = w_st / 2
+        y5 = r4 * np.sin(alpha_total / 2)
+
+        beta5 = alpha_total / 2 - DimRadian(np.arctan(y2 / x2))
+
+        x6 = x2 * np.cos(beta5) - y2 * np.sin(beta5)
+        y6 = x2 * np.sin(beta5) + y2 * np.cos(beta5)
+
+
+        x_arr = [x2, x3, x4, x5, x6]
+        y_arr = [y2, y3, y4, y5, y6]
+
+        seg1 = []
+        seg2 = []
+        arc1 = []
+        seg3 = []
+        arc2 = []
+
+        # transpose list
+        coords = [x_arr, y_arr]
+        coords = list(zip(*coords))
+        coords = [list(sublist) for sublist in coords]
+
+        # for i in range(0, 0):
+        p = self.location.transform_coords(coords, alpha_total * 0)
+        seg1.append(drawer.draw_line(p[0], p[1]))
+        seg2.append(drawer.draw_line(p[1], p[2]))
+        arc1.append(drawer.draw_arc(self.location.anchor_xy, p[2], p[3]))
+        seg3.append(drawer.draw_line(p[3], p[4]))            
+        arc2.append(drawer.draw_arc(self.location.anchor_xy, p[0], p[4]))
+
+        alpha_c = 2 * np.pi / Q * 1 / 2 - (np.arctan(y5 / x5) - np.arctan(y4 / x4)) / 2
+        xc = (x3 + x4) / 2 * np.cos(alpha_c)
+        yc = (x3 + x4) / 2 * np.sin(alpha_c)
+
+        inner_coord = self.location.transform_coords([[xc, yc]])
+        segments = [seg1, seg2, seg3, arc1, arc2]
+        segs = [x for segment in segments for x in segment]
+        cs_token = CrossSectToken(inner_coord[0], segs)
+        return cs_token
+
+    def _validate_attr(self):
+
+        if (isinstance(self.stator_core, CrossSectInnerRotorStator)) or (isinstance(self.stator_core, CrossSectInnerRotorStatorPartial)):
+            pass
+        else:
+            raise TypeError("stator_core not of type CrossSectInnerRotorStator")
+
+
+
+class CrossSectInnerRotorStatorLeftSlot(CrossSectBase):
+
+    def __init__(self, **kwargs: any) -> None:
+        '''
+        Intialization function for HalfSlot class. This function takes in
+        arguments and saves the information passed to private variable to make
+        them read-only
+        Parameters
+        ----------
+        **kwargs : any
+            DESCRIPTION. Keyword arguments provided to the initialization funcntion.
+            The following argument names have to be included in order for the code
+            to execute: name, dim_t, dim_r_o, location. 
+            
+        Returns
+        -------
+        None
+        '''
+        self._create_attr(kwargs)
+
+        super()._validate_attr()
+        self._validate_attr()
+
+    @property
+    def stator_core(self):
+        return self._stator_core
+
+    def draw(self, drawer):
+
+        alpha_st = DimRadian(self.stator_core.dim_alpha_st)
+        alpha_so = DimRadian(self.stator_core.dim_alpha_so)
+        r_si = self.stator_core.dim_r_si
+        d_so = self.stator_core.dim_d_so
+        d_sp = self.stator_core.dim_d_sp
+        d_st = self.stator_core.dim_d_st
+        d_sy = self.stator_core.dim_d_sy
+        w_st = self.stator_core.dim_w_st
+        r_st = self.stator_core.dim_r_st
+        r_sf = self.stator_core.dim_r_sf
+        r_sb = self.stator_core.dim_r_sb
+        Q = self.stator_core.Q
+
+        alpha_total = DimRadian(2 * np.pi / Q)
+
+        x1 = r_si * np.cos(alpha_st / 2)
+        beta2 = alpha_st / 2 - alpha_so
+        x2 = x1 + d_so * np.cos(beta2)
+        r3 = r_si + d_sp
+        beta3 = np.arcsin((w_st / 2) / r3)
+        x3 = r3 * np.cos(beta3)
+        r4 = r3 + d_st
+        beta4 = np.arcsin((w_st / 2) / r4)
+        x4 = r4 * np.cos(beta4)
+        x5 = r4 * np.cos(alpha_total / 2)
+
+        y1 = r_si * np.sin(alpha_st / 2)
+        y2 = y1 + d_so * np.sin(beta2)
+        y3 = w_st / 2
+        y4 = w_st / 2
+        y5 = r4 * np.sin(alpha_total / 2)
+
+        beta5 = alpha_total / 2 - DimRadian(np.arctan(y2 / x2))
+
+        x6 = x2 * np.cos(beta5) - y2 * np.sin(beta5)
+        y6 = x2 * np.sin(beta5) + y2 * np.cos(beta5)
+
+
+        x_arr = [x2, x3, x4, x5, x6]
+        y_arr = [y2, y3, y4, y5, y6]
+            
+        seg1 = []
+        seg2 = []
+        arc1 = []
+        seg3 = []
+        arc2 = []
+
+        # transpose list
+        coords = [x_arr, y_arr]
+        coords = list(zip(*coords))
+        coords = [list(sublist) for sublist in coords]
+        coords = self.location.transform_coords(coords, alpha_total * - 1 / 2)
+        for i in range(0, len(coords)):
+            coords[i][1] = - coords[i][1]
+        coords = self.location.transform_coords(coords, alpha_total * 1 / 2)
+        for i in range(0, len(coords)):
+            x_arr[i] = coords[i][0]
+            y_arr[i] = coords[i][1]
+            
+        p = self.location.transform_coords(coords, alpha_total * 0)
+
+        seg1.append(drawer.draw_line(p[0], p[1]))
+        seg2.append(drawer.draw_line(p[1], p[2]))
+        arc1.append(drawer.draw_arc(self.location.anchor_xy, p[3], p[2]))
+        seg3.append(drawer.draw_line(p[3], p[4]))            
+        arc2.append(drawer.draw_arc(self.location.anchor_xy, p[4], p[0]))
+
+        alpha_c = 2 * np.pi / Q * 1 / 2 + (np.arctan(y5 / x5) - np.arctan(y4 / x4)) / 2
+        xc = (x3 + x4) / 2 * np.cos(alpha_c)
+        yc = (x3 + x4) / 2 * np.sin(alpha_c)
+
+        inner_coord = self.location.transform_coords([[xc, yc]])
+        segments = [seg1, seg2, arc1, seg3, arc2]
+        segs = [x for segment in segments for x in segment]
+        cs_token = CrossSectToken(inner_coord[0], segs)
+        return cs_token
+
+    def _validate_attr(self):
+
+        if (isinstance(self.stator_core, CrossSectInnerRotorStator)) or (isinstance(self.stator_core, CrossSectInnerRotorStatorPartial)):
+            pass
+        else:
+            raise TypeError("stator_core not of type CrossSectInnerRotorStator")
+

--- a/mach_cad/tools/femm/FEMM.py
+++ b/mach_cad/tools/femm/FEMM.py
@@ -1,0 +1,317 @@
+import os, sys
+import numpy as np
+import femm
+
+from ..tool_abc import toolabc as abc
+from ..token_draw import TokenDraw
+from ..token_make import TokenMake
+from ...model_obj.dimensions import *
+
+__all__ = []
+__all__ += ["FEMMDesigner"]
+
+
+class FEMMDesigner(
+    abc.ToolBase, abc.DrawerBase, abc.MakerExtrudeBase, abc.MakerRevolveBase
+):
+    # FEMM Encapsulation.
+    def __init__(self):
+        """ FEMM init."""
+        """Go to https://www.femm.info/wiki/pyFEMM for more details of femm methods."""
+
+    def newdocument(
+        self,
+        hide_window=1,
+        problem_type=0,
+        ):
+        """Create a new .fem document."""
+        # magnetostatic problem: problem_type = 0
+        femm.openfemm(hide_window)
+        femm.newdocument(problem_type)
+
+    def open(self, filename):
+        """Open an existing document"""
+        femm.opendocument(filename)
+
+    def save(self, filepath):
+        """Save document."""
+        femm.mi_saveas(filepath)
+
+    def save_as(self, filepath):
+        """Save document."""
+
+        femm.mi_saveas(filepath)
+        # return attempts
+
+    def close(self):
+        """Close femm"""
+        femm.mi_close()
+        femm.closefemm()
+
+    def draw_line(self, startxy: "Location2D", endxy: "Location2D") -> "TokenDraw":
+        """Draw a line in FEMM.
+
+        Args:
+            startxy: Start point of line. Should be of type Location2D defined with eMach DimLinear.
+            endxy: End point of the line. Should be of type Location2D defined with eMach DimLinear.
+
+        Returns:
+            TokenDraw: Wrapper object holding return values obtained upon drawing a line.
+        """
+        femm.mi_addnode(startxy[0], startxy[1])
+        femm.mi_addnode(endxy[0], endxy[1])
+        femm.mi_addsegment(startxy[0], startxy[1], endxy[0], endxy[1])
+
+        line = 1
+        return TokenDraw(line, 0)
+
+    def draw_arc(
+        self, centerxy: "Location2D", startxy: "Location2D", endxy: "Location2D"
+    ) -> "TokenDraw":
+        """Draw an arc in FEMM.
+
+        Args:
+            centerxy: Center point of arc. Should be of type Location2D defined with eMach Dimensions.
+            startxy: Start point of arc. Should be of type Location2D defined with eMach Dimensions.
+            endxy: End point of arc. Should be of type Location2D defined with eMach Dimensions.
+
+        Returns:
+            TokenDraw: Wrapper object holding return values obtained from tool upon drawing an arc.
+        """
+        
+        alpha_s = np.arctan2(startxy[1] - centerxy[1], startxy[0] - centerxy[0])%(2*np.pi)
+        alpha_e = np.arctan2(endxy[1] - centerxy[1], endxy[0] - centerxy[0])%(2*np.pi)
+        
+        if alpha_e < alpha_s:
+            alpha_e = alpha_e + 2 * np.pi
+
+        arc_angle = (alpha_e - alpha_s) / np.pi * 180    
+        femm.mi_addnode(startxy[0], startxy[1])
+        femm.mi_addnode(endxy[0], endxy[1])
+        femm.mi_addarc(startxy[0], startxy[1], endxy[0], endxy[1], arc_angle, 1)
+        
+        arc = 1
+        return TokenDraw(arc, 1)
+
+    def draw_circle(self, centerxy, radius):
+        """Draw a circle in FEMM."""
+        startxy = np.array([0, 0])
+        endxy = np.array([0, 0])
+        startxy[0] = centerxy[0] + radius
+        startxy[1] = centerxy[1]
+        endxy[0] = centerxy[0] - radius
+        endxy[1] = centerxy[1]
+
+        femm.mi_drawarc(startxy[0], startxy[1], endxy[0], endxy[1], 180, 1)
+        femm.mi_drawarc(endxy[0], endxy[1], startxy[0], startxy[1], 180, 1)
+        return 1
+
+    def probdef(
+        self,
+        freq=0,
+        units='millimeters',
+        type='planar',
+        precision=1e-8,
+        depth=1,
+        minangle=30,
+        acsolver=0):
+        """Define a femm problem."""
+        femm.mi_probdef(freq, units, type, precision, depth, minangle, acsolver)
+
+    def add_material(self,mat_name):
+        """Add a material that already exists in the femm library."""
+        femm.mi_getmaterial(mat_name)
+ 
+    def add_new_material(
+        self,
+        mat_name='NewMaterial', 
+        mu_x=1, 
+        mu_y=1, 
+        H_c=0, 
+        J=0, 
+        Cduct=0, 
+        Lam_d=0, 
+        Phi_hmax=0, 
+        lam_fill=1, 
+        LamType=0, 
+        Phi_hx=0, 
+        Phi_hy=0, 
+        nstr=0, 
+        dwire=0,
+        hdata=(0,0),
+        bdata=(0,0)):
+        """Add a new material to the project."""
+        femm.mi_addmaterial(mat_name, mu_x, mu_y, H_c, J, Cduct, Lam_d, 
+            Phi_hmax, lam_fill, LamType, Phi_hx, Phi_hy, nstr, dwire)
+        if len(bdata) > 2:
+            for n in range(0, len(bdata)):
+                femm.mi_addbhpoint(mat_name, bdata[n], hdata[n])
+
+    def set_block_prop(
+        self,
+        new_block=0,
+        inner_coord=[0,0],        
+        material_name='<None>',
+        automesh=True,
+        meshsize_if_no_automesh=0,
+        incircuit=0,
+        magdir=0,
+        group_no=0,     
+        turns=0,
+        ):
+        """This method selects a block label with coordinates (inner_coord[0], inner_coord[1])
+        and a material name 'material_name', and sets component properties:
+        automesh, meshsize (if no automesh), circuit name,
+        magnet direction, group number, and number of turns.        
+        """
+        if new_block == 1:
+            femm.mi_addblocklabel(inner_coord[0], inner_coord[1])
+
+        femm.mi_selectlabel(inner_coord[0], inner_coord[1])
+        femm.mi_setblockprop(material_name, automesh, meshsize_if_no_automesh,
+            incircuit, magdir, group_no, turns)
+        femm.mi_clearselected()
+
+    def select_circle(self, centerxy=(0, 0), radius=0, editmode=4):
+        """Select circle (used to create a motion component)
+        editmode=4 selects all entity types (nodes, segments, arcs, block labels)"""
+        femm.mi_selectcircle(centerxy[0], centerxy[1], radius, editmode)
+
+    def set_group(self, groupID):
+        """Sets groupID to the selected entities"""
+        femm.mi_setgroup(groupID)
+        femm.mi_clearselected
+
+    def smartmesh(self, state):
+        femm.mi_smartmesh(state)
+
+    def create_boundary_condition(
+        self,
+        number_of_shells=10, # should be between 1 and 10
+        radius=0,
+        centerxy=(0, 0),
+        bc = 1 # 0 for a Dirichlet outer edge or 1 for a Neumann outer edge
+        ):
+        femm.mi_makeABC(number_of_shells, radius, centerxy[0], centerxy[1], bc)
+
+    def add_circuit(self, circuitname='Circuit', current=0, series_or_parallel=1):
+        """Create circuit
+        series_or_parallel: 0 parallel, 1 - series
+        """
+        femm.mi_addcircprop(circuitname, current, series_or_parallel) 
+
+    def set_current(self, circuitname, current):
+        current = str(np.real(current)) + '+I*' + str(np.imag(current))
+        femm.mi_setcurrent(circuitname, current)
+
+    def move_rotate(self, groupID, centerxy, angle):
+        """Rotates objects having the same groupID 
+        For example: rotor components"""
+        femm.mi_clearselected
+        femm.mi_selectgroup(groupID)
+        femm.mi_moverotate(centerxy[0], centerxy[1], angle)
+        femm.mi_clearselected
+
+    def move_translate(self, groupID, dx, dy):
+        """Translates objects having the same groupID 
+        For example: linear motor mover components"""
+        femm.mi_clearselected
+        femm.mi_selectgroup(groupID)
+        femm.mi_movetranslate(dx, dy)
+        femm.mi_clearselected
+
+    def mesh(self):
+        """Mesh .fem problem. Note that this is not a necessary precursor of
+        performing an analysis, as 'analyze' will make sure the mesh is 
+        up to date before running an analysis.
+        """
+        femm.mi_createmesh
+
+    def analyze(self):
+        """Analyze .fem problem and load solution."""
+        femm.mi_analyze(1)
+        femm.mi_loadsolution
+
+    def get_circuit_properties(self, circuitname):
+        """Returns properties of a circuit with a name 'circuitname':
+        - current,
+        - voltage,
+        - flux.
+        """
+        circuit_properties = femm.mo_getcircuitproperties(circuitname)
+        return circuit_properties
+
+    def get_probleminfo(self):
+        probleminfo = femm.mo_getprobleminfo
+        return probleminfo
+
+    def blockintegral(self, groupID, type):
+        """Calculate a block integral for the selected blocks.
+        Used to calculate forces, torque, etc.
+        See https://www.femm.info/wiki/pyFEMM for different integral types (specified by 'type').
+        type: 18 - Fx, 19 - Fy, 22 - torque
+        """
+        femm.mo_groupselectblock(groupID)
+        result = femm.mo_blockintegral(type)
+        femm.mo_close
+        return result
+
+    def get_pointvalues(self, xy):
+        """ Get the values associated with the point at (xy[0],xy[1]).
+        Used to extract field components, etc.
+        Refer to https://www.femm.info/wiki/pyFEMM to see the values that are returned.
+        """
+        results = femm.mo_getpointvalues(xy[0], xy[1])
+        return results
+
+    def get_vectorpotential(self, xy):
+        """  Get the potential associated with the point at (xy[0],xy[1])."""
+        A = femm.mo_geta(xy[0], xy[1])
+        return A
+
+    def get_fluxdensity(self, xy):
+        """  Get the magnetic flux density associated with the point at (xy[0],xy[1]).
+        Returns a list with two elements representing Bx and By for planar problems 
+        or Br and Bz for axisymmetric problems.
+        """
+        B = femm.mo_getb(xy[0], xy[1])
+        return B
+
+    def get_numelements(self):
+        """Returns the number of mesh elements"""
+        numelements = femm.mo_numelements()
+        return numelements
+
+    def get_element(self, n):   
+        """Returns the properties for the n-th element.
+        Refer to https://www.femm.info/wiki/pyFEMM to see the properties that are returned.
+        """
+        element_properties = femm.mo_getelement(n)
+        return element_properties
+
+    def prepare_section(self, cs_token: "CrossSectToken") -> TokenMake:
+        """ Not needed for FEMM.
+        """
+        return cs_token
+
+    def extrude(self, name, material: str, depth: float, token=None) -> any:
+        """ Assign material to a component. 
+        Axial length has to be specified using "probdef" method.
+        """
+        inner_coord = token[0].inner_coord
+        femm.mi_addblocklabel(inner_coord[0], inner_coord[1])
+        femm.mi_selectlabel(inner_coord[0], inner_coord[1])
+        femm.mi_setblockprop(material.name, True, 0, 0, 0, 0, 0)
+        femm.mi_clearselected()
+
+        return 1
+
+    def revolve(self, name, material: str, center, axis, angle: float,) -> any:
+        """ Not implemented in FEMM. 
+        Axisymmetric problem has to be specified using "probdef" method.
+        """
+        
+        return 1
+
+    def select(self):
+        pass   

--- a/mach_cad/tools/femm/__init__.py
+++ b/mach_cad/tools/femm/__init__.py
@@ -1,0 +1,5 @@
+from . import FEMM
+from .FEMM import*
+
+__all__ = []
+__all__ += FEMM.__all__

--- a/mach_cad/tools/jmag/jmag.py
+++ b/mach_cad/tools/jmag/jmag.py
@@ -242,7 +242,7 @@ class JmagDesigner(
     def select(self):
         pass
 
-    def prepare_section(self, cs_token: "CrossSectToken") -> TokenMake:
+    def prepare_section(self, cs_token: "CrossSectToken", num_copy_rotate=0) -> TokenMake:
         """ Creates JMAG geometry region using lines and arcs.
         """
         # self.validate_attr(cs_token, 'CrossSectToken')
@@ -279,6 +279,24 @@ class JmagDesigner(
                 self.doc.GetSelection().Clear()
                 self.doc.GetSelection().Add(self.sketch.GetItem(regionList[idx]))
                 self.doc.GetSelection().Delete()
+
+        # RotateCopy
+        if num_copy_rotate != 0:
+            bMerge = True
+            # print('Copy', num_copy_rotate)
+            Q_float = float(num_copy_rotate)  # don't ask me, ask JSOL
+            circular_pattern = self.sketch.CreateRegionCircularPattern()
+            circular_pattern.SetProperty("Merge", bMerge)
+
+            ref2 = self.doc.CreateReferenceFromItem(region)
+            circular_pattern.SetPropertyByReference("Region", ref2)
+            face_region_string = circular_pattern.GetProperty("Region")
+
+            circular_pattern.SetProperty("CenterType", 2)  # origin I guess
+
+            # print('Copy', Q_float)
+            circular_pattern.SetProperty("Angle", "360/%d" % Q_float)
+            circular_pattern.SetProperty("Instance", str(Q_float))
 
         self.sketch.CloseSketch()
 
@@ -413,4 +431,4 @@ class JmagDesigner(
             self.model.SetUnitCollection("SI_units")
         else:
             raise Exception("Unsupported angle unit")
-
+        


### PR DESCRIPTION
@elsevers This PR is ready for review. This PR adds contents from mach_cad_private (item 1 from [here](https://github.com/Severson-Group/eMach-Private/issues/3#issue-1588100222)). Specifically, it includes:
* FEMM tool.
* An update to JMAG tool that includes rotate-copy feature.
* New cross-sections (`.py` and `.svg` files)  - `inner_rotor_round_slots`, `inner_rotor_drop_slots`, and `inner_rotor_round_slots_double_cage`. This includes new classes and drawings for the rotor partial model and bars.
* An update to the `inner_rotor_stator` cross-section. This includes new classes and drawings for the stator partial model and right and left slots.
* Examples of drawing the above cross-sections and induction motor example in FEMM and JMAG.
* An update to `.gitignore` file to ignore FEMM and some JMAG files.