### PR TITLE
Add SynR Structural Analyzer

### DIFF
--- a/docs/source/mechanical_analyzers/SynR_struct_analyzer.rst
+++ b/docs/source/mechanical_analyzers/SynR_struct_analyzer.rst
@@ -1,0 +1,271 @@
+SynR Structural Analyzer
+########################################################################
+
+This analyzer enables the 2D static FEA evaluation of synchronous reluctance (SynR) machine rotors in JMAG.
+
+Model Background
+****************
+
+Synchronous reluctance (SynR) machines are electric machines capable of producing electromagnetic torque without the need for a 
+rotor-mounted field source. Basic characteristics of the design and analysis of synchronous reluctance machines can be done 
+by hand, as is shown in the paper `here <https://ieeexplore.ieee.org/stamp/stamp.jsp?tp=&arnumber=5167704>`_. Reluctance rotors
+are able to achieve high inductance ratios because of their complex rotor design. This complex rotor design is great for creating
+reluctace torque, but can have some unintended consequences regarding mechanical integrity. The following parameter is crucial to
+ensuring SynR rotors maintain mechanical integrity under rated conditions:
+
+1) Maximum rotor stress must be below yield stress
+
+* R. R. Moghaddam, F. Magnussen and C. Sadarangani, "A FEM1 investigation on the Synchronous Reluctance Machine rotor geometry with 
+  just one flux barrier as a guide toward the optimal barrier's shape," `IEEE EUROCON 2009`, St. Petersburg, Russia, 2009, 
+  pp. 663-670, doi: 10.1109/EURCON.2009.5167704.
+
+This analyzer calculates the aforementioned parameter using JMAG's static structural solver.
+
+Input from User
+*********************************
+
+To use this analyzer, users must pass in a ``MachineDesign`` object. An instance of the ``MachineDesign`` class can be created by passing in 
+``machine`` and ``operating_point`` objects. The machine must be a ``SynR_Machine`` and the ``operating_point`` must be of type 
+``SynR_Machine_Oper_Pt``. More information on both these classes is available in the ``SynR Design`` section under ``MACHINE DESIGNS``. To 
+initialize the ``SynR_Structural_Analyzer``, users must also specify analyzer configuration parameters.
+
+The tables below provide the input expected by the ``MachineDesign`` class and the configuration input required to initialize the 
+``SynR_Structural_Analyzer``.
+
+.. csv-table:: `MachineDesign Input`
+   :file: input_SynR_struct_analyzer.csv
+   :widths: 70, 70
+   :header-rows: 1
+
+.. csv-table:: `SynR_Structural_Analyzer Initialization`
+   :file: init_SynR_struct_analyzer.csv
+   :widths: 70, 70
+   :header-rows: 1
+
+Example code initializing the machine design for the optimized SynR design provided in the example found in the ``SynR Design`` section of 
+``MACHINE DESIGNS`` is shown below. An identical file titled ``example_SynR_machine`` is stored in the ``SynR_eval`` folder within the 
+``mach_eval_examples`` folder in the ``examples`` folder of ``eMach``.
+
+.. code-block:: python
+
+    import os
+    import sys
+
+    from mach_eval.machines.materials.electric_steels import (Arnon5)
+    from mach_eval.machines.materials.miscellaneous_materials import (
+        Steel,
+        Copper,
+        Air,
+    )
+    from mach_eval.machines.SynR.SynR_machine import SynR_Machine
+    from mach_eval.machines.SynR.SynR_machine_oper_pt import SynR_Machine_Oper_Pt
+
+    SynR_dimensions = {
+        'alpha_b': 135,
+        'r_sh': 6,
+        'r_ri': 6,
+        'r_ro': 49,
+        'r_f1': 0.1,
+        'r_f2': 0.1,
+        'r_f3': 0.1,
+        'd_r1': 4,
+        'd_r2': 8,
+        'd_r3': 8,
+        'w_b1': 4,
+        'w_b2': 4,
+        'w_b3': 4,
+        'l_b1': 33.75,
+        'l_b2': 24.4,
+        'l_b3': 12.6,
+        'l_b4': 13,
+        'l_b5': 10,
+        'l_b6': 7,
+        'alpha_st': 25,
+        'alpha_so': 12.5,
+        'r_si': 50,
+        'd_so': 5,
+        'd_sp': 9,
+        'd_st': 40,
+        'd_sy': 36,
+        'w_st': 12,
+        'l_st': 100,
+    }
+
+    SynR_parameters = {
+        'p': 2,
+        'Q': 12,
+        "name": "Example_SynR_Machine",
+        'rated_speed': 1800,
+        'rated_power': 3600,
+        'rated_current': 10,   
+    }
+
+    SynR_materials = {
+        "air_mat": Air,
+        "rotor_iron_mat": Arnon5,
+        "stator_iron_mat": Arnon5,
+        "coil_mat": Copper,
+        "shaft_mat": Steel,
+    }
+
+    SynR_winding = {
+        "no_of_layers": 2,
+        "layer_phases": [ ['U', 'V', 'W', 'U', 'V', 'W', 'U', 'V', 'W', 'U', 'V', 'W'],
+                            ['V', 'W', 'U', 'V', 'W', 'U', 'V', 'W', 'U', 'V', 'W', 'U'] ],
+        "layer_polarity": [ ['+', '-', '+', '-', '+', '-', '+', '-', '+', '-', '+', '-'],
+                            ['-', '+', '-', '+', '-', '+', '-', '+', '-', '+', '-', '+'] ],
+        "pitch": 2,
+        "Z_q": 20,
+        "Kov": 1.8,
+        "Kcu": 0.5,
+        "phase_current_offset": 0,
+    }
+
+    Example_SynR_Machine = SynR_Machine(
+        SynR_dimensions, SynR_parameters, SynR_materials, SynR_winding
+    )
+
+    ################ DEFINE SynR operating point ################
+    Machine_Op_Pt = SynR_Machine_Oper_Pt(
+        speed=1800,
+        phi_0 = 0,
+        ambient_temp=25,
+        rotor_temp_rise=0,
+    )
+
+To use this code, another file must be created and placed one level outside of the ``eMach`` folder in the repository in which it lies. The 
+objective of this file is to call the example machine (in this case the ``example_SynR_machine.py`` that was just created in the ``SynR_eval``
+folder) and create a machine design object. 
+
+.. code-block:: python
+
+    import os
+    import sys
+    from time import time as clock_time
+
+    os.chdir(os.path.dirname(__file__))
+
+    from eMach.mach_eval import (MachineEvaluator, MachineDesign)
+    from eMach.examples.mach_eval_examples.SynR_eval.electromagnetic_step import electromagnetic_step
+    from eMach.examples.mach_eval_examples.SynR_eval.structural_step import structural_step
+    from eMach.examples.mach_eval_examples.SynR_eval.example_SynR_machine import Example_SynR_Machine, Machine_Op_Pt
+
+    ############################ Create Evaluator ########################
+    SynR_evaluator = MachineEvaluator(
+        [
+            electromagnetic_step
+            structural_step
+        ]
+    )
+
+    design_variant = MachineDesign(Example_SynR_Machine, Machine_Op_Pt)
+
+    results = SynR_evaluator.evaluate(design_variant)
+
+Example code defining the structural step is provided below. This code defines the analyzer problem class (input to the analyzer), 
+initializes the analyzer class with an explanation of the required configurations, and calls the post-analyzer class. The 
+``SynR_Structural_PostAnalyzer`` class is used to process the structural data and to print the results. A copy of this file lies in 
+the ``eMach\examples\mach_eval_examples\SynR_eval`` folder.
+
+.. code-block:: python
+
+    import os
+    import sys
+    import copy
+
+    from mach_eval import AnalysisStep, ProblemDefinition
+    from mach_eval.analyzers.mechanical.SynR import SynR_struct_analyzer as SynR_struct
+    from mach_eval.analyzers.mechanical.SynR.SynR_struct_config import SynR_Struct_Config
+    from examples.mach_eval_examples.SynR_eval.SynR_struct_post_analyzer import SynR_Struct_PostAnalyzer
+
+    ############################ Define Structural Step ###########################
+    class SynR_Struct_ProblemDefinition(ProblemDefinition):
+        """Converts a State into a problem"""
+
+        def __init__(self):
+            pass
+
+        def get_problem(state):
+
+            problem = SynR_struct.SynR_Struct_Problem(
+                state.design.machine, state.design.settings)
+            return problem
+
+    # initialize em analyzer class with FEA configuration
+    configuration = SynR_Struct_Config(
+        no_of_rev = 1,
+        no_of_steps = 72,
+
+        mesh_size=3, # mm
+        mesh_size_rotor=0.1, # mm
+        airgap_mesh_radial_div=4,
+        airgap_mesh_circum_div=720,
+        mesh_air_region_scale=1.05,
+
+        only_table_results=False,
+        csv_results="CsvOutputCalculation",
+        del_results_after_calc=False,
+        run_folder=os.path.dirname(__file__) + "/run_data/",
+        jmag_csv_folder=os.path.dirname(__file__) + "/run_data/jmag_csv/",
+
+        max_nonlinear_iterations=50,
+        multiple_cpus=True,
+        num_cpus=4,
+        jmag_scheduler=False,
+        jmag_visible=True,
+        scale_axial_length = True,
+    )
+
+    SynR_struct_analysis = SynR_struct.SynR_Struct_Analyzer(configuration)
+
+    structural_step = AnalysisStep(SynR_Struct_ProblemDefinition, SynR_struct_analysis, SynR_Struct_PostAnalyzer)
+
+Output to User
+**********************************
+
+The ``SynR_Structural_Analyzer`` returns a dictionary holding the results obtained from the static analysis of the machine. The elements 
+of this dictionary and their descriptions are provided below:
+
+.. csv-table:: `SynR_Structural_Analyzer Output`
+   :file: output_SynR_struct_analyzer.csv
+   :widths: 70, 70
+   :header-rows: 1
+
+As mentioned, the post analyzer is necessary to extract and compute the analyzer's computations and to interpret the results. The post analyzer 
+contains the following code and lies also in the ``eMach\examples\mach_eval_examples\SynR_eval`` folder. The code contained in the post analyzer, 
+in this case to find the maximum induced stress, can be seen here:
+
+.. code-block:: python
+
+    import copy
+
+    class SynR_Struct_PostAnalyzer:
+        def get_next_state(results, in_state):
+            state_out = copy.deepcopy(in_state)
+
+            ############################ Extract required info ###########################
+            struct = results["max_stress"]
+            s = struct['Maximum Value']
+            max_stress = s[0]
+            yield_stress = 300 * 1000000
+
+            ############################ Output #################################
+            print("\n************************ STRUCTURAL RESULT ************************")
+            print("Maximum Stress = ", max_stress/1000000, " MPa",)
+            if max_stress > yield_stress:
+                print("This exceeds the yield stress of the rotor!")
+            else:
+                print("This does not exceed the yield stress of the rotor!")
+            print("************************************************************\n")
+        
+
+            return state_out
+
+All example SynR evaluation scripts, including the one used for this analyzer, can be found in ``eMach\examples\mach_eval_examples\SynR_eval``,
+where the post-analyzer script uses FEA results and calculates the maximum induced stress. This analyzer can be run by simply running 
+the ``SynR_evaluator`` file in the aforementioned folder. This example should produce the following results:
+
+.. csv-table:: `SynR_Structural_Analyzer Results`
+   :file: results_SynR_struct_analyzer.csv
+   :widths: 70, 70, 30
+   :header-rows: 1

--- a/docs/source/mechanical_analyzers/SynR_struct_analyzer.rst
+++ b/docs/source/mechanical_analyzers/SynR_struct_analyzer.rst
@@ -10,7 +10,7 @@ Synchronous reluctance (SynR) machines are electric machines capable of producin
 rotor-mounted field source. Basic characteristics of the design and analysis of synchronous reluctance machines can be done 
 by hand, as is shown in the paper `here <https://ieeexplore.ieee.org/stamp/stamp.jsp?tp=&arnumber=5167704>`_. Reluctance rotors
 are able to achieve high inductance ratios because of their complex rotor design. This complex rotor design is great for creating
-reluctace torque, but can have some unintended consequences regarding mechanical integrity. The following parameter is crucial to
+reluctance torque, but can have some unintended consequences regarding mechanical integrity. The following parameter is crucial to
 ensuring SynR rotors maintain mechanical integrity under rated conditions:
 
 1) Maximum rotor stress must be below yield stress
@@ -228,7 +228,7 @@ of this dictionary and their descriptions are provided below:
 
 .. csv-table:: `SynR_Structural_Analyzer Output`
    :file: output_SynR_struct_analyzer.csv
-   :widths: 70, 70
+   :widths: 70, 70, 30
    :header-rows: 1
 
 As mentioned, the post analyzer is necessary to extract and compute the analyzer's computations and to interpret the results. The post analyzer 

--- a/docs/source/mechanical_analyzers/SynR_struct_analyzer.rst
+++ b/docs/source/mechanical_analyzers/SynR_struct_analyzer.rst
@@ -74,9 +74,9 @@ Example code initializing the machine design for the optimized SynR design provi
         'w_b1': 4,
         'w_b2': 4,
         'w_b3': 4,
-        'l_b1': 33.75,
-        'l_b2': 24.4,
-        'l_b3': 12.6,
+        'l_b1': 34.1,
+        'l_b2': 24.75,
+        'l_b3': 13.1,
         'l_b4': 13,
         'l_b5': 10,
         'l_b6': 7,
@@ -91,13 +91,13 @@ Example code initializing the machine design for the optimized SynR design provi
         'l_st': 100,
     }
 
+
     SynR_parameters = {
         'p': 2,
         'Q': 12,
         "name": "Example_SynR_Machine",
         'rated_speed': 1800,
-        'rated_power': 3600,
-        'rated_current': 10,   
+        'rated_current': 20,   
     }
 
     SynR_materials = {
@@ -110,8 +110,8 @@ Example code initializing the machine design for the optimized SynR design provi
 
     SynR_winding = {
         "no_of_layers": 2,
-        "layer_phases": [ ['U', 'V', 'W', 'U', 'V', 'W', 'U', 'V', 'W', 'U', 'V', 'W'],
-                            ['V', 'W', 'U', 'V', 'W', 'U', 'V', 'W', 'U', 'V', 'W', 'U'] ],
+        "layer_phases": [ ['U', 'W', 'V', 'U', 'W', 'V', 'U', 'W', 'V', 'U', 'W', 'V'],
+                            ['W', 'V', 'U', 'W', 'V', 'U', 'W', 'V', 'U', 'W', 'V', 'U'] ],
         "layer_polarity": [ ['+', '-', '+', '-', '+', '-', '+', '-', '+', '-', '+', '-'],
                             ['-', '+', '-', '+', '-', '+', '-', '+', '-', '+', '-', '+'] ],
         "pitch": 2,
@@ -153,7 +153,7 @@ folder) and create a machine design object.
     ############################ Create Evaluator ########################
     SynR_evaluator = MachineEvaluator(
         [
-            electromagnetic_step
+            electromagnetic_step,
             structural_step
         ]
     )

--- a/docs/source/mechanical_analyzers/index.rst
+++ b/docs/source/mechanical_analyzers/index.rst
@@ -15,3 +15,4 @@ This page contains links to analyzers in eMach which aid in evaluating the mecha
     inner_rotor_stator_thermal_analyzer
     SPM_structural_analyzer
     SPM_sleeve_analyzer
+    SynR_struct_analyzer

--- a/docs/source/mechanical_analyzers/init_SynR_struct_analyzer.csv
+++ b/docs/source/mechanical_analyzers/init_SynR_struct_analyzer.csv
@@ -1,0 +1,2 @@
+Arguments,Description
+configuration,"object of type SynR_Struct_Config describing analyzer domain, JMAG configurations, etc."

--- a/docs/source/mechanical_analyzers/input_SynR_struct_analyzer.csv
+++ b/docs/source/mechanical_analyzers/input_SynR_struct_analyzer.csv
@@ -1,0 +1,3 @@
+Arguments,Description
+machine,object of type SynR_Machine describing a SynR design
+operating_point,object of type SynR_Machine_Oper_Pt describing a SynR design operating point

--- a/docs/source/mechanical_analyzers/output_SynR_struct_analyzer.csv
+++ b/docs/source/mechanical_analyzers/output_SynR_struct_analyzer.csv
@@ -1,2 +1,2 @@
-Output,Description
-maximum stress,Maximum stress found in rotor at full speed
+Output,Description,Units
+maximum stress,Maximum stress found in rotor at full speed,MPa

--- a/docs/source/mechanical_analyzers/output_SynR_struct_analyzer.csv
+++ b/docs/source/mechanical_analyzers/output_SynR_struct_analyzer.csv
@@ -1,0 +1,2 @@
+Output,Description
+maximum stress,Maximum stress found in rotor at full speed

--- a/docs/source/mechanical_analyzers/results_SynR_struct_analyzer.csv
+++ b/docs/source/mechanical_analyzers/results_SynR_struct_analyzer.csv
@@ -1,2 +1,2 @@
 Result,Value,Unit
-Torque Density,46.52,MPa
+Maximum Stress,46.52,MPa

--- a/docs/source/mechanical_analyzers/results_SynR_struct_analyzer.csv
+++ b/docs/source/mechanical_analyzers/results_SynR_struct_analyzer.csv
@@ -1,2 +1,2 @@
 Result,Value,Unit
-Torque Density,15.38,MPa
+Torque Density,46.52,MPa

--- a/docs/source/mechanical_analyzers/results_SynR_struct_analyzer.csv
+++ b/docs/source/mechanical_analyzers/results_SynR_struct_analyzer.csv
@@ -1,0 +1,2 @@
+Result,Value,Unit
+Torque Density,15.38,MPa

--- a/examples/mach_eval_examples/SynR_eval/SynR_evaluator.py
+++ b/examples/mach_eval_examples/SynR_eval/SynR_evaluator.py
@@ -7,12 +7,14 @@ sys.path.append("../../../")
 
 from mach_eval import (MachineEvaluator, MachineDesign)
 from electromagnetic_step import electromagnetic_step
+from structural_step import structural_step
 from example_SynR_machine import Example_SynR_Machine, Machine_Op_Pt
 
 ############################ Create Evaluator ########################
 SynR_evaluator = MachineEvaluator(
     [
-        electromagnetic_step
+        electromagnetic_step,
+        structural_step
     ]
 )
 

--- a/examples/mach_eval_examples/SynR_eval/SynR_struct_post_analyzer.py
+++ b/examples/mach_eval_examples/SynR_eval/SynR_struct_post_analyzer.py
@@ -1,0 +1,20 @@
+import copy
+
+class SynR_Struct_PostAnalyzer:
+    def get_next_state(results, in_state):
+        state_out = copy.deepcopy(in_state)
+
+        ############################ Extract required info ###########################
+        struct = results["max_stress"]
+        s = struct['Maximum Value']
+        max_stress = s[0]
+        yield_stress = 300 * 1000000
+
+        ############################ Output #################################
+        print("\n************************ STRUCTURAL RESULT ************************")
+        print("Maximum Stress = ", max_stress/1000000, " MPa",)
+        if max_stress > yield_stress:
+            print("This exceeds the yield stress of the rotor!")
+        print("************************************************************\n")
+
+        return state_out

--- a/examples/mach_eval_examples/SynR_eval/SynR_struct_post_analyzer.py
+++ b/examples/mach_eval_examples/SynR_eval/SynR_struct_post_analyzer.py
@@ -15,6 +15,9 @@ class SynR_Struct_PostAnalyzer:
         print("Maximum Stress = ", max_stress/1000000, " MPa",)
         if max_stress > yield_stress:
             print("This exceeds the yield stress of the rotor!")
+        else:
+            print("This does not exceed the yield stress of the rotor!")
         print("************************************************************\n")
+    
 
         return state_out

--- a/examples/mach_eval_examples/SynR_eval/structural_step.py
+++ b/examples/mach_eval_examples/SynR_eval/structural_step.py
@@ -26,7 +26,7 @@ configuration = SynR_Struct_Config(
     no_of_steps = 72,
 
     mesh_size=3, # mm
-    mesh_size_rotor=1, # mm
+    mesh_size_rotor=0.1, # mm
     airgap_mesh_radial_div=4,
     airgap_mesh_circum_div=720,
     mesh_air_region_scale=1.05,

--- a/examples/mach_eval_examples/SynR_eval/structural_step.py
+++ b/examples/mach_eval_examples/SynR_eval/structural_step.py
@@ -1,0 +1,50 @@
+import os
+import sys
+import copy
+
+from mach_eval import AnalysisStep, ProblemDefinition
+from mach_eval.analyzers.mechanical.SynR import SynR_struct_analyzer as SynR_struct
+from mach_eval.analyzers.mechanical.SynR.SynR_struct_config import SynR_Struct_Config
+from examples.mach_eval_examples.SynR_eval.SynR_struct_post_analyzer import SynR_Struct_PostAnalyzer
+
+############################ Define Electromagnetic Step ###########################
+class SynR_Struct_ProblemDefinition(ProblemDefinition):
+    """Converts a State into a problem"""
+
+    def __init__(self):
+        pass
+
+    def get_problem(state):
+
+        problem = SynR_struct.SynR_Struct_Problem(
+            state.design.machine, state.design.settings)
+        return problem
+
+# initialize em analyzer class with FEA configuration
+configuration = SynR_Struct_Config(
+    no_of_rev = 1,
+    no_of_steps = 72,
+
+    mesh_size=3, # mm
+    mesh_size_rotor=1, # mm
+    airgap_mesh_radial_div=4,
+    airgap_mesh_circum_div=720,
+    mesh_air_region_scale=1.05,
+
+    only_table_results=False,
+    csv_results="CsvOutputCalculation",
+    del_results_after_calc=False,
+    run_folder=os.path.dirname(__file__) + "/run_data/",
+    jmag_csv_folder=os.path.dirname(__file__) + "/run_data/jmag_csv/",
+
+    max_nonlinear_iterations=50,
+    multiple_cpus=True,
+    num_cpus=4,
+    jmag_scheduler=False,
+    jmag_visible=True,
+    scale_axial_length = True,
+)
+
+SynR_struct_analysis = SynR_struct.SynR_Struct_Analyzer(configuration)
+
+structural_step = AnalysisStep(SynR_Struct_ProblemDefinition, SynR_struct_analysis, SynR_Struct_PostAnalyzer)

--- a/examples/mach_eval_examples/SynR_eval/structural_step.py
+++ b/examples/mach_eval_examples/SynR_eval/structural_step.py
@@ -7,7 +7,7 @@ from mach_eval.analyzers.mechanical.SynR import SynR_struct_analyzer as SynR_str
 from mach_eval.analyzers.mechanical.SynR.SynR_struct_config import SynR_Struct_Config
 from examples.mach_eval_examples.SynR_eval.SynR_struct_post_analyzer import SynR_Struct_PostAnalyzer
 
-############################ Define Electromagnetic Step ###########################
+############################ Define Structural Step ###########################
 class SynR_Struct_ProblemDefinition(ProblemDefinition):
     """Converts a State into a problem"""
 

--- a/examples/mach_eval_examples/SynR_eval/structural_step.py
+++ b/examples/mach_eval_examples/SynR_eval/structural_step.py
@@ -22,8 +22,6 @@ class SynR_Struct_ProblemDefinition(ProblemDefinition):
 
 # initialize em analyzer class with FEA configuration
 configuration = SynR_Struct_Config(
-    no_of_rev = 1,
-    no_of_steps = 72,
 
     mesh_size=3, # mm
     mesh_size_rotor=0.1, # mm

--- a/mach_eval/analyzers/mechanical/SynR/SynR_struct_analyzer.py
+++ b/mach_eval/analyzers/mechanical/SynR/SynR_struct_analyzer.py
@@ -167,7 +167,7 @@ class SynR_Struct_Analyzer:
             theta=mo.DimDegree(-180 / self.machine_variant.Q)),
             )
 
-        self.rotor_core = mo.CrossSectFluxBarrierRotor(
+        self.rotor_core = mo.CrossSectFluxBarrierRotorPartial(
             name="RotorCore",
             dim_alpha_b=mo.DimDegree(self.machine_variant.alpha_b),
             dim_r_ri=mo.DimMillimeter(self.machine_variant.r_ri),
@@ -272,7 +272,7 @@ class SynR_Struct_Analyzer:
         tool.sketch.SetProperty("Name", self.rotor_core.name)
         tool.sketch.SetProperty("Color", r"#808080")
         cs_rotor_core = self.rotor_core.draw(tool)
-        rotor_tool = tool.prepare_section(cs_rotor_core)
+        rotor_tool = tool.prepare_section(cs_rotor_core, 2*self.machine_variant.p)
 
         return True
 

--- a/mach_eval/analyzers/mechanical/SynR/SynR_struct_analyzer.py
+++ b/mach_eval/analyzers/mechanical/SynR/SynR_struct_analyzer.py
@@ -1,0 +1,762 @@
+import os
+import numpy as np
+import pandas as pd
+import sys
+from time import time as clock_time
+
+from mach_cad import model_obj as mo
+from mach_opt import InvalidDesign
+from mach_cad.tools import jmag as JMAG
+
+class SynR_Struct_Problem:
+    def __init__(self, machine, operating_point):
+        self.machine = machine
+        self.operating_point = operating_point
+        self._validate_attr()
+
+    def _validate_attr(self):
+        if 'SynR_Machine' in str(type(self.machine)):
+            pass
+        else:
+            raise TypeError("Invalid machine type")
+
+        if 'SynR_Machine_Oper_Pt' in str(type(self.operating_point)):
+            pass
+        else:
+            raise TypeError("Invalid settings type")
+
+
+class SynR_Struct_Analyzer:
+    def __init__(self, configuration):
+        self.config = configuration
+
+    def analyze(self, problem):
+        self.machine_variant = problem.machine
+        self.operating_point = problem.operating_point
+        
+        ####################################################
+        # 01 Setting project name and output folder
+        ####################################################
+        
+        self.project_name = self.machine_variant.name
+        # expected_project_file = self.config.run_folder + "%s_attempts_2.jproj" % self.project_name
+        expected_project_file = self.config.run_folder + "%s_Struct.jproj" % self.project_name
+        # Create output folder
+        if not os.path.isdir(self.config.jmag_csv_folder):
+            os.makedirs(self.config.jmag_csv_folder)
+
+        attempts = 1
+        if os.path.exists(expected_project_file):
+            print(
+                "JMAG project exists already, I will not delete it but create a new one with a different name instead."
+            )
+            # os.remove(expected_project_file_path)
+            attempts = 2
+            temp_path = expected_project_file[
+                : -len(".jproj")
+            ] + "_attempts_%d.jproj" % (attempts)
+            while os.path.exists(temp_path):
+                attempts += 1
+                temp_path = expected_project_file[
+                    : -len(".jproj")
+                ] + "_attempts_%d.jproj" % (attempts)
+
+            expected_project_file = temp_path
+
+        if attempts > 1:
+            self.project_name = self.project_name + "_attempts_%d" % (attempts)
+
+        toolJmag = JMAG.JmagDesigner()
+
+        toolJmag.visible = self.config.jmag_visible
+        toolJmag.open(comp_filepath=expected_project_file, length_unit="DimMillimeter", study_type="StructuralStatic2D")
+        toolJmag.save()
+
+        self.study_name = self.project_name + "_Stat_SynR"
+        self.design_results_folder = (
+            self.config.run_folder + "%s_results/" % self.project_name
+        )
+        if not os.path.isdir(self.design_results_folder):
+            os.makedirs(self.design_results_folder)
+
+        ################################################################
+        # 02 Run Structural analysis
+        ################################################################
+
+        # Draw cross_section
+        draw_success = self.draw_machine(toolJmag)
+    
+        if not draw_success:
+            raise InvalidDesign
+
+        toolJmag.doc.SaveModel(False)
+        app = toolJmag.jd
+        model = app.GetCurrentModel()
+
+        # Pre-processing
+        model.SetName(self.project_name)
+        model.SetDescription(self.show(self.project_name, toString=True))
+
+        valid_design = self.pre_process(model)
+
+        if not valid_design:
+            raise InvalidDesign
+
+        # Create static study
+        # model = toolJmag.create_model(self.study_name)
+        study = self.add_struct_study(app, model, self.config.jmag_csv_folder, self.study_name)
+        self.create_custom_material(
+            app, self.machine_variant.stator_iron_mat["core_material"]
+        )
+        app.SetCurrentStudy(self.study_name)
+
+        # Mesh study
+        self.mesh_study(app, model, study)
+
+        # Run study
+        self.run_study(app, study, clock_time())
+
+        toolJmag.save()
+        # app.Quit()
+
+        ####################################################
+        # 03 Load FEA output
+        ####################################################
+
+        fea_rated_output = self.extract_JMAG_results(
+            self.config.jmag_csv_folder, self.study_name
+        )
+
+        return fea_rated_output
+
+    @property
+    def speed(self):
+        return self.operating_point.speed
+
+
+    def draw_machine(self, tool):
+        ####################################################
+        # Adding parts objects
+        ####################################################
+        self.stator_core = mo.CrossSectInnerRotorStatorPartial(
+            name="StatorCore",
+            dim_alpha_st=mo.DimDegree(self.machine_variant.alpha_st),
+            dim_alpha_so=mo.DimDegree(self.machine_variant.alpha_so),
+            dim_r_si=mo.DimMillimeter(self.machine_variant.r_si),
+            dim_d_so=mo.DimMillimeter(self.machine_variant.d_so),
+            dim_d_sp=mo.DimMillimeter(self.machine_variant.d_sp),
+            dim_d_st=mo.DimMillimeter(self.machine_variant.d_st),
+            dim_d_sy=mo.DimMillimeter(self.machine_variant.d_sy),
+            dim_w_st=mo.DimMillimeter(self.machine_variant.w_st),
+            dim_r_st=mo.DimMillimeter(0),
+            dim_r_sf=mo.DimMillimeter(0),
+            dim_r_sb=mo.DimMillimeter(0),
+            Q=self.machine_variant.Q,
+            location=mo.Location2D(anchor_xy=[mo.DimMillimeter(0), mo.DimMillimeter(0)],
+            theta=mo.DimDegree(-180 / self.machine_variant.Q)),
+            )
+
+        self.winding_layer1 = mo.CrossSectInnerRotorStatorRightSlot(
+            name="WindingLayer1",
+            stator_core=self.stator_core,
+            location=mo.Location2D(anchor_xy=[mo.DimMillimeter(0), mo.DimMillimeter(0)],
+            theta=mo.DimDegree(-180 / self.machine_variant.Q)),
+            )
+
+        self.winding_layer2 = mo.CrossSectInnerRotorStatorLeftSlot(
+            name="WindingLayer2",
+            stator_core=self.stator_core,
+            location=mo.Location2D(anchor_xy=[mo.DimMillimeter(0), mo.DimMillimeter(0)],
+            theta=mo.DimDegree(-180 / self.machine_variant.Q)),
+            )
+
+        self.rotor_core = mo.CrossSectFluxBarrierRotor(
+            name="RotorCore",
+            dim_alpha_b=mo.DimDegree(self.machine_variant.alpha_b),
+            dim_r_ri=mo.DimMillimeter(self.machine_variant.r_ri),
+            dim_r_ro=mo.DimMillimeter(self.machine_variant.r_ro),
+            dim_r_f1=mo.DimMillimeter(self.machine_variant.r_f1),
+            dim_r_f2=mo.DimMillimeter(self.machine_variant.r_f2),
+            dim_r_f3=mo.DimMillimeter(self.machine_variant.r_f3),
+            dim_d_r1=mo.DimMillimeter(self.machine_variant.d_r1),
+            dim_d_r2=mo.DimMillimeter(self.machine_variant.d_r2),
+            dim_d_r3=mo.DimMillimeter(self.machine_variant.d_r3),
+            dim_w_b1=mo.DimMillimeter(self.machine_variant.w_b1),
+            dim_w_b2=mo.DimMillimeter(self.machine_variant.w_b2),
+            dim_w_b3=mo.DimMillimeter(self.machine_variant.w_b3),
+            dim_l_b1=mo.DimMillimeter(self.machine_variant.l_b1),
+            dim_l_b2=mo.DimMillimeter(self.machine_variant.l_b2),
+            dim_l_b3=mo.DimMillimeter(self.machine_variant.l_b3),
+            dim_l_b4=mo.DimMillimeter(self.machine_variant.l_b4),
+            dim_l_b5=mo.DimMillimeter(self.machine_variant.l_b5),
+            dim_l_b6=mo.DimMillimeter(self.machine_variant.l_b6),
+            p=2,
+            location=mo.Location2D(anchor_xy=[mo.DimMillimeter(0), mo.DimMillimeter(0)], theta=mo.DimDegree(-180 / (2 * self.machine_variant.p))),
+            )
+
+        self.shaft = mo.CrossSectHollowCylinder(
+            name="Shaft",
+            dim_t=mo.DimMillimeter(self.machine_variant.r_ri),
+            dim_r_o=mo.DimMillimeter(self.machine_variant.r_ri),
+            location=mo.Location2D(anchor_xy=[mo.DimMillimeter(0), mo.DimMillimeter(0)]),
+            )
+
+
+        self.comp_stator_core = mo.Component(
+            name="StatorCore",
+            cross_sections=[self.stator_core],
+            material=mo.MaterialGeneric(name=self.machine_variant.stator_iron_mat["core_material"], color=r"#808080"),
+            make_solid=mo.MakeExtrude(location=mo.Location3D(), 
+                    dim_depth=mo.DimMillimeter(self.machine_variant.l_st)),
+            )
+
+        self.comp_winding_layer1 = mo.Component(
+            name="WindingLayer1",
+            cross_sections=[self.winding_layer1],
+            material=mo.MaterialGeneric(name=self.machine_variant.coil_mat["coil_material"]),
+            make_solid=mo.MakeExtrude(location=mo.Location3D(), 
+            dim_depth=mo.DimMillimeter(self.machine_variant.l_st)),
+            )
+
+        self.comp_winding_layer2 = mo.Component(
+            name="WindingLayer2",
+            cross_sections=[self.winding_layer2],
+            material=mo.MaterialGeneric(name=self.machine_variant.coil_mat["coil_material"]),
+            make_solid=mo.MakeExtrude(location=mo.Location3D(), 
+            dim_depth=mo.DimMillimeter(self.machine_variant.l_st)),
+            )
+
+        self.comp_rotor_core = mo.Component(
+            name="RotorCore",
+            cross_sections=[self.rotor_core],
+            material=mo.MaterialGeneric(name=self.machine_variant.rotor_iron_mat["core_material"], color=r"#808080"),
+            make_solid=mo.MakeExtrude(location=mo.Location3D(), 
+                    dim_depth=mo.DimMillimeter(self.machine_variant.l_st)),
+            )
+        
+        self.comp_shaft = mo.Component(
+            name="Shaft",
+            cross_sections=[self.shaft],
+            material=mo.MaterialGeneric(name=self.machine_variant.shaft_mat["shaft_material"], color=r"#71797E"),
+            make_solid=mo.MakeExtrude(location=mo.Location3D(), 
+                    dim_depth=mo.DimMillimeter(self.machine_variant.l_st)),
+            )
+
+
+        tool.bMirror = False
+
+        tool.sketch = tool.create_sketch()
+        tool.sketch.SetProperty("Name", self.stator_core.name)
+        tool.sketch.SetProperty("Color", r"#808080")
+        cs_stator = self.stator_core.draw(tool)
+        stator_tool = tool.prepare_section(cs_stator, self.machine_variant.Q)
+
+        tool.sketch = tool.create_sketch()
+        tool.sketch.SetProperty("Name", self.winding_layer1.name)
+        tool.sketch.SetProperty("Color", r"#B87333")
+        cs_winding_layer1 = self.winding_layer1.draw(tool)
+        winding_tool1 = tool.prepare_section(cs_winding_layer1, self.machine_variant.Q)
+        self.winding_layer1_inner_coord = cs_winding_layer1.inner_coord
+
+        tool.sketch = tool.create_sketch()
+        tool.sketch.SetProperty("Name", self.winding_layer2.name)
+        tool.sketch.SetProperty("Color", r"#B87333")
+        cs_winding_layer2 = self.winding_layer2.draw(tool)
+        winding_tool2 = tool.prepare_section(cs_winding_layer2, self.machine_variant.Q)
+        self.winding_layer2_inner_coord = cs_winding_layer2.inner_coord
+
+        tool.sketch = tool.create_sketch()
+        tool.sketch.SetProperty("Name", self.shaft.name)
+        tool.sketch.SetProperty("Color", r"#71797E")
+        cs_shaft = self.shaft.draw(tool)
+        shaft_tool = tool.prepare_section(cs_shaft)
+
+        tool.sketch = tool.create_sketch()
+        tool.sketch.SetProperty("Name", self.rotor_core.name)
+        tool.sketch.SetProperty("Color", r"#808080")
+        cs_rotor_core = self.rotor_core.draw(tool)
+        rotor_tool = tool.prepare_section(cs_rotor_core)
+
+        return True
+
+
+    def show(self, name, toString=False):
+        attrs = list(vars(self).items())
+        key_list = [el[0] for el in attrs]
+        val_list = [el[1] for el in attrs]
+        the_dict = dict(list(zip(key_list, val_list)))
+        sorted_key = sorted(
+            key_list,
+            key=lambda item: (
+                int(item.partition(" ")[0]) if item[0].isdigit() else float("inf"),
+                item,
+            ),
+        )  # this is also useful for string beginning with digiterations '15 Steel'.
+        tuple_list = [(key, the_dict[key]) for key in sorted_key]
+        if not toString:
+            print("- SynR Individual #%s\n\t" % name, end=" ")
+            print(", \n\t".join("%s = %s" % item for item in tuple_list))
+            return ""
+        else:
+            return "\n- SynR Individual #%s\n\t" % name + ", \n\t".join(
+                "%s = %s" % item for item in tuple_list
+            )
+
+    def pre_process(self, model):
+        # pre-process : you can select part by coordinate!
+        """Group"""
+
+        def group(name, id_list):
+            model.GetGroupList().CreateGroup(name)
+            for the_id in id_list:
+                model.GetGroupList().AddPartToGroup(name, the_id)
+                # model.GetGroupList().AddPartToGroup(name, name) #<- this also works
+
+        part_ID_list = model.GetPartIDs()
+
+        if len(part_ID_list) != int(
+            1 + 1 + self.machine_variant.Q * 2 + 1
+        ):
+            print("Parts are missing in this machine")
+            return False
+
+        self.id_statorCore = id_statorCore = part_ID_list[0]
+        partIDRange_Coil = part_ID_list[1 : int(2 * self.machine_variant.Q + 1)]
+        self.id_rotorCore = id_rotorCore = part_ID_list[int(2 * self.machine_variant.Q + 1)]
+        id_shaft = part_ID_list[-1]   
+
+        group("Coils", partIDRange_Coil)
+
+        """ Add Part to Set for later references """
+
+        def add_part_to_set(name, x, y, ID=None):
+            model.GetSetList().CreatePartSet(name)
+            model.GetSetList().GetSet(name).SetMatcherType("Selection")
+            model.GetSetList().GetSet(name).ClearParts()
+            sel = model.GetSetList().GetSet(name).GetSelection()
+            if ID is None:
+                # print x,y
+                sel.SelectPartByPosition(x, y, 0)  # z=0 for 2D
+            else:
+                sel.SelectPart(ID)
+            model.GetSetList().GetSet(name).AddSelected(sel)
+
+        # RotorSet
+        add_part_to_set("RotorSet", 0.0, 0.0, ID=id_shaft)
+
+        # Create Set for right layer
+        Angle_StatorSlotSpan = 360 / self.machine_variant.Q
+        # R = self.r_si + self.d_sp + self.d_st *0.5 # this is not generally working (JMAG selects stator core instead.)
+        # THETA = 0.25*(Angle_StatorSlotSpan)/180.*np.pi
+        R = np.sqrt(self.winding_layer1_inner_coord[0] ** 2 + self.winding_layer1_inner_coord[1] ** 2)
+        THETA = np.arctan(self.winding_layer1_inner_coord[1] / self.winding_layer1_inner_coord[0])
+        X = R * np.cos(THETA)
+        Y = R * np.sin(THETA)
+        count = 0
+        for UVW, UpDown in zip(
+            self.machine_variant.layer_phases[0], self.machine_variant.layer_polarity[0]
+        ):
+            count += 1
+            add_part_to_set("coil_right_%s%s %d" % (UVW, UpDown, count), X, Y)
+
+            # print(X, Y, THETA)
+            THETA += Angle_StatorSlotSpan / 180.0 * np.pi
+            X = R * np.cos(THETA)
+            Y = R * np.sin(THETA)
+
+        # Create Set for left layer
+        THETA = np.arctan(self.winding_layer2_inner_coord[1] / self.winding_layer2_inner_coord[0])
+        X = R * np.cos(THETA)
+        Y = R * np.sin(THETA)
+        count = 0
+        for UVW, UpDown in zip(
+            self.machine_variant.layer_phases[1], self.machine_variant.layer_polarity[1]
+        ):
+            count += 1
+            add_part_to_set("coil_left_%s%s %d" % (UVW, UpDown, count), X, Y)
+
+            THETA += Angle_StatorSlotSpan / 180.0 * np.pi
+            X = R * np.cos(THETA)
+            Y = R * np.sin(THETA)
+
+        # Create Set for Motion Region
+        def part_list_set(name, list_part_id=None, prefix=None):
+            model.GetSetList().CreatePartSet(name)
+            model.GetSetList().GetSet(name).SetMatcherType("Selection")
+            model.GetSetList().GetSet(name).ClearParts()
+            sel = model.GetSetList().GetSet(name).GetSelection()
+
+            if list_part_id is not None:
+                for ID in list_part_id:
+                    sel.SelectPart(ID)
+            model.GetSetList().GetSet(name).AddSelected(sel)
+
+        part_list_set(
+            "Motion_Region", list_part_id=[id_rotorCore, id_shaft]
+        )
+
+        return True
+
+
+    def create_custom_material(self, app, steel_name):
+
+        app.GetMaterialLibrary().CreateCustomMaterial(
+            self.machine_variant.stator_iron_mat["core_material"], "Custom Materials"
+        )
+        app.GetMaterialLibrary().GetUserMaterial(
+            self.machine_variant.stator_iron_mat["core_material"]
+        ).SetValue(
+            "Density", self.machine_variant.stator_iron_mat["core_material_density"] / 1000
+        )
+        app.GetMaterialLibrary().GetUserMaterial(
+            self.machine_variant.stator_iron_mat["core_material"]
+        ).SetValue("MagneticSteelPermeabilityType", 2)
+        app.GetMaterialLibrary().GetUserMaterial(
+            self.machine_variant.stator_iron_mat["core_material"]
+        ).SetValue("CoerciveForce", 0)
+        # app.GetMaterialLibrary().GetUserMaterial(u"Arnon5-final").GetTable("BhTable").SetName(u"SmoothZeroPointOne")
+        BH = np.loadtxt(
+            self.machine_variant.stator_iron_mat["core_bh_file"],
+            unpack=True,
+            usecols=(0, 1),
+        )  # values from Nishanth Magnet BH curve
+        refarray = BH.T.tolist()
+        app.GetMaterialLibrary().GetUserMaterial(
+            self.machine_variant.stator_iron_mat["core_material"]
+        ).GetTable("BhTable").SetTable(refarray)
+        app.GetMaterialLibrary().GetUserMaterial(
+            self.machine_variant.stator_iron_mat["core_material"]
+        ).SetValue("DemagnetizationCoerciveForce", 0)
+        app.GetMaterialLibrary().GetUserMaterial(
+            self.machine_variant.stator_iron_mat["core_material"]
+        ).SetValue("MagnetizationSaturated", 0)
+        app.GetMaterialLibrary().GetUserMaterial(
+            self.machine_variant.stator_iron_mat["core_material"]
+        ).SetValue("MagnetizationSaturated2", 0)
+        app.GetMaterialLibrary().GetUserMaterial(
+            self.machine_variant.stator_iron_mat["core_material"]
+        ).SetValue("ExtrapolationMethod", 0)
+        app.GetMaterialLibrary().GetUserMaterial(
+            self.machine_variant.stator_iron_mat["core_material"]
+        ).SetValue("YoungModulus", self.machine_variant.stator_iron_mat["core_youngs_modulus"] / 1000000)
+        app.GetMaterialLibrary().GetUserMaterial(
+            self.machine_variant.stator_iron_mat["core_material"]
+        ).SetValue("PoissonRatio", self.machine_variant.stator_iron_mat["core_poission_ratio"])
+        app.GetMaterialLibrary().GetUserMaterial(
+            self.machine_variant.stator_iron_mat["core_material"]
+        ).SetValue("ShearModulus", self.machine_variant.stator_iron_mat["core_youngs_modulus"] / (1000000 * 2 * (1 + self.machine_variant.stator_iron_mat["core_poission_ratio"])))
+
+        app.GetMaterialLibrary().GetUserMaterial(
+            self.machine_variant.stator_iron_mat["core_material"]
+        ).SetValue("Loss_Type", 1)
+        app.GetMaterialLibrary().GetUserMaterial(
+            self.machine_variant.stator_iron_mat["core_material"]
+        ).SetValue(
+            "LossConstantKhX", self.machine_variant.stator_iron_mat["core_ironloss_Kh"]
+        )
+        app.GetMaterialLibrary().GetUserMaterial(
+            self.machine_variant.stator_iron_mat["core_material"]
+        ).SetValue(
+            "LossConstantKeX", self.machine_variant.stator_iron_mat["core_ironloss_Ke"]
+        )
+        app.GetMaterialLibrary().GetUserMaterial(
+            self.machine_variant.stator_iron_mat["core_material"]
+        ).SetValue(
+            "LossConstantAlphaX",
+            self.machine_variant.stator_iron_mat["core_ironloss_a"],
+        )
+        app.GetMaterialLibrary().GetUserMaterial(
+            self.machine_variant.stator_iron_mat["core_material"]
+        ).SetValue(
+            "LossConstantBetaX", self.machine_variant.stator_iron_mat["core_ironloss_b"]
+        )
+
+
+
+    def add_struct_study(
+        self, app, model, dir_csv_output_folder, study_name
+    ):
+
+        # study = toolJmag.create_study(self.study_name, "Transient2D", model)
+        model.CreateStudy("StructuralStatic2D", study_name)
+        app.SetCurrentStudy(self.study_name)
+        study = model.GetStudy(study_name)
+
+        # Study properties
+        study.GetStudyProperties().SetValue(
+            "ModelThickness", self.machine_variant.l_st
+        )  # [mm] Stack Length
+
+        # Material
+        self.add_materials(study)
+
+        # Conditions - Displacement Restraint
+        study.CreateCondition("Displacement", "Containment")
+        study.GetCondition("Containment").SetXYZPoint("Direction", 0, 0, 1)
+        study.GetCondition("Containment").ClearParts()
+        study.GetCondition("Containment").AddSet(
+            model.GetSetList().GetSet("Motion_Region"), 1
+        )
+
+        # Conditions - Centrifugal Force
+        study.CreateCondition("CentrifugalForce",
+            "RotCon") 
+        study.GetCondition("RotCon").SetXYZPoint("Axis", 0, 0, 1) # megbox warning
+        study.GetCondition("RotCon").SetValue("AngularVelocity",
+            int(self.speed))
+        study.GetCondition("RotCon").ClearParts()
+        study.GetCondition("RotCon").AddSet(
+            model.GetSetList().GetSet("Motion_Region"), 0
+        )
+
+        # Conditions - Target Result
+        app.SetCurrentStudy(self.study_name)
+        model.GetStudy(self.study_name).CreateCalculationDefinition("MaxStress")
+        model.GetStudy(self.study_name).GetCalculationDefinition("MaxStress").SetResultType("MisesStress", "")
+        model.GetStudy(self.study_name).GetCalculationDefinition("MaxStress").SetResultCoordinate("Global Rectangular")
+        model.GetStudy(self.study_name).GetCalculationDefinition("MaxStress").SetCalculationType("max")
+        model.GetStudy(self.study_name).GetCalculationDefinition("MaxStress").SetDirectionAxis(0, 0, 1)
+        model.GetStudy(self.study_name).GetCalculationDefinition("MaxStress").ClearParts()
+        model.GetStudy(self.study_name).GetCalculationDefinition("MaxStress").AddSet(
+            model.GetSetList().GetSet("Motion_Region"), 0
+        )
+
+        # Suppress Stator
+        # model.GetStudy(self.study_name).SuppressPart("StatorCore", 1)
+        # model.GetStudy(self.study_name).SuppressPart("Coils", 1)
+
+        # True: no mesh or field results are needed
+        study.GetStudyProperties().SetValue(
+            "OnlyTableResults", self.config.only_table_results
+        )
+
+        # this can be said to be super fast over ICCG solver.
+        # https://www2.jmag-international.com/support/en/pdf/JMAG-Designer_Ver.17.1_ENv3.pdf
+        study.GetStudyProperties().SetValue("DirectSolverType", 1)
+
+        if self.config.multiple_cpus:
+            # This SMP(shared memory process) is effective only if there are tons of elements. e.g., over 100,000.
+            # too many threads will in turn make them compete with each other and slow down the solve. 2 is good enough
+            # for eddy current solve. 6~8 is enough for transient solve.
+            study.GetStudyProperties().SetValue("UseMultiCPU", True)
+            study.GetStudyProperties().SetValue("MultiCPU", self.config.num_cpus)
+
+        # speed, freq
+        study.GetCondition("RotCon").SetValue("AngularVelocity", "speed")
+
+        # Calculate CSV results
+        study.GetStudyProperties().SetValue(
+            "CsvOutputPath", dir_csv_output_folder
+        )  # it's folder rather than file!
+        study.GetStudyProperties().SetValue(self.config.csv_results,1)
+        study.GetStudyProperties().SetValue(
+            "DeleteResultFiles", self.config.del_results_after_calc
+        )
+        #study.GetMaterial("Shaft").SetValue("OutputResult", 0)
+        #study.GetMaterial("Coils").SetValue("OutputResult", 0)
+
+        return study
+
+
+    def add_materials(self, study):
+        # if 'M19' in self.machine_variant.stator_iron_mat["core_material"]:
+        # study.SetMaterialByName(self.comp_stator_core.name, "M-19 Steel Gauge-29")
+        # study.GetMaterial(self.comp_stator_core.name).SetValue("Laminated", 1)
+        # study.GetMaterial(self.comp_stator_core.name).SetValue("LaminationFactor",
+        #     self.machine_variant.stator_iron_mat["core_stacking_factor"])
+
+        # study.SetMaterialByName(self.comp_rotor_core.name, "M-19 Steel Gauge-29")
+        # study.GetMaterial(self.comp_rotor_core.name).SetValue("Laminated", 1)
+        # study.GetMaterial(self.comp_rotor_core.name).SetValue("LaminationFactor",
+        #     self.machine_variant.rotor_iron_mat["core_stacking_factor"])
+
+        study.SetMaterialByName(self.comp_stator_core.name,
+            self.machine_variant.stator_iron_mat["core_material"])
+        study.GetMaterial(self.comp_stator_core.name).SetValue("Laminated", 1)
+        study.GetMaterial(self.comp_stator_core.name).SetValue("LaminationFactor",
+            self.machine_variant.stator_iron_mat["core_stacking_factor"])
+
+        study.SetMaterialByName(self.comp_rotor_core.name, 
+            self.machine_variant.rotor_iron_mat["core_material"])
+        study.GetMaterial(self.comp_rotor_core.name).SetValue("Laminated", 1)
+        study.GetMaterial(self.comp_rotor_core.name).SetValue("LaminationFactor",
+            self.machine_variant.rotor_iron_mat["core_stacking_factor"])
+
+        study.SetMaterialByName(self.comp_shaft.name,
+            self.machine_variant.shaft_mat["shaft_material"])
+        study.GetMaterial(self.comp_shaft.name).SetValue("Laminated", 0)
+        study.GetMaterial(self.comp_shaft.name).SetValue("EddyCurrentCalculation", 1)
+
+        study.SetMaterialByName(self.comp_winding_layer1.name, 
+            self.machine_variant.coil_mat["coil_material"])
+        study.GetMaterial(self.comp_shaft.name).SetValue("UserConductivityType", 1)
+        
+
+    def mesh_study(self, app, model, study):
+
+        # this `if' judgment is effective only if JMAG-DeleteResultFiles is False
+        # if not study.AnyCaseHasResult():
+        # mesh
+        print("------------------Adding mesh")
+        self.add_mesh(study, model)
+
+        # Export Image
+        app.View().ShowAllAirRegions()
+        # app.View().ShowMeshGeometry() # 2nd btn
+        app.View().ShowMesh()  # 3rn btn
+        app.View().Zoom(3)
+        app.View().Pan(-self.machine_variant.r_si / 1000, 0)
+        app.ExportImageWithSize(
+            self.design_results_folder + self.project_name + "mesh.png", 2000, 2000
+        )
+        app.View().ShowModel()  # 1st btn. close mesh view, and note that mesh data will be deleted if only ouput table
+        # results are selected.
+
+
+    def add_mesh(self, study, model):
+        # this is for multi slide planes, which we will not be usin
+        refarray = [[0 for i in range(2)] for j in range(1)]
+        refarray[0][0] = 3
+        refarray[0][1] = 1
+        study.GetMeshControl().GetTable("SlideTable2D").SetTable(refarray)
+
+        study.GetMeshControl().SetValue("MeshType", 1)  # make sure this has been exe'd:
+        # study.GetCondition(u"RotCon").AddSet(model.GetSetList().GetSet(u"Motion_Region"), 0)
+        study.GetMeshControl().SetValue(
+            "RadialDivision", self.config.airgap_mesh_radial_div
+        )  # for air region near which motion occurs
+        study.GetMeshControl().SetValue(
+            "CircumferentialDivision", self.config.airgap_mesh_circum_div
+        )  # 1440) # for air region near which motion occurs
+        study.GetMeshControl().SetValue(
+            "AirRegionScale", self.config.mesh_air_region_scale
+        )  # [Model Length]: Specify a value within (1.05 <= value < 1000)
+        study.GetMeshControl().SetValue("MeshSize", self.config.mesh_size)
+        study.GetMeshControl().SetValue("AutoAirMeshSize", 0)
+        study.GetMeshControl().SetValue(
+            "AirMeshSize", self.config.mesh_size_rotor
+        )  # mm
+        study.GetMeshControl().SetValue("Adaptive", 0)
+
+        study.GetMeshControl().CreateCondition("RotationPeriodicMeshAutomatic", 
+                "autoRotMesh") # with this you can choose to set CircumferentialDivision automatically
+
+        study.GetMeshControl().CreateCondition("Part", "ShaftMeshCtrl")
+        study.GetMeshControl().GetCondition("ShaftMeshCtrl").SetValue("Size", 1) # 10 mm
+        study.GetMeshControl().GetCondition("ShaftMeshCtrl").ClearParts()
+        study.GetMeshControl().GetCondition("ShaftMeshCtrl").AddSet(model.GetSetList().GetSet("Motion_Region"), 0)
+
+        def mesh_all_cases(study):
+            numCase = study.GetDesignTable().NumCases()
+            for case in range(0, numCase):
+                study.SetCurrentCase(case)
+                if not study.HasMesh():
+                    study.CreateMesh()
+
+        # if self.MODEL_ROTATE:
+        #     if self.total_number_of_cases>1: # just to make sure
+        #         model.RestoreCadLink()
+        #         study.ApplyAllCasesCadParameters()
+
+        mesh_all_cases(study)
+
+
+    def run_study(self, app, study, toc):
+        if not self.config.jmag_scheduler:
+            print("-----------------------Running JMAG...")
+            # if run_list[1] == True:
+            study.RunAllCases()
+            msg = "Time spent on %s is %g s." % (study.GetName(), clock_time() - toc)
+            print(msg)
+        else:
+            print("Submit to JMAG_Scheduler...")
+            job = study.CreateJob()
+            job.SetValue("Title", study.GetName())
+            job.SetValue("Queued", True)
+            job.Submit(False)  # False:CurrentCase, True:AllCases
+            # wait and check
+            # study.CheckForCaseResults()
+        
+        app.Save()
+
+
+    def prepare_section(
+        self, list_regions, tool, bMirrorMerge=True, bRotateMerge=True
+    ):  # csToken is a list of cross section's token
+
+        def regionCircularPattern360Origin(region, tool, bMerge=True):
+            # index is used to define name of region
+
+            Q_float = float(tool.iRotateCopy)  # don't ask me, ask JSOL
+            circular_pattern = tool.sketch.CreateRegionCircularPattern()
+            circular_pattern.SetProperty("Merge", bMerge)
+
+            ref2 = tool.doc.CreateReferenceFromItem(region)
+            circular_pattern.SetPropertyByReference("Region", ref2)
+            face_region_string = circular_pattern.GetProperty("Region")
+
+            circular_pattern.SetProperty("CenterType", 2)  # origin I guess
+
+            # print('Copy', Q_float)
+            circular_pattern.SetProperty("Angle", "360/%d" % Q_float)
+            circular_pattern.SetProperty("Instance", str(Q_float))
+
+        list_region_objects = []
+        for idx, list_segments in enumerate(list_regions):
+            # Region
+            tool.doc.GetSelection().Clear()
+            for segment in list_segments:
+                tool.doc.GetSelection().Add(tool.sketch.GetItem(segment.draw_token.GetName()))
+
+            tool.sketch.CreateRegions()
+            # self.sketch.CreateRegionsWithCleanup(EPS, True) # StatorCore will fail
+
+            if idx == 0:
+                region_object = tool.sketch.GetItem(
+                    "Region"
+                )  # This is how you get access to the region you create.
+            else:
+                region_object = tool.sketch.GetItem(
+                    "Region.%d" % (idx + 1)
+                )  # This is how you get access to the region you create.
+            list_region_objects.append(region_object)
+        # raise
+
+        for idx, region_object in enumerate(list_region_objects):
+            # Mirror
+            if tool.bMirror == True:
+                if tool.edge4Ref is None:
+                    tool.regionMirrorCopy(
+                        region_object,
+                        edge4Ref=None,
+                        symmetryType=2,
+                        bMerge=bMirrorMerge,
+                    )  # symmetryType=2 means x-axis as ref
+                else:
+                    tool.regionMirrorCopy(
+                        region_object,
+                        edge4Ref=tool.edge4ref,
+                        symmetryType=None,
+                        bMerge=bMirrorMerge,
+                    )  # symmetryType=2 means x-axis as ref
+
+            # RotateCopy
+            if tool.iRotateCopy != 0:
+                # print('Copy', self.iRotateCopy)
+                regionCircularPattern360Origin(
+                    region_object, tool, bMerge=bRotateMerge
+                )
+
+        tool.sketch.CloseSketch()
+        return list_region_objects
+
+    def extract_JMAG_results(self, path, study_name):
+        max_stress_csv_path = path + study_name + "_calculation_MaxStress.csv"
+        max_stress_df = pd.read_csv(max_stress_csv_path, skiprows=5)
+        # max_stress_df = max_stress_df.set_index("Time(s)")
+        
+        fea_data = {
+            "max_stress": max_stress_df,
+        }
+
+        return fea_data

--- a/mach_eval/analyzers/mechanical/SynR/SynR_struct_config.py
+++ b/mach_eval/analyzers/mechanical/SynR/SynR_struct_config.py
@@ -1,0 +1,27 @@
+class SynR_Struct_Config:
+    def __init__(self, **kwargs) -> None:
+        # attributes for the number of rev and steps
+        self.no_of_rev = kwargs["no_of_rev"] # number of revolutions
+        self.no_of_steps = kwargs["no_of_steps"] # number steps
+
+        self.mesh_size = kwargs["mesh_size"] # generic mesh size for overall model [mm]
+        self.mesh_size_rotor = kwargs["mesh_size_rotor"] # mesh size for rotor [mm]
+        self.airgap_mesh_radial_div = kwargs["airgap_mesh_radial_div"] # radial divisions of airgap mesh
+        self.airgap_mesh_circum_div = kwargs["airgap_mesh_circum_div"] # circumferential divisions of airgap mesh
+        self.mesh_air_region_scale = kwargs["mesh_air_region_scale"] # factor by which air region is scaled beyond machine model
+
+        # results and paths
+        self.only_table_results = kwargs["only_table_results"] # if True: no mesh or field results are extracted
+        self.csv_results = kwargs["csv_results"] # data to be extracted from JMAG in csv format
+        self.del_results_after_calc = kwargs["del_results_after_calc"] # Flag to delete result plot files after calculation
+        self.run_folder = kwargs["run_folder"] # folder in which JMAG files will reside
+        self.jmag_csv_folder = kwargs["jmag_csv_folder"] # folder in which csv files from solve are extracted to
+        
+        # other settings
+        # set maximum iteration number of nonlinear calculation required until solution converges
+        self.max_nonlinear_iterations = kwargs["max_nonlinear_iterations"] 
+        self.multiple_cpus = kwargs["multiple_cpus"] # True if multiple cores are required
+        self.num_cpus = kwargs["num_cpus"] # number of cpus or cores used. Only value if multiple_cpus = True
+        self.jmag_scheduler = kwargs["jmag_scheduler"] # True if it is desired to schedule jobs instead of solving immediately
+        self.jmag_visible = kwargs["jmag_visible"] # JMAG application visible if true
+        self.scale_axial_length = kwargs["scale_axial_length"] # True: scale axial length to get the required rated torque

--- a/mach_eval/analyzers/mechanical/SynR/SynR_struct_config.py
+++ b/mach_eval/analyzers/mechanical/SynR/SynR_struct_config.py
@@ -1,8 +1,5 @@
 class SynR_Struct_Config:
     def __init__(self, **kwargs) -> None:
-        # attributes for the number of rev and steps
-        self.no_of_rev = kwargs["no_of_rev"] # number of revolutions
-        self.no_of_steps = kwargs["no_of_steps"] # number steps
 
         self.mesh_size = kwargs["mesh_size"] # generic mesh size for overall model [mm]
         self.mesh_size_rotor = kwargs["mesh_size_rotor"] # mesh size for rotor [mm]


### PR DESCRIPTION
This PR adds a synchronous reluctance rotor structural analyzer that uses JMAG to the `mechanical_analyzers` folder in the `mach_eval` module, and adds an example to the `examples` module in `eMach`. It can be thought of as two sections:

1) Structural Analyzer

    a) The synchronous reluctance rotor structural analyzer (`SynR_struct_analyzer.py`) takes the input state and operating point of an example machine and finds the structural integrity of the rotor during rated operation. The analyzer takes in the `machine` and `operating point` objects defined above and produces the following output variable:
    - Maximum Rotor Stress

    b) The synchronous reluctance rotor structural analyzer configuration (`SynR_struct_config.py`) file defines the required parameters for the analyzer and configures them as a single object to be pulled into the analyzer itself. These include mostly the JMAG parameters that were not previously defined in the machine.

    Together, the `SynR_em_analyzer` and `SynR_em_config` files define and carry out the analyzer, resulting in usable FEA data files that are used by the `post analyzer` file defined in the following section. 

2) Example that uses the analyzer

    a) The example synchronous reluctance machine (`example_SynR_machine.py`) provides an example of a 12-slot, 4-pole machine with distributed windings. This contains all of the dimensions, parameters, materials, and winding characteristics that are needed by the `SynR_machine` that is used. This example machine is called by the evaluator file.

    b) The structural step (`structural_step.py`) defines all of the requirements needed by the analyzer configuration file, which contains the problem definition and configuration classes of the step.

    c) The post analyzer (`SynR_struct_post_analyzer.py`) is the last file in the chain that interprets the results of the analyzer and calculates the desired output value for the machine evaluation.

    d) The evaluator (`SynR_evaluator.py`) is the file that is used to run the example. It takes in the structural step and example machine, and passes them through the analyzer and post analyzer files. It also indicates whether the maximum rotor stress does or doesn't exceed the yield stress of the rotor.

For the machine in the example file, the cross-section and results can be seen below:
 
![image](https://user-images.githubusercontent.com/112111913/232662853-aece4768-b8ee-44a2-ae4f-b33003deab55.png)

- Maximum Rotor Stress = 46.52 MPa

The documentation files are also contained in this PR.