### PR TITLE
Edit BSPM Eval Tutorial Documentation

### DIFF
--- a/docs/source/EM_analyzers/output_jmag2d_analyzer.csv
+++ b/docs/source/EM_analyzers/output_jmag2d_analyzer.csv
@@ -4,7 +4,7 @@ voltage,Data frame of coil terminal voltage vs time
 torque,Data frame of torque vs time
 force,Data frame of force in x and y axes vs time
 iron_loss,Data frame of iron loss at different frequencies
-hysterisis_loss,Data frame of hysteresis loss at different frequencies
+hysteresis_loss,Data frame of hysteresis loss at different frequencies
 eddy_current_loss,Data frame of eddy current loss vs time
 copper_loss,Analytically estimated copper loss
 range_fine_step,Elements of dataframe over second time step

--- a/docs/source/EM_analyzers/output_jmag2d_analyzer.csv
+++ b/docs/source/EM_analyzers/output_jmag2d_analyzer.csv
@@ -4,7 +4,7 @@ voltage,Data frame of coil terminal voltage vs time
 torque,Data frame of torque vs time
 force,Data frame of force in x and y axes vs time
 iron_loss,Data frame of iron loss at different frequencies
-hysterisis_loss,Data frame of hysterisis loss at different frequencies
+hysterisis_loss,Data frame of hysteresis loss at different frequencies
 eddy_current_loss,Data frame of eddy current loss vs time
 copper_loss,Analytically estimated copper loss
 range_fine_step,Elements of dataframe over second time step

--- a/docs/source/getting_started/tutorials/bspm_eval_tutorial/index.rst
+++ b/docs/source/getting_started/tutorials/bspm_eval_tutorial/index.rst
@@ -5,7 +5,7 @@ BSPM Evaluation Tutorial
 * **Complexity:** 4/5
 * **Estimated Time:** 30 - 60 min
 
-This tutorial demonstrates how to perform a multi-physics evaluation of a ``BSPM_Machine`` by using the ``Analyzer`` s available in ``eMach``.
+This tutorial demonstrates how to perform a multi-physics evaluation of a ``BSPM_Machine`` by using the ``Analyzers`` available in ``eMach``.
 By the end of this tutorial you will be able to:
 
 * create a digital BSPM design
@@ -50,10 +50,10 @@ Step 2: Create BSPM Evaluator
 The main purpose of this tutorial is to showcase how multi-physics evaluations are handled by ``eMach`` using the analyzers
 provided within the repository. To demonstrate this, the structural, electromagnetic, and thermal performance of the example BSPM design created 
 in ``ecce_2020_bspm.py`` are evaluated. ``AnalysisStep`` objects are created for each analyzer to ensure proper interface to and from the 
-analyzers. The ``AnalysisStep`` s are then joined together to create an ``Evaluator``, in manner so as to 
+analyzers. The ``AnalysisSteps`` are then joined together to create an ``Evaluator``, in a manner so as to 
 ensure proper transfer of information and to facilitate computational efficiency during optimization. In this particular example, the thermal
 analyzers come after the electromagnetic analyzers as thermal performance is determined by motor losses. The structural analyzer is placed 
-at the very beginning as this is a quick, equation based analyzer which determines whether an appropriate sized sleeve can be placed on an 
+at the very beginning as this is a quick equation-based analyzer which determines whether an appropriate sized sleeve can be placed on an 
 SPM rotor or not. Machines which are structurally unsound can be discarded prior to the computationally intensive electromagnetic 
 ``AnalysisStep``, thereby saving time. The steps involved in created a multi-physics BSPM ``Evaluator`` are discussed below. Readers can 
 create a single Python script holding all the code snippets provided below or can separate them out into individual modules as done in  
@@ -154,8 +154,8 @@ to post-process FEA results. Simply modify the import statements as shown below.
     )
 
 The code snip provided below shows how this analyzer can be interfaced to a BSPM design. After the analysis is completed, relevant information 
-is stored in ``State`` for future reference. Its worth noting that the losses obtained from this analysis is required by the next two thermal 
-``AnalysisStep`` s to determine the rotor and stator temperatures.
+is stored in ``State`` for future reference. Its worth noting that the losses obtained from this analysis are required by the next two thermal 
+``AnalysisSteps`` to determine the rotor and stator temperatures.
 
 .. code-block:: python
 	

--- a/docs/source/getting_started/tutorials/bspm_eval_tutorial/index.rst
+++ b/docs/source/getting_started/tutorials/bspm_eval_tutorial/index.rst
@@ -154,7 +154,7 @@ to post-process FEA results. Simply modify the import statements as shown below.
     )
 
 The code snip provided below shows how this analyzer can be interfaced to a BSPM design. After the analysis is completed, relevant information 
-is stored in ``State`` for future reference. Its worth noting that the losses obtained from this analysis are required by the next two thermal 
+is stored in ``State`` for future reference. It is worth noting that the losses obtained from this analysis are required by the next two thermal 
 ``AnalysisSteps`` to determine the rotor and stator temperatures.
 
 .. code-block:: python

--- a/docs/source/getting_started/tutorials/bspm_eval_tutorial/index.rst
+++ b/docs/source/getting_started/tutorials/bspm_eval_tutorial/index.rst
@@ -382,7 +382,7 @@ Step 2.5: Create Windage Loss ``AnalysisStep``
 
 Finally, an ``AnalysisStep`` is created to define the interface between the BSPM design and the :doc:`Windage Loss Analyzer <../../../mechanical_analyzers/windage_loss_analyzer>`.
 The purpose of this analyzer is evaluate the windage loss arising in a BSPM due to rotational speed of the machine. The code snip provided 
-below shows how this analyzer can be interfaced to a BSPM design and the require rotor axial airflow for cooling the magnets. After the 
+below shows how this analyzer can be interfaced to a BSPM design and the required rotor axial airflow for cooling the magnets. After the 
 analysis is completed, the overall efficiency of the motor is calculated and saved.
 
 .. code-block:: python

--- a/docs/source/getting_started/tutorials/bspm_eval_tutorial/index.rst
+++ b/docs/source/getting_started/tutorials/bspm_eval_tutorial/index.rst
@@ -1,7 +1,7 @@
 BSPM Evaluation Tutorial
 ===========================================
 
-* **Goal:** Leverage capabilites of ``mach_eval`` to perform multi-physics evaluations on bearingless surface permamanent magnet machines
+* **Goal:** Leverage capabilites of ``mach_eval`` to perform multi-physics evaluations on bearingless surface permanent magnet machines
 * **Complexity:** 4/5
 * **Estimated Time:** 30 - 60 min
 

--- a/docs/source/getting_started/tutorials/bspm_eval_tutorial/index.rst
+++ b/docs/source/getting_started/tutorials/bspm_eval_tutorial/index.rst
@@ -290,7 +290,7 @@ de-magnetization from high temperatures, the required airflow and the correspond
 Step 2.4: Create Stator Thermal ``AnalysisStep``
 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
-In this step, we define the interface between a BSPM design and the :doc:`Stator Thermal Analyzer <../../../mechanical_analyzers/SPM_rotor_airflow_analyzer>`. 
+In this step, we define the interface between a BSPM design and the :doc:`Stator Thermal Analyzer <../../../mechanical_analyzers/inner_rotor_stator_thermal_analyzer>`. 
 The purpose of this analyzer is evaluate the stator winding temperature for a provided stator outer bore convection coefficient. 
 The cooling rate is set at ``h = 200 W/m^2K`` for this evaluation. The code snip provided below shows how this analyzer can be interfaced to 
 a BSPM design and the loss data obtained from FEA. After the analysis is completed, the stator winding and yoke temperatures are saved for 

--- a/docs/source/getting_started/tutorials/bspm_eval_tutorial/index.rst
+++ b/docs/source/getting_started/tutorials/bspm_eval_tutorial/index.rst
@@ -135,8 +135,8 @@ Step 2.2: Create Electromagnetic ``AnalysisStep``
 In this step, we define the interface between a BSPM design and the :doc:`BSPM JMAG 2D FEA Analyzer <../../../EM_analyzers/bspm_jmag2d_analyzer>`. 
 The purpose of this analyzer is to run a JMAG 2D FEA simulation of an input BSPM machine and return data relevant to the performance of
 this machine. The input provided to this analyzer is the BSPM machine and its operating point. The analyzer returns a set of dataframes
-extracted from JMAG 2D FEA solve which can be interpreted to determine the motor losses, and torque, force performance. As ineterpreting this
-information can be challenging, readers are adviced to copy the ``bpsm_em_post_analyzer.py`` script file in ``examples/mach_eval_examples/bspm_eval`` 
+extracted from JMAG 2D FEA solve which can be interpreted to determine the motor losses and torque and force performance. As interpreting this
+information can be challenging, readers are advised to copy the ``bpsm_em_post_analyzer.py`` script file in ``examples/mach_eval_examples/bspm_eval`` 
 to post-process FEA results. Simply modify the import statements as shown below.
 
 .. code-block:: python

--- a/docs/source/getting_started/tutorials/bspm_eval_tutorial/index.rst
+++ b/docs/source/getting_started/tutorials/bspm_eval_tutorial/index.rst
@@ -133,7 +133,7 @@ Step 2.2: Create Electromagnetic ``AnalysisStep``
 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 In this step, we define the interface between a BSPM design and the :doc:`BSPM JMAG 2D FEA Analyzer <../../../EM_analyzers/bspm_jmag2d_analyzer>`. 
-The purpose of this analyzer is to run a JMAG 2D FEA simulation of an input BPSM machine and return data relevant to the performance of
+The purpose of this analyzer is to run a JMAG 2D FEA simulation of an input BSPM machine and return data relevant to the performance of
 this machine. The input provided to this analyzer is the BSPM machine and its operating point. The analyzer returns a set of dataframes
 extracted from JMAG 2D FEA solve which can be interpreted to determine the motor losses, and torque, force performance. As ineterpreting this
 information can be challenging, readers are adviced to copy the ``bpsm_em_post_analyzer.py`` script file in ``examples/mach_eval_examples/bspm_eval`` 

--- a/docs/source/getting_started/tutorials/bspm_eval_tutorial/index.rst
+++ b/docs/source/getting_started/tutorials/bspm_eval_tutorial/index.rst
@@ -211,7 +211,7 @@ In this step, we define the interface between a BSPM design and the :doc:`SPM Ai
 The purpose of this analyzer is evaluate the airflow required (under certain bounds) to prevent the BSPM machine magnets from overheating at 
 the provided operating conditions. The code snip provided below shows how this analyzer can be interfaced to a BSPM design and the loss data
 obtained from FEA. After the analysis is completed, the design is discarded if the magnets get overheated. If the magnets are not at risk of
-de-magnetization from high temperatures, the required airflow and the corresponding magnet temperature rise are saved for future reference.
+de-magnetization from high temperatures, the required airflow and the corresponding magnet temperature rises are saved for future reference.
 
 .. code-block:: python
 	

--- a/docs/source/getting_started/tutorials/bspm_eval_tutorial/index.rst
+++ b/docs/source/getting_started/tutorials/bspm_eval_tutorial/index.rst
@@ -498,7 +498,7 @@ Upon running this script you should get the following results:
 - Efficiency = 97.2\%
 
 .. note:: The ``examples/mach_eval_examples/bspm_eval`` folder provides working code for the tutorial discussed here. You can run the 
-    ``bspm_evaluator.py`` script herewith to evaluate the ``ecce_2020_design`` and compare the results against those obtained from your own 
+    ``bspm_evaluator.py`` script here to evaluate the ``ecce_2020_design`` and compare the results against those obtained from your own 
     ``Evaluator``.
 
 Conclusion


### PR DESCRIPTION
This PR edits the [BSPM Eval Tutorial](https://emach.readthedocs.io/en/latest/getting_started/tutorials/bspm_eval_tutorial/index.html) to fix spelling and grammar mistakes.

This also edits a spelling error in the JMAG BSPM 2D FEA Analyzer output .csv file.