### PR TITLE
Remove mach_cad readme.md

### DIFF
--- a/mach_cad/README.md
+++ b/mach_cad/README.md
@@ -1,3 +1,0 @@
--------------TODO----------
-
-Add the eMach module into this folder.


### PR DESCRIPTION
This PR removes a temporary `README.md` file from the `mach_cad` module. The `README.md` file was a holdover from early eMach days before we had imported the `eMach` python code as `mach_cad`.