### PR TITLE
Fix typo in the Analytical Machine Design Tutorial

### DIFF
--- a/docs/source/getting_started/tutorials/analytical_machine_des_tutorial/index.rst
+++ b/docs/source/getting_started/tutorials/analytical_machine_des_tutorial/index.rst
@@ -264,7 +264,7 @@ The ``create_new_design`` method demonstrates how the input tuple values are int
                         w_tooth,d_yoke,z_q,l_st,
                         self.magnet_mat,self.core_mat,self.coil_mat)
                 
-                return machine
+			return machine
 
 Step 6: Define the ``SettingsHandler``
 ---------------------------------------


### PR DESCRIPTION
Fixed the indentation on `line 267` of the tutorial code.