### PR TITLE
Update plot_script import in BSPM opti tutorial

### DIFF
--- a/docs/source/getting_started/tutorials/bspm_opti_tutorial/index.rst
+++ b/docs/source/getting_started/tutorials/bspm_opti_tutorial/index.rst
@@ -212,7 +212,7 @@ Create a file named ``plot_script.py``. Copy paste the code provided below to pl
 
     import os
 
-    from data_handler import MyDataHandler
+    from my_data_handler import MyDataHandler
     from my_plotting_functions import DataAnalyzer
 
     path = os.path.dirname(__file__)


### PR DESCRIPTION
The `plot_script.py` that the [BSPM optimization tutorial](https://emach.readthedocs.io/en/latest/getting_started/tutorials/bspm_opti_tutorial/index.html) has us create in `Step 6` uses the following import statement that uses `data_handler` instead of `my_data_handler` that the tutorial asks us to copy from `examples/mach_opt_examples/bspm_opt`.

![image](https://user-images.githubusercontent.com/90465550/233858189-94e198f0-3543-4998-a33d-39533518e908.png)
