### PR TITLE
Fix BSPM post analyzer script

### DIFF
--- a/examples/mach_eval_examples/bspm_eval/bpsm_em_post_analyzer.py
+++ b/examples/mach_eval_examples/bspm_eval/bpsm_em_post_analyzer.py
@@ -72,7 +72,8 @@ class BSPM_EM_PostAnalyzer:
 
         ############################ post processing #################################
         torque_prob = ProcessTorqueDataProblem(results["torque"]["TorCon"])
-        torque_avg, torque_ripple = ProcessTorqueDataAnalyzer.analyze(torque_prob)
+        torque_analyzer = ProcessTorqueDataAnalyzer()
+        torque_avg, torque_ripple = torque_analyzer.analyze(torque_prob)
 
         force_prob = ProcessForceDataProblem(
             Fx=results["force"][r"ForCon:1st"],


### PR DESCRIPTION
@elsevers This PR fixes the issue in BSPM post analyzer script, which is needed for BSPM optimization tutorial. The original script used `ProcessTorqueDataAnalyzer` class instead of creating an instance when calculating average torque and torque ripple. We had the same issue in the documentation of [BSPM JMAG 2D FEA Analyzer](https://emach.readthedocs.io/en/latest/EM_analyzers/bspm_jmag2d_analyzer.html#bspm-jmag-2d-fea-analyzer), which was addressed in PR #253 (points 2 and 3). 