### PR TITLE
Split induction motor drawing examples into two files (FEMM and JMAG)

### DIFF
--- a/docs/source/getting_started/tutorials/make_electric_machine_tutorial/index.rst
+++ b/docs/source/getting_started/tutorials/make_electric_machine_tutorial/index.rst
@@ -156,3 +156,8 @@ Conclusion
 Congratulations! You have successfully used ``eMach`` to make most of the components required to simulate a surface permanent 
 magnet machine! Users are recommended to further explore additional cross-sections currently supported by ``eMach`` or to create 
 their own cross-sections which they feel are generic enough to find use in a wide range of electric machine applications.
+
+If it takes a considerable amount of time to draw a motor in JMAG using the above approach, 
+users are suggested to have a look at another approach, as demonstrated in ``eMach/examples/mach_cad_examples/example_induction_motor_jmag.py`` 
+for an example induction machine. In this example, all cross-sections are first drawn in 
+JMAG Geometry Editor and only then exported to JMAG Designer.

--- a/examples/mach_cad_examples/example_induction_motor_femm.py
+++ b/examples/mach_cad_examples/example_induction_motor_femm.py
@@ -6,7 +6,6 @@ os.chdir(os.path.dirname(__file__))
 # add the directory immediately above this file's directory to path for module import
 sys.path.append("../..")
 
-import mach_cad.tools.jmag as JMAG
 from mach_cad.tools.femm import FEMM
 import mach_cad.model_obj as mo
 import numpy as np

--- a/examples/mach_cad_examples/example_induction_motor_femm.py
+++ b/examples/mach_cad_examples/example_induction_motor_femm.py
@@ -69,27 +69,7 @@ bim_materials = {
 
 
 ###################### Create cross-section objects ######################
-# Partial models are used in JMAG (to reduce drawing time)
-
 stator = mo.CrossSectInnerRotorStator(
-    name="StatorCore",
-    dim_alpha_st=mo.DimDegree(stator_dimensions["alpha_st"]),
-    dim_alpha_so=mo.DimDegree(stator_dimensions["alpha_so"]),
-    dim_r_si=mo.DimMillimeter(stator_dimensions["r_si"]),
-    dim_d_so=mo.DimMillimeter(stator_dimensions["d_so"]),
-    dim_d_sp=mo.DimMillimeter(stator_dimensions["d_sp"]),
-    dim_d_st=mo.DimMillimeter(stator_dimensions["d_st"]),
-    dim_d_sy=mo.DimMillimeter(stator_dimensions["d_sy"]),
-    dim_w_st=mo.DimMillimeter(stator_dimensions["w_st"]),
-    dim_r_st=mo.DimMillimeter(0),
-    dim_r_sf=mo.DimMillimeter(0),
-    dim_r_sb=mo.DimMillimeter(0),
-    Q=Q,
-    location=mo.Location2D(anchor_xy=[mo.DimMillimeter(0), mo.DimMillimeter(0)],theta=mo.DimRadian(0)),
-    theta=mo.DimDegree(0),
-)
-
-stator_partial = mo.CrossSectInnerRotorStatorPartial(
     name="StatorCore",
     dim_alpha_st=mo.DimDegree(stator_dimensions["alpha_st"]),
     dim_alpha_so=mo.DimDegree(stator_dimensions["alpha_so"]),
@@ -114,8 +94,6 @@ for i in range (0, Q):
         stator_core=stator,
         location=mo.Location2D(anchor_xy=[mo.DimMillimeter(0), mo.DimMillimeter(0)],theta=mo.DimRadian(2 * np.pi / Q * i)),
         ))
-    
-winding_layer1_partial = winding_layer1[0]
 
 winding_layer2 = []
 for i in range (0, Q):
@@ -126,23 +104,7 @@ for i in range (0, Q):
         theta=mo.DimDegree(0),
         ))
 
-winding_layer2_partial = winding_layer2[0]
-
 rotor = mo.CrossSectInnerRotorDropSlots(
-    name="RotorCore",
-    dim_r_ri=mo.DimMillimeter(rotor_dimensions["r_ri"]),
-    dim_d_ri=mo.DimMillimeter(rotor_dimensions["d_ri"]),
-    dim_d_rb=mo.DimMillimeter(rotor_dimensions["d_rb"]),
-    dim_r_rb1=mo.DimMillimeter(rotor_dimensions["r_rb1"]),
-    dim_r_rb2=mo.DimMillimeter(rotor_dimensions["r_rb2"]),
-    dim_d_so=mo.DimMillimeter(rotor_dimensions["d_so"]),
-    dim_w_so=mo.DimMillimeter(rotor_dimensions["w_so"]),
-    Qr=Qr,
-    location=mo.Location2D(anchor_xy=[mo.DimMillimeter(0), mo.DimMillimeter(0)]),
-    theta=mo.DimDegree(0),
-)
-
-rotor_partial = mo.CrossSectInnerRotorDropSlotsPartial(
     name="RotorCore",
     dim_r_ri=mo.DimMillimeter(rotor_dimensions["r_ri"]),
     dim_d_ri=mo.DimMillimeter(rotor_dimensions["d_ri"]),
@@ -165,12 +127,7 @@ for i in range(0,Qr):
     theta=mo.DimDegree(0),
     ))
 
-bar_partial = bar[0]
-
-
 ###################### Create component objects ######################
-# Only used in FEMM. Can also be used in JMAG, but increases drawing time.
-
 comp_stator = mo.Component(
         name="StatorCore",
         cross_sections=[stator],
@@ -211,7 +168,6 @@ for i in range(0,Qr):
     material=mo.MaterialGeneric(name="Copper", color=r"#4d4b4f"),
     make_solid=mo.MakeExtrude(location=mo.Location3D(), dim_depth=mo.DimMillimeter(1)),
     ))
-
 
 ###################### Draw the motor in FEMM ######################
 tool_femm = FEMM.FEMMDesigner()
@@ -278,65 +234,3 @@ if os.path.exists(file):
 
 # Save the file
 tool_femm.save_as(file)
-
-
-###################### Draw the motor in JMAG ######################
-tool_jmag = JMAG.JmagDesigner()
-
-# Check if a specified file name exists already
-file = r"example_induction_motor.jproj"
-attempts = 1
-if os.path.exists(file):
-    print(
-        "JMAG project exists already, I will not delete it but create a new one with a different name instead."
-    )
-    attempts = 2
-    temp_path = file[
-        : -len(".jproj")
-    ] + "_attempts_%d.jproj" % (attempts)
-    while os.path.exists(temp_path):
-        attempts += 1
-        temp_path = file[
-            : -len(".jproj")
-        ] + "_attempts_%d.jproj" % (attempts)
-
-    file = temp_path
-
-tool_jmag.open(comp_filepath=file, length_unit="DimMillimeter", study_type="Transient")
-tool_jmag.set_visibility(True)
-
-# Draw the model
-tool_jmag.sketch = tool_jmag.create_sketch()
-tool_jmag.sketch.SetProperty("Name", stator_partial.name)
-tool_jmag.sketch.SetProperty("Color", r"#808080")
-cs_stator = stator_partial.draw(tool_jmag)
-stator_tool = tool_jmag.prepare_section(cs_stator, num_copy_rotate=Q)
-
-tool_jmag.sketch = tool_jmag.create_sketch()
-tool_jmag.sketch.SetProperty("Name", winding_layer1_partial.name)
-tool_jmag.sketch.SetProperty("Color", r"#B87333")
-cs_winding_layer1 = winding_layer1_partial.draw(tool_jmag)
-winding_tool1 = tool_jmag.prepare_section(cs_winding_layer1, num_copy_rotate=Q)
-
-tool_jmag.sketch = tool_jmag.create_sketch()
-tool_jmag.sketch.SetProperty("Name", winding_layer2_partial.name)
-tool_jmag.sketch.SetProperty("Color", r"#B87333")
-cs_winding_layer2 = winding_layer2_partial.draw(tool_jmag)
-winding_tool2 = tool_jmag.prepare_section(cs_winding_layer2, num_copy_rotate=Q)
-
-tool_jmag.sketch = tool_jmag.create_sketch()
-tool_jmag.sketch.SetProperty("Name", rotor_partial.name)
-tool_jmag.sketch.SetProperty("Color", r"#808080")
-cs_rotor_core = rotor_partial.draw(tool_jmag)
-rotor_tool = tool_jmag.prepare_section(cs_rotor_core, num_copy_rotate=Qr)
-
-tool_jmag.sketch = tool_jmag.create_sketch()
-tool_jmag.sketch.SetProperty("Name", bar_partial.name)
-tool_jmag.sketch.SetProperty("Color", r"#C89E9B")
-cs_rotor_bar = bar_partial.draw(tool_jmag)
-rotor_bar_tool = tool_jmag.prepare_section(cs_rotor_bar, num_copy_rotate=Qr)
-
-tool_jmag.doc.SaveModel(False)
-
-# Save the file
-tool_jmag.save()

--- a/examples/mach_cad_examples/example_induction_motor_jmag.py
+++ b/examples/mach_cad_examples/example_induction_motor_jmag.py
@@ -1,0 +1,182 @@
+import os
+import sys
+
+# change current working directory to file location
+os.chdir(os.path.dirname(__file__))
+# add the directory immediately above this file's directory to path for module import
+sys.path.append("../..")
+
+import mach_cad.tools.jmag as JMAG
+from mach_cad.tools.femm import FEMM
+import mach_cad.model_obj as mo
+import numpy as np
+from mach_eval.machines.materials.electric_steels import M19Gauge29
+from mach_eval.machines.materials.electric_steels import M19Gauge29
+from mach_eval.machines.materials.miscellaneous_materials import (
+    Steel,
+    Copper,
+    Hub,
+    Air,
+)
+
+# Motor dimensions
+stator_dimensions = {
+    'alpha_st': 50,
+    'alpha_so': 22.25,
+    'r_si': 14.16,
+    'd_so': 2.71,
+    'd_sp': 4.07,
+    'd_st': 11.27,
+    'd_sy': 9,
+    'w_st': 9.09,
+    'alpha_m': 178.78,
+    'l_st': 1,
+}
+
+rotor_dimensions = {
+    'r_ri': 3,
+    'd_ri': 4,
+    'd_rb': 2,
+    'r_rb1': 1,
+    'r_rb2': 0.5,
+    'd_so': 2,
+    'w_so': 0.5,
+}
+
+# Number of stator and rotor slots
+Q = 6
+Qr = 12
+
+# Boundary parameters (for FEMM)
+radius_boundary = 100
+radius_air_region1 = 13.6
+radius_air_region2 = 70
+
+# Materials
+Aluminium = {
+    "bar_material": "Aluminium"
+}
+
+bim_materials = {
+    "air_mat": Air,
+    "rotor_iron_mat": M19Gauge29,
+    "stator_iron_mat": M19Gauge29,
+    "coil_mat": Copper,
+    "rotor_bar_mat": Aluminium,
+    "shaft_mat": Steel,
+    "rotor_hub": Hub,
+}
+
+
+###################### Create cross-section objects ######################
+stator_partial = mo.CrossSectInnerRotorStatorPartial(
+    name="StatorCore",
+    dim_alpha_st=mo.DimDegree(stator_dimensions["alpha_st"]),
+    dim_alpha_so=mo.DimDegree(stator_dimensions["alpha_so"]),
+    dim_r_si=mo.DimMillimeter(stator_dimensions["r_si"]),
+    dim_d_so=mo.DimMillimeter(stator_dimensions["d_so"]),
+    dim_d_sp=mo.DimMillimeter(stator_dimensions["d_sp"]),
+    dim_d_st=mo.DimMillimeter(stator_dimensions["d_st"]),
+    dim_d_sy=mo.DimMillimeter(stator_dimensions["d_sy"]),
+    dim_w_st=mo.DimMillimeter(stator_dimensions["w_st"]),
+    dim_r_st=mo.DimMillimeter(0),
+    dim_r_sf=mo.DimMillimeter(0),
+    dim_r_sb=mo.DimMillimeter(0),
+    Q=Q,
+    location=mo.Location2D(anchor_xy=[mo.DimMillimeter(0), mo.DimMillimeter(0)],theta=mo.DimRadian(0)),
+    theta=mo.DimDegree(0),
+)
+
+winding_layer1 = mo.CrossSectInnerRotorStatorRightSlot(
+    name="WindingLayer1",
+    stator_core=stator_partial,
+    location=mo.Location2D(anchor_xy=[mo.DimMillimeter(0), mo.DimMillimeter(0)],theta=mo.DimRadian(0)),
+    )
+
+winding_layer2 = mo.CrossSectInnerRotorStatorLeftSlot(
+    name="WindingLayer2",
+    stator_core=stator_partial,
+    location=mo.Location2D(anchor_xy=[mo.DimMillimeter(0), mo.DimMillimeter(0)],theta=mo.DimRadian(0)),
+    )
+
+rotor_partial = mo.CrossSectInnerRotorDropSlotsPartial(
+    name="RotorCore",
+    dim_r_ri=mo.DimMillimeter(rotor_dimensions["r_ri"]),
+    dim_d_ri=mo.DimMillimeter(rotor_dimensions["d_ri"]),
+    dim_d_rb=mo.DimMillimeter(rotor_dimensions["d_rb"]),
+    dim_r_rb1=mo.DimMillimeter(rotor_dimensions["r_rb1"]),
+    dim_r_rb2=mo.DimMillimeter(rotor_dimensions["r_rb2"]),
+    dim_d_so=mo.DimMillimeter(rotor_dimensions["d_so"]),
+    dim_w_so=mo.DimMillimeter(rotor_dimensions["w_so"]),
+    Qr=Qr,
+    location=mo.Location2D(anchor_xy=[mo.DimMillimeter(0), mo.DimMillimeter(0)]),
+    theta=mo.DimDegree(0),
+)
+
+bar = mo.CrossSectInnerRotorDropSlotsBar(
+    name="Bar",
+    rotor_core=rotor_partial,
+    location=mo.Location2D(anchor_xy=[mo.DimMillimeter(0), mo.DimMillimeter(0)],theta=mo.DimRadian(0)),
+    theta=mo.DimDegree(0),
+    )
+
+###################### Draw the motor in JMAG ######################
+tool_jmag = JMAG.JmagDesigner()
+
+# Check if a specified file name exists already
+file = r"example_induction_motor.jproj"
+attempts = 1
+if os.path.exists(file):
+    print(
+        "JMAG project exists already, I will not delete it but create a new one with a different name instead."
+    )
+    attempts = 2
+    temp_path = file[
+        : -len(".jproj")
+    ] + "_attempts_%d.jproj" % (attempts)
+    while os.path.exists(temp_path):
+        attempts += 1
+        temp_path = file[
+            : -len(".jproj")
+        ] + "_attempts_%d.jproj" % (attempts)
+
+    file = temp_path
+
+tool_jmag.open(comp_filepath=file, length_unit="DimMillimeter", study_type="Transient")
+tool_jmag.set_visibility(True)
+
+# Draw the model
+tool_jmag.sketch = tool_jmag.create_sketch()
+tool_jmag.sketch.SetProperty("Name", stator_partial.name)
+tool_jmag.sketch.SetProperty("Color", r"#808080")
+cs_stator = stator_partial.draw(tool_jmag)
+stator_tool = tool_jmag.prepare_section(cs_stator, num_copy_rotate=Q)
+
+tool_jmag.sketch = tool_jmag.create_sketch()
+tool_jmag.sketch.SetProperty("Name", winding_layer1.name)
+tool_jmag.sketch.SetProperty("Color", r"#B87333")
+cs_winding_layer1 = winding_layer1.draw(tool_jmag)
+winding_tool1 = tool_jmag.prepare_section(cs_winding_layer1, num_copy_rotate=Q)
+
+tool_jmag.sketch = tool_jmag.create_sketch()
+tool_jmag.sketch.SetProperty("Name", winding_layer2.name)
+tool_jmag.sketch.SetProperty("Color", r"#B87333")
+cs_winding_layer2 = winding_layer2.draw(tool_jmag)
+winding_tool2 = tool_jmag.prepare_section(cs_winding_layer2, num_copy_rotate=Q)
+
+tool_jmag.sketch = tool_jmag.create_sketch()
+tool_jmag.sketch.SetProperty("Name", rotor_partial.name)
+tool_jmag.sketch.SetProperty("Color", r"#808080")
+cs_rotor_core = rotor_partial.draw(tool_jmag)
+rotor_tool = tool_jmag.prepare_section(cs_rotor_core, num_copy_rotate=Qr)
+
+tool_jmag.sketch = tool_jmag.create_sketch()
+tool_jmag.sketch.SetProperty("Name", bar.name)
+tool_jmag.sketch.SetProperty("Color", r"#C89E9B")
+cs_rotor_bar = bar.draw(tool_jmag)
+rotor_bar_tool = tool_jmag.prepare_section(cs_rotor_bar, num_copy_rotate=Qr)
+
+tool_jmag.doc.SaveModel(False)
+
+# Save the file
+tool_jmag.save()

--- a/examples/mach_cad_examples/example_induction_motor_jmag.py
+++ b/examples/mach_cad_examples/example_induction_motor_jmag.py
@@ -7,7 +7,6 @@ os.chdir(os.path.dirname(__file__))
 sys.path.append("../..")
 
 import mach_cad.tools.jmag as JMAG
-from mach_cad.tools.femm import FEMM
 import mach_cad.model_obj as mo
 import numpy as np
 from mach_eval.machines.materials.electric_steels import M19Gauge29

--- a/mach_cad/model_obj/cross_sects/inner_rotor_drop_slots/__init__.py
+++ b/mach_cad/model_obj/cross_sects/inner_rotor_drop_slots/__init__.py
@@ -540,7 +540,7 @@ class CrossSectInnerRotorDropSlotsBar(CrossSectBase):
 
     def _validate_attr(self):
 
-        if isinstance(self.rotor_core, CrossSectInnerRotorDropSlots):
+        if isinstance(self.rotor_core, CrossSectInnerRotorDropSlots) or isinstance(self.rotor_core, CrossSectInnerRotorDropSlotsPartial):
             pass
         else:
-            raise TypeError("rotor_core not of type CrossSectInnerRotorDropSlots")
+            raise TypeError("rotor_core not of type CrossSectInnerRotorDropSlots or CrossSectInnerRotorDropSlotsPartial")

--- a/mach_cad/model_obj/cross_sects/inner_rotor_round_slots/__init__.py
+++ b/mach_cad/model_obj/cross_sects/inner_rotor_round_slots/__init__.py
@@ -399,4 +399,4 @@ class CrossSectInnerRotorRoundSlotsBar(CrossSectBase):
         if (isinstance(self.rotor_core, CrossSectInnerRotorRoundSlots)) or (isinstance(self.rotor_core, CrossSectInnerRotorRoundSlotsPartial)):
             pass
         else:
-            raise TypeError("rotor_core not of type CrossSectInnerRotorRoundSlots")
+            raise TypeError("rotor_core not of type CrossSectInnerRotorRoundSlots or CrossSectInnerRotorRoundSlotsPartial")

--- a/mach_cad/model_obj/cross_sects/inner_rotor_round_slots_double_cage/__init__.py
+++ b/mach_cad/model_obj/cross_sects/inner_rotor_round_slots_double_cage/__init__.py
@@ -449,7 +449,7 @@ class CrossSectInnerRotorRoundSlotsDoubleCageBar1(CrossSectBase):
         ):
             pass
         else:
-            raise TypeError("rotor_core not of type CrossSectInnerRotorRoundSlotsDoubleCage")
+            raise TypeError("rotor_core not of type CrossSectInnerRotorRoundSlotsDoubleCage or CrossSectInnerRotorRoundSlotsDoubleCagePartial")
 
 
 class CrossSectInnerRotorRoundSlotsDoubleCageBar2(CrossSectBase):
@@ -529,4 +529,4 @@ class CrossSectInnerRotorRoundSlotsDoubleCageBar2(CrossSectBase):
         ):
             pass
         else:
-            raise TypeError("rotor_core not of type CrossSectInnerRotorRoundSlotsDoubleCage")
+            raise TypeError("rotor_core not of type CrossSectInnerRotorRoundSlotsDoubleCage or CrossSectInnerRotorRoundSlotsDoubleCagePartial")


### PR DESCRIPTION
This PR addresses issue #250. This PR includes:
* two files for drawing an example induction motor in FEMM and JMAG,
* an update to an `index.rst` file of `Making an Electric Machine using eMach` tutorial to mention the location of the induction motor example that draws in JMAG, and
* changes to inner rotor round/drop slot cross-sections to use partial rotor core models when drawing bars.