### PR TITLE
Update stator winding resistance analyzer and documentation

### DIFF
--- a/docs/source/EM_analyzers/Images/coil_diagram.svg
+++ b/docs/source/EM_analyzers/Images/coil_diagram.svg
@@ -1,0 +1,922 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="149.06491mm"
+   height="122.29721mm"
+   viewBox="0 0 149.06491 122.29721"
+   version="1.1"
+   id="svg8"
+   inkscape:version="1.0.1 (3bc2e813f5, 2020-09-07)"
+   sodipodi:docname="coil_diagram.svg">
+  <defs
+     id="defs2">
+    <marker
+       style="overflow:visible"
+       id="marker6125"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow2Lend"
+       inkscape:isstock="true">
+      <path
+         transform="matrix(-1.1,0,0,-1.1,-1.1,0)"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         id="path6123" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="marker6115"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow2Lend"
+       inkscape:isstock="true">
+      <path
+         transform="matrix(-1.1,0,0,-1.1,-1.1,0)"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         id="path6113" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="marker6105"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend"
+       inkscape:isstock="true">
+      <path
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path6103" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="marker6095"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend"
+       inkscape:isstock="true">
+      <path
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path6093" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="marker6085"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend"
+       inkscape:isstock="true">
+      <path
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path6083" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="marker6075"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow2Lstart"
+       inkscape:isstock="true">
+      <path
+         transform="matrix(1.1,0,0,1.1,1.1,0)"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         id="path6073" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="marker6065"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow2Lstart"
+       inkscape:isstock="true">
+      <path
+         transform="matrix(1.1,0,0,1.1,1.1,0)"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         id="path6063" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="marker6055"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow2Lstart"
+       inkscape:isstock="true">
+      <path
+         transform="matrix(1.1,0,0,1.1,1.1,0)"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         id="path6053" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="marker5525"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend"
+       inkscape:isstock="true">
+      <path
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path5523" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="marker5515"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow2Lstart"
+       inkscape:isstock="true">
+      <path
+         transform="matrix(1.1,0,0,1.1,1.1,0)"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         id="path5513" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="marker5103"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend"
+       inkscape:isstock="true"
+       inkscape:collect="always">
+      <path
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path5101" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="marker5093"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow2Lstart"
+       inkscape:isstock="true"
+       inkscape:collect="always">
+      <path
+         transform="matrix(1.1,0,0,1.1,1.1,0)"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         id="path5091" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="marker4661"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow2Lend"
+       inkscape:isstock="true">
+      <path
+         transform="matrix(-1.1,0,0,-1.1,-1.1,0)"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         id="path4659" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="marker4651"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend"
+       inkscape:isstock="true"
+       inkscape:collect="always">
+      <path
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path4649" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="marker4641"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow2Lstart"
+       inkscape:isstock="true"
+       inkscape:collect="always">
+      <path
+         transform="matrix(1.1,0,0,1.1,1.1,0)"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         id="path4639" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="marker4111"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow2Lend"
+       inkscape:isstock="true">
+      <path
+         transform="matrix(-1.1,0,0,-1.1,-1.1,0)"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         id="path4109" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="marker4101"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow2Lstart"
+       inkscape:isstock="true">
+      <path
+         transform="matrix(1.1,0,0,1.1,1.1,0)"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         id="path4099" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="marker3478"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow2Lend"
+       inkscape:isstock="true">
+      <path
+         transform="matrix(-1.1,0,0,-1.1,-1.1,0)"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         id="path3476" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="marker3468"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend"
+       inkscape:isstock="true">
+      <path
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path3466" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="marker3458"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow2Lstart"
+       inkscape:isstock="true">
+      <path
+         transform="matrix(1.1,0,0,1.1,1.1,0)"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         id="path3456" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="marker2826"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow2Lend"
+       inkscape:isstock="true">
+      <path
+         transform="matrix(-1.1,0,0,-1.1,-1.1,0)"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         id="path2824" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="marker2316"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend"
+       inkscape:isstock="true">
+      <path
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path2314" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="marker1990"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow2Lend"
+       inkscape:isstock="true"
+       inkscape:collect="always">
+      <path
+         transform="matrix(-1.1,0,0,-1.1,-1.1,0)"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         id="path1988" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="marker1980"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend"
+       inkscape:isstock="true"
+       inkscape:collect="always">
+      <path
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path1978" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="marker1970"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow2Lstart"
+       inkscape:isstock="true"
+       inkscape:collect="always">
+      <path
+         transform="matrix(1.1,0,0,1.1,1.1,0)"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         id="path1968" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="marker1607"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow2Lend"
+       inkscape:isstock="true"
+       inkscape:collect="always">
+      <path
+         transform="matrix(-1.1,0,0,-1.1,-1.1,0)"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         id="path1605" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="marker1597"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend"
+       inkscape:isstock="true"
+       inkscape:collect="always">
+      <path
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path1595" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="marker1587"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow2Lstart"
+       inkscape:isstock="true"
+       inkscape:collect="always">
+      <path
+         transform="matrix(1.1,0,0,1.1,1.1,0)"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         id="path1585" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="Arrow2Lend"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow2Lend"
+       inkscape:isstock="true"
+       inkscape:collect="always">
+      <path
+         transform="matrix(-1.1,0,0,-1.1,-1.1,0)"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         id="path984" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="Arrow1Lend"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend"
+       inkscape:isstock="true"
+       inkscape:collect="always">
+      <path
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path966" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="marker1271"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow2Lstart"
+       inkscape:isstock="true"
+       inkscape:collect="always">
+      <path
+         transform="matrix(1.1,0,0,1.1,1.1,0)"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         id="path1269" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="Arrow2Lstart"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow2Lstart"
+       inkscape:isstock="true">
+      <path
+         transform="matrix(1.1,0,0,1.1,1.1,0)"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         id="path981" />
+    </marker>
+    <pattern
+       id="EMFhbasepattern"
+       patternUnits="userSpaceOnUse"
+       width="6"
+       height="6"
+       x="0"
+       y="0" />
+    <pattern
+       id="EMFhbasepattern-6"
+       patternUnits="userSpaceOnUse"
+       width="6"
+       height="6"
+       x="0"
+       y="0" />
+    <pattern
+       id="EMFhbasepattern-7"
+       patternUnits="userSpaceOnUse"
+       width="6"
+       height="6"
+       x="0"
+       y="0" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="2.6370593"
+     inkscape:cx="210.29471"
+     inkscape:cy="360.13082"
+     inkscape:document-units="mm"
+     inkscape:current-layer="layer1"
+     inkscape:document-rotation="0"
+     showgrid="false"
+     inkscape:window-width="1920"
+     inkscape:window-height="1009"
+     inkscape:window-x="-8"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1" />
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(-36.060817,-25.568949)">
+    <rect
+       style="fill:#f2f2f2;stroke:#f2f2f2;stroke-width:0.449792;stroke-linejoin:round"
+       id="rect835"
+       width="18.142857"
+       height="61.610119"
+       x="54.42857"
+       y="55.940475" />
+    <rect
+       style="fill:#f2f2f2;stroke:#f2f2f2;stroke-width:0.449792;stroke-linejoin:round"
+       id="rect839"
+       width="18.142857"
+       height="61.610119"
+       x="90.714279"
+       y="55.940475" />
+    <rect
+       style="fill:#f2f2f2;stroke:#f2f2f2;stroke-width:0.449792;stroke-linejoin:round"
+       id="rect843"
+       width="18.142857"
+       height="61.610119"
+       x="126.99998"
+       y="55.940475" />
+    <rect
+       style="fill:#cccccc;stroke:#000000;stroke-width:0.449792;stroke-linejoin:round"
+       id="rect845"
+       width="18.142857"
+       height="61.610119"
+       x="145.14284"
+       y="55.940475" />
+    <path
+       style="fill:#f2f2f2;stroke:#000000;stroke-width:0.1;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none"
+       d="M 63.610148,51.022581 V 122.52911"
+       id="path847" />
+    <rect
+       style="fill:#cccccc;stroke:#000000;stroke-width:0.449792;stroke-linejoin:round"
+       id="rect837"
+       width="18.142857"
+       height="61.610119"
+       x="72.571426"
+       y="55.940479" />
+    <rect
+       style="fill:#cccccc;stroke:#000000;stroke-width:0.449792;stroke-linejoin:round"
+       id="rect841"
+       width="18.142857"
+       height="61.610119"
+       x="108.85713"
+       y="55.940475" />
+    <rect
+       style="fill:#cccccc;stroke:#000000;stroke-width:0.449792;stroke-linejoin:round"
+       id="rect833"
+       width="18.142857"
+       height="61.610119"
+       x="36.285713"
+       y="55.940475" />
+    <path
+       style="fill:#f2f2f2;stroke:#000000;stroke-width:0.1;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none"
+       d="M 99.958804,51.022581 V 122.52911"
+       id="path898" />
+    <path
+       style="fill:#f2f2f2;stroke:#000000;stroke-width:0.1;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none"
+       d="M 136.30746,51.022581 V 122.52911"
+       id="path900" />
+    <path
+       style="fill:#f2f2f2;stroke:#000000;stroke-width:0.65;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none"
+       d="M 68.114157,55.747283 V 117.8044"
+       id="path902" />
+    <path
+       style="fill:#f2f2f2;stroke:#000000;stroke-width:0.65;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none"
+       d="M 131.66224,55.747283 V 117.8044"
+       id="path904" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.649999;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none"
+       id="path906"
+       sodipodi:type="arc"
+       sodipodi:cx="81.548363"
+       sodipodi:cy="55.987724"
+       sodipodi:rx="13.432485"
+       sodipodi:ry="13.432485"
+       sodipodi:start="3.1495687"
+       sodipodi:end="4.7108986"
+       sodipodi:arc-type="arc"
+       d="M 68.116305,55.880587 A 13.432485,13.432485 0 0 1 81.528343,42.555255"
+       sodipodi:open="true" />
+    <path
+       style="fill:#f2f2f2;stroke:#000000;stroke-width:0.649999;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none"
+       d="M 81.528342,42.555255 H 118.40405"
+       id="path908" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.649999;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none"
+       id="path910"
+       sodipodi:type="arc"
+       sodipodi:cx="-118.23163"
+       sodipodi:cy="55.987724"
+       sodipodi:rx="13.432485"
+       sodipodi:ry="13.432485"
+       sodipodi:start="3.1495687"
+       sodipodi:end="4.7108986"
+       sodipodi:arc-type="arc"
+       d="m -131.66369,55.880587 a 13.432485,13.432485 0 0 1 13.41204,-13.325332"
+       sodipodi:open="true"
+       transform="scale(-1,1)" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.649999;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none"
+       id="path912"
+       sodipodi:type="arc"
+       sodipodi:cx="81.548363"
+       sodipodi:cy="-117.66975"
+       sodipodi:rx="13.432485"
+       sodipodi:ry="13.432485"
+       sodipodi:start="3.1495687"
+       sodipodi:end="4.7108986"
+       sodipodi:arc-type="arc"
+       d="m 68.116305,-117.77688 a 13.432485,13.432485 0 0 1 13.412038,-13.32534"
+       sodipodi:open="true"
+       transform="scale(1,-1)" />
+    <path
+       style="fill:#f2f2f2;stroke:#000000;stroke-width:0.649999;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none"
+       d="M 81.528342,131.10241 H 118.40405"
+       id="path914" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.649999;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none"
+       id="path916"
+       sodipodi:type="arc"
+       sodipodi:cx="-118.23163"
+       sodipodi:cy="-117.66975"
+       sodipodi:rx="13.432485"
+       sodipodi:ry="13.432485"
+       sodipodi:start="3.1495687"
+       sodipodi:end="4.7108986"
+       sodipodi:arc-type="arc"
+       d="m -131.66369,-117.77688 a 13.432485,13.432485 0 0 1 13.41204,-13.32534"
+       sodipodi:open="true"
+       transform="scale(-1)" />
+    <path
+       style="fill:#f2f2f2;stroke:#000000;stroke-width:0.0999999;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none"
+       d="m 81.540405,40.769231 v 3.374212"
+       id="path920" />
+    <path
+       style="fill:#f2f2f2;stroke:#000000;stroke-width:0.0999999;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none"
+       d="m 118.3849,40.769231 v 3.374212"
+       id="path922" />
+    <path
+       style="fill:#f2f2f2;stroke:#000000;stroke-width:0.0999999;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none"
+       d="M 81.540405,129.36877 V 132.743"
+       id="path924" />
+    <path
+       style="fill:#f2f2f2;stroke:#000000;stroke-width:0.0999999;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none"
+       d="M 118.3849,129.36877 V 132.743"
+       id="path926" />
+    <path
+       style="fill:#f2f2f2;stroke:#000000;stroke-width:0.0999999;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none"
+       d="M 69.806656,55.743212 H 66.432444"
+       id="path928" />
+    <path
+       style="fill:#f2f2f2;stroke:#000000;stroke-width:0.0999999;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none"
+       d="m 133.2969,55.743212 h -3.37421"
+       id="path930" />
+    <path
+       style="fill:#f2f2f2;stroke:#000000;stroke-width:0.0999999;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none"
+       d="M 69.806656,117.76443 H 66.432444"
+       id="path932" />
+    <path
+       style="fill:#f2f2f2;stroke:#000000;stroke-width:0.0999999;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none"
+       d="m 133.2969,117.76443 h -3.37421"
+       id="path934" />
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:400;font-size:11.5123px;line-height:125%;font-family:'Cambria Math';text-align:start;letter-spacing:0px;word-spacing:0px;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+       x="167.72807"
+       y="91.119995"
+       id="text947"><tspan
+         sodipodi:role="line"
+         x="167.72807"
+         y="91.119995"
+         id="tspan945"
+         style="stroke-width:0.264583"><tspan
+           dx="0"
+           dy="0"
+           style="font-style:normal;font-variant:normal;font-weight:400;font-size:11.5123px;font-family:'Cambria Math';fill:#000000;stroke-width:0.264583"
+           id="tspan939">𝑙</tspan><tspan
+           dx="0"
+           dy="2.3813541 0"
+           style="font-style:normal;font-variant:normal;font-weight:400;font-size:8.37702px;font-family:'Cambria Math';fill:#000000;stroke-width:0.264583"
+           id="tspan941">st</tspan><tspan
+           dx="1.3366255"
+           dy="-2.3813541"
+           style="font-style:normal;font-variant:normal;font-weight:400;font-size:11.5123px;font-family:Calibri;fill:#000000;stroke-width:0.264583"
+           id="tspan943"> </tspan></tspan></text>
+    <path
+       style="fill:#000000;stroke:#000000;stroke-width:0.2;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;marker-start:url(#marker1271);marker-mid:url(#Arrow1Lend);marker-end:url(#Arrow2Lend)"
+       d="M 166.57702,56.313024 V 117.21023"
+       id="path961" />
+    <path
+       style="fill:#000000;stroke:#000000;stroke-width:0.1;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none"
+       d="m 163.28569,55.940475 h 6.18938"
+       id="path1525" />
+    <path
+       style="fill:#000000;stroke:#000000;stroke-width:0.1;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none"
+       d="m 163.28569,117.58786 h 6.18938"
+       id="path1527" />
+    <path
+       style="fill:#000000;stroke:#000000;stroke-width:0.2;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;marker-start:url(#marker1587);marker-mid:url(#marker1597);marker-end:url(#marker1607)"
+       d="m 72.855254,119.8246 h 17.48153"
+       id="path1583" />
+    <path
+       style="fill:#000000;stroke:#000000;stroke-width:0.1;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none"
+       d="M 72.519884,123.73998 V 117.5506"
+       id="path1737" />
+    <path
+       style="fill:#000000;stroke:#000000;stroke-width:0.1;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none"
+       d="m 90.662734,123.77724 v -6.18938"
+       id="path1739" />
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:400;font-size:11.2889px;line-height:125%;font-family:'Cambria Math';text-align:start;letter-spacing:0px;word-spacing:0px;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+       x="71.195641"
+       y="133.86412"
+       id="text1878"
+       transform="scale(1.0548198,0.94802922)"><tspan
+         sodipodi:role="line"
+         x="71.195641"
+         y="133.86412"
+         id="tspan1876"
+         style="font-size:11.2889px;stroke-width:0.264583"><tspan
+           dx="0"
+           dy="0"
+           style="font-style:normal;font-variant:normal;font-weight:400;font-size:11.2889px;font-family:'Cambria Math';fill:#000000;stroke-width:0.264583"
+           id="tspan1870">𝑤<tspan
+   style="font-size:65%;baseline-shift:sub"
+   id="tspan1892">st</tspan></tspan><tspan
+           dx="0.42774051"
+           dy="-0.76206964"
+           style="font-style:normal;font-variant:normal;font-weight:400;font-size:11.2889px;font-family:Calibri;fill:#000000;stroke-width:0.264583"
+           id="tspan1874"> </tspan></tspan></text>
+    <path
+       style="fill:#000000;stroke:#000000;stroke-width:0.199999;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;marker-start:url(#marker1970);marker-mid:url(#marker1980);marker-end:url(#marker1990)"
+       d="M 81.907235,39.657973 H 118.00336"
+       id="path1952" />
+    <path
+       style="fill:#000000;stroke:#000000;stroke-width:0.1;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none"
+       d="m 81.540405,34.579851 v 6.18938"
+       id="path1954" />
+    <path
+       style="fill:#000000;stroke:#000000;stroke-width:0.1;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none"
+       d="m 118.3849,34.579851 v 6.18938"
+       id="path1956" />
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:400;font-size:11.5123px;line-height:125%;font-family:'Cambria Math';text-align:start;letter-spacing:0px;word-spacing:0px;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+       x="97.538399"
+       y="33.607323"
+       id="text2282"><tspan
+         sodipodi:role="line"
+         x="97.538399"
+         y="33.607323"
+         id="tspan2280"
+         style="stroke-width:0.264583"><tspan
+           dx="0"
+           dy="0"
+           style="font-style:normal;font-variant:normal;font-weight:400;font-size:11.5123px;font-family:'Cambria Math';fill:#000000;stroke-width:0.264583"
+           id="tspan2274">𝑙</tspan><tspan
+           dy="0"
+           style="font-style:normal;font-variant:normal;font-weight:400;font-size:65%;font-family:'Cambria Math';baseline-shift:sub;fill:#000000;stroke-width:0.264583"
+           id="tspan2276">1</tspan><tspan
+           dx="1.3366255"
+           dy="-2.3813541"
+           style="font-style:normal;font-variant:normal;font-weight:400;font-size:11.5123px;font-family:Calibri;fill:#000000;stroke-width:0.264583"
+           id="tspan2278"> </tspan></tspan></text>
+    <path
+       style="fill:#000000;stroke:#000000;stroke-width:0.1;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none"
+       d="m 137.85162,55.747283 h -6.18938"
+       id="path3366" />
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:400;font-size:11.5123px;line-height:125%;font-family:'Cambria Math';text-align:start;letter-spacing:0px;word-spacing:0px;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+       x="60.378712"
+       y="38.729183"
+       id="text3376"><tspan
+         sodipodi:role="line"
+         x="60.378712"
+         y="38.729183"
+         id="tspan3374"
+         style="stroke-width:0.264583"><tspan
+           dx="0"
+           dy="0"
+           style="font-style:normal;font-variant:normal;font-weight:400;font-size:11.5123px;font-family:'Cambria Math';fill:#000000;stroke-width:0.264583"
+           id="tspan3368">𝑙</tspan><tspan
+           style="font-style:normal;font-variant:normal;font-weight:400;font-size:65%;font-family:'Cambria Math';baseline-shift:sub;fill:#000000;stroke-width:0.264583"
+           id="tspan3370">2</tspan><tspan
+           dx="1.3366255"
+           dy="-2.3813541"
+           style="font-style:normal;font-variant:normal;font-weight:400;font-size:11.5123px;font-family:Calibri;fill:#000000;stroke-width:0.264583"
+           id="tspan3372"> </tspan></tspan></text>
+    <path
+       style="fill:#000000;stroke:#000000;stroke-width:0.2;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;marker-start:url(#marker3458);marker-mid:url(#marker3468);marker-end:url(#marker3478)"
+       d="m 63.985896,136.84631 h 35.65536"
+       id="path3450" />
+    <path
+       style="fill:#000000;stroke:#000000;stroke-width:0.0999999;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none"
+       d="M 99.967221,139.99716 V 117.77161"
+       id="path3454" />
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:400;font-size:11.2889px;line-height:125%;font-family:'Cambria Math';text-align:start;letter-spacing:0px;word-spacing:0px;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+       x="76.924095"
+       y="143.48325"
+       id="text3863"><tspan
+         sodipodi:role="line"
+         x="76.924095"
+         y="143.48325"
+         id="tspan3861"
+         style="font-size:11.2889px;stroke-width:0.264583"><tspan
+           dx="0 0"
+           dy="0 0.80384618"
+           style="font-style:normal;font-variant:normal;font-weight:400;font-size:11.2889px;font-family:'Cambria Math';fill:#000000;stroke-width:0.264583"
+           id="tspan3855">𝜏<tspan
+   style="font-size:65%;baseline-shift:sub"
+   id="tspan4045">𝑢</tspan></tspan></tspan></text>
+    <path
+       style="fill:#000000;stroke:#000000;stroke-width:0.0999999;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none"
+       d="M 63.640151,139.99716 V 117.77161"
+       id="path4065" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.2;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;marker-start:url(#marker4101);marker-end:url(#marker4111)"
+       id="path4097"
+       sodipodi:type="arc"
+       sodipodi:cx="81.745445"
+       sodipodi:cy="56.0243"
+       sodipodi:rx="16.456272"
+       sodipodi:ry="16.45627"
+       sodipodi:start="3.1760881"
+       sodipodi:end="4.6781514"
+       sodipodi:arc-type="arc"
+       d="M 65.298963,55.456746 A 16.456272,16.45627 0 0 1 81.182132,39.577674"
+       sodipodi:open="true" />
+    <path
+       style="fill:#000000;stroke:#000000;stroke-width:0.1;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none"
+       d="m 68.114157,55.747283 h -6.18938"
+       id="path4381" />
+    <path
+       style="fill:#000000;stroke:#000000;stroke-width:0.2;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;marker-start:url(#marker4641);marker-mid:url(#marker4651)"
+       d="m 140.06366,114.21324 3.29277,12.58662"
+       id="path4637" />
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:10.5833px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+       x="130.96774"
+       y="133.69751"
+       id="text5043"><tspan
+         sodipodi:role="line"
+         x="130.96774"
+         y="133.69751"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman, ';stroke-width:0.264583"
+         id="tspan5045">stator slots</tspan></text>
+    <path
+       style="fill:#000000;stroke:#000000;stroke-width:0.2;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;marker-start:url(#marker5093);marker-mid:url(#marker5103)"
+       d="M 154.70186,59.124827 161.2736,47.896403"
+       id="path5085" />
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:10.5833px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+       x="138.46722"
+       y="45.727112"
+       id="text5089"><tspan
+         sodipodi:role="line"
+         x="138.46722"
+         y="45.727112"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman, ';stroke-width:0.264583"
+         id="tspan5087">stator teeth</tspan></text>
+    <path
+       style="fill:#000000;stroke:#000000;stroke-width:0.2;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;marker-start:url(#marker5515);marker-mid:url(#marker5525)"
+       d="m 111.16693,134.14946 7.19059,10.84254"
+       id="path5511" />
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:10.5833px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+       x="120.30084"
+       y="147.72147"
+       id="text5799"><tspan
+         sodipodi:role="line"
+         x="120.30084"
+         y="147.72147"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman, ';stroke-width:0.264583"
+         id="tspan5797">coil</tspan></text>
+  </g>
+</svg>

--- a/docs/source/EM_analyzers/Images/stator_wdg_cross_sect.svg
+++ b/docs/source/EM_analyzers/Images/stator_wdg_cross_sect.svg
@@ -1,0 +1,1803 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   inkscape:export-ydpi="150"
+   inkscape:export-xdpi="150"
+   inkscape:export-filename="C:\Users\nheme\Documents\Research\Bearingless Motor\Bearinless_Parametrization_Rev1_wht_bckgrnd.png"
+   inkscape:version="1.2.2 (732a01da63, 2022-12-09)"
+   sodipodi:docname="stator_wdg_cross_sect.svg"
+   id="svg837"
+   version="1.1"
+   viewBox="0 0 129.41939 108.30766"
+   height="108.30766mm"
+   width="129.41939mm"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <defs
+     id="defs831">
+    <marker
+       inkscape:stockid="Arrow1Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker3363"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path3361"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mstart"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker2957"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path2955"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(0.4,0,0,0.4,4,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker2473"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path2471"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker2091"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mstart">
+      <path
+         transform="matrix(0.4,0,0,0.4,4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path2089" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:stockid="Arrow1Mstart"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker1611"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path1609"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(0.4,0,0,0.4,4,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mstart"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker4727"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path4725"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(0.4,0,0,0.4,4,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mstart"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker4345"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path4343"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(0.4,0,0,0.4,4,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mstart"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker3969"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path3967"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(0.4,0,0,0.4,4,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mstart"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker3599"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path3597"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(0.4,0,0,0.4,4,0)" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker2905"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow2Send">
+      <path
+         transform="matrix(-0.3,0,0,-0.3,0.69,0)"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         id="path2903" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker3124"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow2Send">
+      <path
+         transform="matrix(-0.3,0,0,-0.3,0.69,0)"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         id="path3122" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker1741"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path1739"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#ff0000;fill-opacity:1;fill-rule:evenodd;stroke:#ff0000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow2Send"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker4852"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path4850"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         transform="matrix(-0.3,0,0,-0.3,0.69,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow2Send"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker3691"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path3689"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         transform="matrix(-0.3,0,0,-0.3,0.69,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Sstart"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker3429"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path3427"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(0.2,0,0,0.2,1.2,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow2Send"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker2019"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path2017"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         transform="matrix(-0.3,0,0,-0.3,0.69,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow2Sstart"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker1781"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path1779"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         transform="matrix(0.3,0,0,0.3,-0.69,0)" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker1488"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mend">
+      <path
+         transform="matrix(-0.4,0,0,-0.4,-4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path1486" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker1244"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mend">
+      <path
+         inkscape:connector-curvature="0"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path1242" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow2Send"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker16235"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path16233"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         transform="matrix(-0.3,0,0,-0.3,0.69,0)" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:stockid="Arrow2Send"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker15733"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path15731"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         transform="matrix(-0.3,0,0,-0.3,0.69,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker15525"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path15523"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker10501"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mend">
+      <path
+         transform="matrix(-0.4,0,0,-0.4,-4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path10499" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:stockid="Arrow1Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker10219"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path10217"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker9500"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mend">
+      <path
+         transform="matrix(-0.4,0,0,-0.4,-4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path9498" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker9322"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mstart">
+      <path
+         transform="matrix(0.4,0,0,0.4,4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path9320" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker8927"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mend">
+      <path
+         transform="matrix(-0.4,0,0,-0.4,-4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path8925" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:stockid="Arrow1Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker8563"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path8561"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker8403"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mstart">
+      <path
+         transform="matrix(0.4,0,0,0.4,4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path8401" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker8209"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mend">
+      <path
+         transform="matrix(-0.4,0,0,-0.4,-4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path8207" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker8061"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mstart">
+      <path
+         transform="matrix(0.4,0,0,0.4,4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path8059" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker7820"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path7818"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mstart"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker7684"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path7682"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(0.4,0,0,0.4,4,0)" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:stockid="Arrow1Mstart"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker6757"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path6755"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(0.4,0,0,0.4,4,0)" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:stockid="Arrow1Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker6627"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path6625"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker6012"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mstart">
+      <path
+         transform="matrix(0.4,0,0,0.4,4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path6010" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker5894"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mend">
+      <path
+         transform="matrix(-0.4,0,0,-0.4,-4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path5892" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:stockid="Arrow1Mstart"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker5567"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path5565"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(0.4,0,0,0.4,4,0)" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:stockid="Arrow1Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker5461"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path5459"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:stockid="Arrow1Mstart"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker5080"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path5078"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(0.4,0,0,0.4,4,0)" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker4986"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mend">
+      <path
+         transform="matrix(-0.4,0,0,-0.4,-4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path4984" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker4450"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow2Send">
+      <path
+         transform="matrix(-0.3,0,0,-0.3,0.69,0)"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         id="path4448" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker4374"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path4372"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:stockid="Arrow1Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker4128"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path4126"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker3864"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mend">
+      <path
+         transform="matrix(-0.4,0,0,-0.4,-4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path3862" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="Arrow1Mstart"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mstart">
+      <path
+         transform="matrix(0.4,0,0,0.4,4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path1491" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="Arrow1Sstart"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Sstart">
+      <path
+         transform="matrix(0.2,0,0,0.2,1.2,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path1497" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker1939"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow2Send">
+      <path
+         transform="matrix(-0.3,0,0,-0.3,0.69,0)"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         id="path1937" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="Arrow2Sstart"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow2Sstart">
+      <path
+         transform="matrix(0.3,0,0,0.3,-0.69,0)"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         id="path1515" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="Arrow2Send"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow2Send">
+      <path
+         transform="matrix(-0.3,0,0,-0.3,0.69,0)"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         id="path1518" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="Arrow2Mstart"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow2Mstart">
+      <path
+         transform="scale(0.6)"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         id="path1509" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="Arrow1Mend"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mend">
+      <path
+         transform="matrix(-0.4,0,0,-0.4,-4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path1494" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:stockid="Arrow1Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker4128-8"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path4126-2"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow2Send"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker4852-2"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path4850-0"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         transform="matrix(-0.3,0,0,-0.3,0.69,0)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow2Send"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker4852-2-2"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path4850-0-3"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         transform="matrix(-0.3,0,0,-0.3,0.69,0)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker1387"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mend">
+      <path
+         transform="matrix(-0.4,0,0,-0.4,-4,0)"
+         style="fill:#ff0000;fill-opacity:1;fill-rule:evenodd;stroke:#ff0000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path1385" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker1741-6"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path1739-4"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#ff0000;fill-opacity:1;fill-rule:evenodd;stroke:#ff0000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker3967"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mend">
+      <path
+         transform="matrix(-0.4,0,0,-0.4,-4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path3965" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker8403-9"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mstart">
+      <path
+         transform="matrix(0.4,0,0,0.4,4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path8401-0" />
+    </marker>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath15392">
+      <g
+         inkscape:label="Clip"
+         id="use15394">
+        <rect
+           style="fill:#4d4d4d;stroke-width:0.30014;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none"
+           id="rect18145"
+           width="170.34219"
+           height="92.773621"
+           x="5.2448597"
+           y="151.94365" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath18505">
+      <rect
+         style="fill:#4d4d4d;stroke-width:0.264999;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none"
+         id="rect18507"
+         width="150.90056"
+         height="108.30766"
+         x="3.65082"
+         y="43.809841" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath18509">
+      <rect
+         style="fill:#4d4d4d;stroke-width:0.264999;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none"
+         id="rect18511"
+         width="150.90056"
+         height="108.30766"
+         x="-301.82599"
+         y="-86.905685"
+         transform="rotate(-90)" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath18513">
+      <rect
+         style="fill:#4d4d4d;stroke-width:0.264999;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none"
+         id="rect18515"
+         width="150.90056"
+         height="108.30766"
+         x="3.65082"
+         y="43.809841" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath18517">
+      <rect
+         style="fill:#4d4d4d;stroke-width:0.264999;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none"
+         id="rect18519"
+         width="150.90056"
+         height="108.30766"
+         x="3.65082"
+         y="43.809841" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath18521">
+      <rect
+         style="fill:#4d4d4d;stroke-width:0.264999;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none"
+         id="rect18523"
+         width="150.90056"
+         height="108.30766"
+         x="3.65082"
+         y="43.809841" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath18525">
+      <rect
+         style="fill:#4d4d4d;stroke-width:0.264999;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none"
+         id="rect18527"
+         width="150.90056"
+         height="108.30766"
+         x="3.65082"
+         y="43.809841" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath18529">
+      <rect
+         style="fill:#4d4d4d;stroke-width:0.264999;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none"
+         id="rect18531"
+         width="150.90056"
+         height="108.30766"
+         x="3.65082"
+         y="43.809841" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath18533">
+      <rect
+         style="fill:#4d4d4d;stroke-width:0.264999;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none"
+         id="rect18535"
+         width="150.90056"
+         height="108.30766"
+         x="3.65082"
+         y="43.809841" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath18537">
+      <rect
+         style="fill:#4d4d4d;stroke-width:0.264999;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none"
+         id="rect18539"
+         width="150.90056"
+         height="108.30766"
+         x="3.65082"
+         y="43.809841" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath18541">
+      <rect
+         style="fill:#4d4d4d;stroke-width:0.264999;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none"
+         id="rect18543"
+         width="150.90056"
+         height="108.30766"
+         x="3.65082"
+         y="43.809841" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath18545">
+      <rect
+         style="fill:#4d4d4d;stroke-width:0.264999;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none"
+         id="rect18547"
+         width="150.90056"
+         height="108.30766"
+         x="3.65082"
+         y="43.809841" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath18549">
+      <rect
+         style="fill:#4d4d4d;stroke-width:0.264999;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none"
+         id="rect18551"
+         width="150.90056"
+         height="108.30766"
+         x="3.65082"
+         y="43.809841" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath18553">
+      <rect
+         style="fill:#4d4d4d;stroke-width:0.264999;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none"
+         id="rect18555"
+         width="150.90056"
+         height="108.30766"
+         x="3.65082"
+         y="43.809841" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath18557">
+      <rect
+         style="fill:#4d4d4d;stroke-width:0.264999;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none"
+         id="rect18559"
+         width="150.90056"
+         height="108.30766"
+         x="3.65082"
+         y="43.809841"
+         transform="rotate(-90)" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath18561">
+      <rect
+         style="fill:#4d4d4d;stroke-width:0.264999;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none"
+         id="rect18563"
+         width="150.90056"
+         height="108.30766"
+         x="3.65082"
+         y="43.809841" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath18565">
+      <rect
+         style="fill:#4d4d4d;stroke-width:0.264999;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none"
+         id="rect18567"
+         width="150.90056"
+         height="108.30766"
+         x="3.65082"
+         y="43.809841" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath18569">
+      <rect
+         style="fill:#4d4d4d;stroke-width:0.264999;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none"
+         id="rect18571"
+         width="150.90056"
+         height="108.30766"
+         x="3.65082"
+         y="43.809841"
+         transform="rotate(-90)" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath18573">
+      <rect
+         style="fill:#4d4d4d;stroke-width:0.264999;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none"
+         id="rect18575"
+         width="150.90056"
+         height="108.30766"
+         x="3.65082"
+         y="43.809841" />
+    </clipPath>
+  </defs>
+  <sodipodi:namedview
+     height="281mm"
+     inkscape:document-rotation="0"
+     inkscape:snap-to-guides="true"
+     inkscape:snap-global="true"
+     inkscape:snap-bbox="false"
+     inkscape:object-paths="true"
+     inkscape:snap-intersection-paths="true"
+     inkscape:snap-object-midpoints="true"
+     inkscape:snap-others="true"
+     inkscape:snap-smooth-nodes="true"
+     inkscape:snap-midpoints="true"
+     inkscape:snap-center="true"
+     inkscape:window-maximized="1"
+     inkscape:window-y="62"
+     inkscape:window-x="-9"
+     inkscape:window-height="991"
+     inkscape:window-width="1920"
+     inkscape:guide-bbox="true"
+     showguides="false"
+     showborder="true"
+     showgrid="false"
+     inkscape:current-layer="layer4"
+     inkscape:document-units="mm"
+     inkscape:cy="302.5167"
+     inkscape:cx="312.31248"
+     inkscape:zoom="0.86772068"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     borderopacity="1.0"
+     bordercolor="#666666"
+     pagecolor="#ffffff"
+     id="base"
+     inkscape:showpageshadow="2"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1" />
+  <metadata
+     id="metadata834">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     style="display:none"
+     inkscape:label="Background"
+     id="layer5"
+     inkscape:groupmode="layer"
+     transform="translate(-5.2448594,-43.809841)" />
+  <g
+     style="display:none"
+     id="layer1"
+     inkscape:groupmode="layer"
+     inkscape:label="Total_Motor"
+     transform="translate(-5.2448594,-43.809841)">
+    <path
+       inkscape:connector-curvature="0"
+       id="path1388"
+       transform="scale(0.26458333)"
+       d="M 0,650.07812 A 472.4409,472.4409 0 0 0 -472.44141,1122.5195 472.4409,472.4409 0 0 0 0,1594.9609 472.4409,472.4409 0 0 0 472.44141,1122.5195 472.4409,472.4409 0 0 0 0,650.07812 Z m -62.580078,131.7168 c 2.119773,-0.0633 4.238058,0.0941 6.103516,0.6543 2.541358,0.7632 4.943413,2.47682 6.457031,4.65625 1.450551,2.08861 2.260179,4.14371 2.77539,6.56445 v 96.20703 l -32.126953,32.12696 v 25.01171 A 192.85715,192.85715 0 0 1 0,929.66211 192.85715,192.85715 0 0 1 79.371094,946.94922 V 922.00391 L 47.244141,889.87695 v -96.1914 c 0.515003,-2.42755 1.32369,-4.487 2.777343,-6.58008 1.513618,-2.17943 3.915677,-3.89305 6.457032,-4.65625 1.645518,-0.49416 3.491159,-0.65631 5.357422,-0.64844 A 347.10338,347.10338 0 0 1 262.25586,895.70703 c 1.75673,2.4167 3.37685,5.15152 4.01758,7.86524 0.60972,2.58247 0.32595,5.51939 -0.80469,7.91992 -1.08536,2.30442 -2.46502,4.03425 -4.30859,5.69336 l -83.3086,48.09765 -43.88476,-11.75781 -21.66211,12.50586 a 192.85715,192.85715 0 0 1 54.71484,60.06055 192.85715,192.85715 0 0 1 24.71485,77.3809 L 213.33789,1091 l 11.75781,-43.8867 83.31055,-48.09963 c 2.35704,-0.76605 4.54514,-1.093 7.08203,-0.88086 2.64428,0.2211 5.33009,1.4444 7.26172,3.26369 1.49012,1.4034 2.72559,3.2743 3.76172,5.248 a 347.10338,347.10338 0 0 1 20.5918,115.875 347.10338,347.10338 0 0 1 -20.0625,114.8164 c -1.13505,2.3551 -2.53462,4.6543 -4.28907,6.3067 -1.93162,1.8193 -4.61553,3.0425 -7.25976,3.2636 -2.5387,0.2123 -4.72893,-0.1155 -7.08789,-0.8828 l -83.3086,-48.0976 -11.75781,-43.8848 -21.66211,-12.5058 a 192.85715,192.85715 0 0 1 -24.65625,77.414 192.85715,192.85715 0 0 1 -54.65625,60.0938 l 21.60352,12.4726 43.88476,-11.7597 83.30664,48.0976 c 1.84358,1.6591 3.22324,3.3889 4.3086,5.6934 1.13066,2.4005 1.41246,5.3374 0.80273,7.9199 -0.38563,1.6333 -1.14266,3.2715 -2.05273,4.8496 A 347.10338,347.10338 0 0 1 63.15625,1463.209 c -2.309571,0.1107 -4.639833,-0.01 -6.673828,-0.6192 -2.541351,-0.7632 -4.94539,-2.4748 -6.458984,-4.6543 -1.45523,-2.0953 -2.264404,-4.1588 -2.779297,-6.5898 v -96.1836 l 32.126953,-32.1269 v -25.0118 A 192.85715,192.85715 0 0 1 0,1315.377 192.85715,192.85715 0 0 1 -79.371094,1298.0898 v 24.9454 l 32.126953,32.1269 v 96.1914 c -0.514998,2.4276 -1.323687,4.489 -2.777343,6.582 -1.513614,2.1795 -3.915681,3.8911 -6.457032,4.6543 -1.645521,0.4942 -3.491159,0.6564 -5.357422,0.6485 A 347.10338,347.10338 0 0 1 -262.22656,1349.3672 c -1.76655,-2.4252 -3.39721,-5.1736 -4.04102,-7.9004 -0.60972,-2.5825 -0.32791,-5.5194 0.80274,-7.9199 1.08656,-2.307 2.46775,-4.0385 4.31445,-5.6992 l 83.29883,-48.0918 43.88476,11.7597 21.66211,-12.5058 a 192.85715,192.85715 0 0 1 -54.71484,-60.0606 192.85715,192.85715 0 0 1 -24.71485,-77.3808 l -21.60351,12.4726 -11.75781,43.8848 -83.31055,48.0996 c -2.35704,0.766 -4.54513,1.093 -7.08203,0.8808 -2.64427,-0.2211 -5.33009,-1.4443 -7.26172,-3.2636 -1.49012,-1.4035 -2.72559,-3.2744 -3.76172,-5.2481 a 347.10338,347.10338 0 0 1 -20.5918,-115.875 347.10338,347.10338 0 0 1 20.04688,-114.7754 c 1.13845,-2.3696 2.54575,-4.6855 4.31055,-6.3476 1.93163,-1.81929 4.61551,-3.04259 7.25976,-3.26369 2.53416,-0.21191 4.7201,0.11466 7.07422,0.87891 l 83.31641,48.10158 11.75781,43.8867 21.66211,12.5059 a 192.85715,192.85715 0 0 1 24.65625,-77.4141 192.85715,192.85715 0 0 1 54.65625,-60.09571 l -21.60352,-12.4707 -43.88476,11.75781 -83.30664,-48.09765 c -1.84358,-1.65911 -3.22324,-3.38894 -4.3086,-5.69336 -1.13063,-2.40057 -1.41246,-5.33745 -0.80273,-7.91992 0.3858,-1.63403 1.14211,-3.27284 2.05273,-4.85157 A 347.10338,347.10338 0 0 1 -63.158203,781.83008 c 0.193318,-0.009 0.38466,-0.0294 0.578125,-0.0352 z"
+       style="opacity:1;fill:#008000;fill-opacity:1;stroke:#000000;stroke-width:3.77953;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+    <circle
+       r="43.733097"
+       cy="297"
+       cx="0"
+       id="path1390"
+       style="opacity:1;fill:#ff0000;fill-opacity:1;stroke:#000000;stroke-width:1.09333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+  </g>
+  <g
+     style="display:none"
+     inkscape:label="Motor_Cutaway"
+     id="layer2"
+     inkscape:groupmode="layer"
+     transform="translate(-5.2448594,-43.809841)" />
+  <g
+     style="display:none"
+     inkscape:label="Annotations_1"
+     id="layer3"
+     inkscape:groupmode="layer"
+     transform="translate(-5.2448594,-43.809841)">
+    <path
+       inkscape:connector-curvature="0"
+       id="path5884"
+       d="M -7.5563861,234.90369 V 206.70526"
+       style="fill:none;stroke:#000000;stroke-width:0.259632px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-start:url(#marker6012);marker-end:url(#marker5894)" />
+    <rect
+       y="218.84871"
+       x="-8.3674479"
+       height="2.2158854"
+       width="1.5875"
+       id="rect6524"
+       style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.264583;stroke-miterlimit:4;stroke-dasharray:0.79375, 0.264583;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal" />
+    <path
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       id="path1464"
+       d="M -0.02743323,297.01265 35.30925,221.27907"
+       style="fill:none;stroke:#000000;stroke-width:0.202531;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:0.810125, 0.202531;stroke-dashoffset:0;stroke-opacity:1" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.202531;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:0.810125, 0.202531;stroke-dashoffset:0;stroke-opacity:1"
+       d="M 0,297 -35.336683,221.26642"
+       id="path1466"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cc" />
+    <path
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       id="path1470"
+       d="M -21.000268,250.56454 V 221.26642"
+       style="fill:none;stroke:#000000;stroke-width:0.264583;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:0.79375, 0.264583;stroke-dashoffset:0;stroke-opacity:1" />
+    <path
+       sodipodi:nodetypes="csc"
+       inkscape:connector-curvature="0"
+       id="path1482"
+       d="m -11.797594,270.57892 c 3.5813579,-1.66871 7.5752744,-2.60053 11.78682858,-2.60053 4.23356982,0 8.24722062,0.94159 11.84295942,2.62676"
+       style="opacity:1;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.264583;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-start:url(#Arrow2Sstart);marker-end:url(#Arrow2Send);paint-order:normal" />
+    <g
+       transform="translate(-23.187493,-34.196779)"
+       id="g1919">
+      <rect
+         style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.264583;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal"
+         id="rect1907"
+         width="6.160902"
+         height="5.5858846"
+         x="20.12562"
+         y="299.38223" />
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+         x="20.947077"
+         y="304.3931"
+         id="text1895"><tspan
+           sodipodi:role="line"
+           id="tspan1893"
+           x="20.947077"
+           y="304.3931"
+           style="stroke-width:0.264583">θ<tspan
+   style="font-size:3.52778px"
+   id="tspan1897">t</tspan></tspan></text>
+    </g>
+    <flowRoot
+       transform="scale(0.26458333)"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:24px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none"
+       id="flowRoot1899"
+       xml:space="preserve"><flowRegion
+         id="flowRegion1901"><rect
+           y="1122.5197"
+           x="61.473213"
+           height="49.675323"
+           width="50.91721"
+           id="rect1903" /></flowRegion><flowPara
+         id="flowPara1905" /></flowRoot>
+    <path
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       id="path1934"
+       d="m -29.626283,232.40708 c 2.447086,-1.23671 5.213559,-1.9334 8.142751,-1.9334"
+       style="display:inline;opacity:1;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.236671;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-start:url(#Arrow1Sstart);marker-end:url(#marker1939);paint-order:normal" />
+    <rect
+       y="229.11623"
+       x="-27.407322"
+       height="3.6542518"
+       width="3.6240244"
+       id="rect1927"
+       style="display:inline;opacity:1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.13113;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal" />
+    <text
+       id="text1923"
+       y="232.42699"
+       x="-27.561081"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+       xml:space="preserve"><tspan
+         style="stroke-width:0.264583"
+         y="232.42699"
+         x="-27.561081"
+         id="tspan1921"
+         sodipodi:role="line">α</tspan></text>
+    <path
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       id="path3542"
+       d="m 25.501249,208.12668 8.748058,-30.47166"
+       style="fill:none;stroke:#000000;stroke-width:0.251839px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-start:url(#Arrow1Mstart);marker-end:url(#marker3864)" />
+    <text
+       id="text4090"
+       y="162.72395"
+       x="57.811459"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+       xml:space="preserve"><tspan
+         style="stroke-width:0.264583"
+         y="162.72395"
+         x="57.811459"
+         id="tspan4088"
+         sodipodi:role="line" /></text>
+    <path
+       inkscape:connector-curvature="0"
+       id="path3528"
+       d="M -12.500012,236.16224 V 246.8512"
+       style="display:inline;fill:none;stroke:#000000;stroke-width:0.24847px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-start:url(#marker5567);marker-end:url(#marker5461)" />
+    <text
+       id="text4094"
+       y="173.58723"
+       x="-52.318027"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+       xml:space="preserve"><tspan
+         style="stroke-width:0.264583"
+         y="173.58723"
+         x="-52.318027"
+         id="tspan4092"
+         sodipodi:role="line">D<tspan
+   id="tspan4096"
+   style="font-size:3.52778px">os</tspan></tspan></text>
+    <g
+       transform="translate(-16.559098,-7.3212701)"
+       id="g4116">
+      <rect
+         style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:0.237103;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal"
+         id="rect4104"
+         width="6.6424799"
+         height="5.9479485"
+         x="43.113136"
+         y="197.23814" />
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+         x="43.78854"
+         y="202.14687"
+         id="text4100"><tspan
+           sodipodi:role="line"
+           id="tspan4098"
+           x="43.78854"
+           y="202.14687"
+           style="stroke-width:0.264583">T<tspan
+   style="font-size:3.52778px"
+   id="tspan4102">s</tspan></tspan></text>
+    </g>
+    <path
+       sodipodi:nodetypes="ccc"
+       inkscape:connector-curvature="0"
+       id="path4118"
+       d="m -44.334244,171.98437 h 2.000911 l 4.828646,4.82865"
+       style="fill:none;stroke:#000000;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#marker4128)" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path4364"
+       d="m 15.718783,210.03594 -1.547002,-1.79208"
+       style="fill:none;stroke:#000000;stroke-width:0.191617;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:0.383234, 0.191617;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker4450)" />
+    <text
+       id="text4634"
+       y="212.41602"
+       x="15.941146"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+       xml:space="preserve"><tspan
+         style="stroke-width:0.264583"
+         y="212.41602"
+         x="15.941146"
+         id="tspan4632"
+         sodipodi:role="line">r</tspan></text>
+    <path
+       inkscape:connector-curvature="0"
+       id="path4976"
+       d="M -11.547554,219.80781 H 11.547554"
+       style="fill:none;stroke:#000000;stroke-width:0.254303px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-start:url(#marker5080);marker-end:url(#marker4986)" />
+    <g
+       transform="translate(-43.306146,19.473489)"
+       id="g4116-9">
+      <g
+         transform="translate(0,0.18708867)"
+         id="g5421">
+        <rect
+           y="197.24779"
+           x="42.65506"
+           height="5.928659"
+           width="7.7924948"
+           id="rect4104-4"
+           style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:0.256393;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal" />
+        <text
+           id="text4100-8"
+           y="202.70813"
+           x="42.993412"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+           xml:space="preserve"><tspan
+             style="stroke-width:0.264583"
+             y="202.70813"
+             x="42.993412"
+             id="tspan4098-5"
+             sodipodi:role="line">W<tspan
+   style="font-size:3.52778px"
+   id="tspan5415">t</tspan></tspan></text>
+      </g>
+    </g>
+    <path
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       id="path5449"
+       d="m -12.500012,247.56684 h 9.8872516"
+       style="fill:none;stroke:#000000;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+    <path
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       id="path5451"
+       d="m -12.500012,235.4466 h 9.8872516"
+       style="fill:none;stroke:#000000;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+    <path
+       sodipodi:arc-type="arc"
+       style="display:inline;opacity:1;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.265;stroke-miterlimit:4;stroke-dasharray:0.795, 0.265;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal"
+       id="path5875"
+       sodipodi:type="arc"
+       sodipodi:cx="0"
+       sodipodi:cy="296.99997"
+       sodipodi:rx="91.67807"
+       sodipodi:ry="91.67807"
+       sodipodi:start="4.4466291"
+       sodipodi:end="4.5768786"
+       sodipodi:open="true"
+       d="m -24.078562,208.54042 a 91.67807,91.67807 0 0 1 11.693219,-2.37806" />
+    <path
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       id="path5878"
+       d="m -12.500012,213.23104 v -7.0392"
+       style="fill:none;stroke:#000000;stroke-width:0.264583;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:0.79375, 0.264583;stroke-dashoffset:0;stroke-opacity:1" />
+    <path
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       id="path5882"
+       d="m -12.385343,206.16235 h 9.7725826"
+       style="fill:none;stroke:#000000;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+    <g
+       transform="translate(-53.364328,27.478398)"
+       id="g4116-9-8"
+       style="display:inline">
+      <g
+         transform="translate(0,0.18708867)"
+         id="g5421-1">
+        <rect
+           y="197.24779"
+           x="42.65506"
+           height="5.928659"
+           width="7.7924948"
+           id="rect4104-4-4"
+           style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:0.256393;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal" />
+        <text
+           id="text4100-8-5"
+           y="202.17897"
+           x="43.456432"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+           xml:space="preserve"><tspan
+             style="stroke-width:0.264583"
+             y="202.17897"
+             x="43.456432"
+             id="tspan4098-5-6"
+             sodipodi:role="line"><tspan
+               style="font-size:3.52778px"
+               id="tspan5415-7"><tspan
+   id="tspan6615"
+   style="font-size:6.35px">L</tspan>t</tspan></tspan></text>
+      </g>
+    </g>
+    <g
+       transform="translate(-53.364328,40.708055)"
+       id="g4116-9-8-7"
+       style="display:inline">
+      <g
+         transform="translate(0,0.18708867)"
+         id="g5421-1-5">
+        <rect
+           y="197.24779"
+           x="42.65506"
+           height="5.928659"
+           width="7.7924948"
+           id="rect4104-4-4-1"
+           style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:0.256393;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal" />
+        <text
+           id="text4100-8-5-7"
+           y="202.17897"
+           x="43.456432"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+           xml:space="preserve"><tspan
+             style="stroke-width:0.264583"
+             y="202.17897"
+             x="43.456432"
+             id="tspan4098-5-6-6"
+             sodipodi:role="line"><tspan
+               style="font-size:3.52778px"
+               id="tspan5415-7-7"><tspan
+   id="tspan6580-5"
+   style="font-size:6.35px">L</tspan>tt</tspan></tspan></text>
+      </g>
+    </g>
+    <path
+       sodipodi:nodetypes="ccc"
+       inkscape:connector-curvature="0"
+       id="path4118-8"
+       d="m -28.486583,277.7367 h -2.000911 l -4.828646,-4.82865"
+       style="display:inline;fill:none;stroke:#000000;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#marker4128-8)" />
+    <text
+       id="text4094-6"
+       y="279.95316"
+       x="-28.468546"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+       xml:space="preserve"><tspan
+         style="stroke-width:0.264583"
+         y="279.95316"
+         x="-28.468546"
+         id="tspan4092-2"
+         sodipodi:role="line">D<tspan
+   id="tspan4096-9"
+   style="font-size:3.52778px;stroke-width:0.264583">or</tspan></tspan></text>
+    <path
+       inkscape:transform-center-y="-47.336963"
+       inkscape:transform-center-x="-0.53635573"
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       id="path6617"
+       d="m 0.49341607,252.4546 0.0643483,-5.62927"
+       style="display:inline;fill:none;stroke:#000000;stroke-width:0.204665px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-start:url(#marker6757);marker-end:url(#marker6627)" />
+    <text
+       id="text4100-8-5-7-6"
+       y="251.6891"
+       x="1.700698"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+       xml:space="preserve"><tspan
+         style="stroke-width:0.264583"
+         y="251.6891"
+         x="1.700698"
+         id="tspan4098-5-6-6-5"
+         sodipodi:role="line"><tspan
+           style="font-size:3.52778px"
+           id="tspan5415-7-7-3"><tspan
+   id="tspan6580-5-5"
+   style="font-size:6.35px">L</tspan>g</tspan></tspan></text>
+    <path
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       id="path15507"
+       d="m 21.000268,250.54698 h 8.688366"
+       style="fill:none;stroke:#000000;stroke-width:0.23934px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+    <path
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       id="path15509"
+       d="m 21.000268,243.94686 h 8.688366"
+       style="fill:none;stroke:#000000;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+    <text
+       id="text15513"
+       y="248.73111"
+       x="25.765221"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+       xml:space="preserve"><tspan
+         style="stroke-width:0.264583"
+         y="248.73111"
+         x="25.765221"
+         id="tspan15511"
+         sodipodi:role="line">s</tspan></text>
+    <path
+       inkscape:connector-curvature="0"
+       id="path15515"
+       d="m 27.057699,249.05852 v 0.97042"
+       style="fill:none;stroke:#000000;stroke-width:0.276484px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#marker15733)" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path15945"
+       d="m 27.060298,245.50384 v -1.05237"
+       style="fill:none;stroke:#000000;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#marker16235)" />
+  </g>
+  <g
+     style="display:inline"
+     inkscape:label="Annotations_2"
+     id="layer4"
+     inkscape:groupmode="layer"
+     transform="translate(-5.2448594,-43.809841)">
+    <g
+       transform="translate(-20.688286,17.424232)"
+       id="g4116-9-8-2-5"
+       style="display:inline">
+      <g
+         transform="translate(0,0.18708867)"
+         id="g5421-1-7-0">
+        <text
+           id="text4100-8-5-1-8"
+           y="202.24512"
+           x="42.629608"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+           xml:space="preserve"><tspan
+             style="stroke-width:0.264583"
+             y="0"
+             x="0"
+             id="tspan4098-5-6-1-3"
+             sodipodi:role="line"><tspan
+               style="font-size:3.52778px"
+               id="tspan5415-7-3-8"><tspan
+                 id="tspan6615-5-9"
+                 style="font-size:6.35px" /></tspan></tspan></text>
+      </g>
+    </g>
+    <path
+       style="display:inline;fill:none;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="M 71.607849,238.11623 C 110.27454,215.81889 134.11779,174.59555 134.16424,129.96056 134.10004,85.334389 110.24969,44.127279 71.586145,21.842099 m -36.90886,63.92788 c 6.266709,3.63682 11.687032,8.56654 15.900323,14.461131 l 3.299539,-5.715931 -3.11092,-11.61118 12.725837,-22.04155 c 0.438973,-0.48778 0.896657,-0.85281 1.506368,-1.13998 0.635151,-0.29915 1.412201,-0.37371 2.095479,-0.21239 0.432337,0.10208 0.865939,0.30218 1.283645,0.54312 16.119659,13.64823 27.042213,32.43565 30.92731,53.196751 0.0024,0.0512 0.0078,0.10178 0.0093,0.15296 0.01675,0.56086 -0.0249,1.12132 -0.173117,1.61489 -0.20193,0.6724 -0.655325,1.30795 -1.231966,1.70843 -0.552611,0.38379 -1.096356,0.598 -1.736844,0.73432 H 70.717475 l -8.500259,-8.50026 h -6.617682 c 3.00432,6.59464 4.569531,13.75356 4.591439,21.00027 -0.0164,7.24543 -1.575599,14.4043 -4.573881,21.00027 h 6.600114 l 8.500259,-8.50026 h 25.450641 c 0.642289,0.13626 1.187186,0.35023 1.74098,0.73484 0.576641,0.40048 1.030036,1.03602 1.231966,1.70842 0.130746,0.43538 0.173649,0.92371 0.171566,1.41749 -3.711442,20.59314 -14.344053,39.3014 -30.137696,53.02777 -0.639418,0.4648 -1.363006,0.89346 -2.081011,1.06298 -0.683278,0.16133 -1.460339,0.0862 -2.095479,-0.2129 -0.609711,-0.28717 -1.067395,-0.65221 -1.506369,-1.13999 l -12.725836,-22.04206 3.11092,-11.61118 -3.308842,-5.73143 c -4.208931,5.89921 -9.626137,10.83425 -15.89102,14.47663"
+       id="path3512"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccccccsccccccccccccccccccccccccc"
+       clip-path="url(#clipPath18573)" />
+    <path
+       sodipodi:arc-type="arc"
+       style="display:inline;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.265;stroke-miterlimit:4;stroke-dasharray:0.795, 0.265;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal"
+       id="path5445"
+       sodipodi:type="arc"
+       sodipodi:cx="129.9606"
+       sodipodi:cy="-9.1640749"
+       sodipodi:rx="91.67807"
+       sodipodi:ry="91.67807"
+       sodipodi:start="4.5605958"
+       sodipodi:end="4.8587494"
+       sodipodi:open="true"
+       d="m 116.09788,-99.787986 a 91.67807,91.67807 0 0 1 27.23291,-0.07398"
+       transform="rotate(90)"
+       clip-path="url(#clipPath18569)" />
+    <path
+       sodipodi:nodetypes="cccsc"
+       inkscape:connector-curvature="0"
+       id="path7566"
+       d="m 49.082383,62.166709 c 7.297775,5.33633 17.361426,17.07955 22.700468,24.36714 m 4.860633,10.79479 c 1.534133,2.788071 3.747178,9.561551 4.54909,12.920461 1.238106,5.18597 2.31316,11.01392 2.338114,16.21747"
+       style="display:inline;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.265;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-start:url(#marker1611);marker-end:url(#marker1488);paint-order:normal"
+       clip-path="url(#clipPath18565)" />
+    <text
+       id="text7574"
+       y="93.237755"
+       x="71.674332"
+       style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;line-height:1.25;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman,  Italic';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#999999;fill-opacity:1;stroke:none;stroke-width:0.264583"
+       xml:space="preserve"
+       clip-path="url(#clipPath18561)"><tspan
+         style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman,  Italic';fill:#000000"
+         y="93.237755"
+         x="71.674332"
+         id="tspan1718"
+         sodipodi:role="line">𝜏<tspan
+   id="tspan1720"
+   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:65%;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman, ';baseline-shift:sub;fill:#000000">u</tspan></tspan></text>
+    <path
+       sodipodi:arc-type="arc"
+       style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.264583;stroke-miterlimit:4;stroke-dasharray:0.79375, 0.264583;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal"
+       id="path8399"
+       sodipodi:type="arc"
+       sodipodi:cx="129.94983"
+       sodipodi:cy="-9.1871157"
+       sodipodi:rx="62.683178"
+       sodipodi:ry="62.683178"
+       sodipodi:start="4.5297849"
+       sodipodi:end="4.8943481"
+       sodipodi:open="true"
+       d="m 118.56713,-70.828133 a 62.683178,62.683178 0 0 1 22.72564,-0.0073"
+       transform="rotate(90)"
+       clip-path="url(#clipPath18557)" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.265;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-start:url(#marker9322);marker-end:url(#marker8563)"
+       d="m 72.412155,129.94979 h 8.817802 m 6.184649,0 h 12.786514"
+       id="path8727"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccc"
+       clip-path="url(#clipPath18553)" />
+    <path
+       style="fill:#000000;stroke:#000000;stroke-width:0.24498px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-start:url(#marker8403);marker-end:url(#marker8927)"
+       d="m 71.299604,129.94979 h -3.01551 m -4.72399,0 h -2.396911"
+       id="path8905"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccc"
+       clip-path="url(#clipPath18549)" />
+    <text
+       xml:space="preserve"
+       style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;line-height:1.25;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman,  Italic';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#999999;fill-opacity:1;stroke:none;stroke-width:0.264583"
+       x="82.081345"
+       y="132.07571"
+       id="text4100-8-5-1"
+       clip-path="url(#clipPath18545)"><tspan
+         sodipodi:role="line"
+         id="tspan4098-5-6-1"
+         x="82.081345"
+         y="132.07571"
+         style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman,  Italic';fill:#000000;stroke-width:0.264583"><tspan
+           id="tspan1752"
+           style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman,  Italic';fill:#000000">d</tspan><tspan
+           id="tspan5415-7-3"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:65%;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman, ';baseline-shift:sub;fill:#000000">st</tspan></tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.20298px;line-height:1.25;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman,  Italic';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#808080;fill-opacity:1;stroke:none;stroke-width:0.258458"
+       x="63.842854"
+       y="133.08711"
+       id="text4100-8-5-7-9"
+       clip-path="url(#clipPath18541)"><tspan
+         sodipodi:role="line"
+         id="tspan4098-5-6-6-7"
+         x="63.842854"
+         y="133.08711"
+         style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman,  Italic';fill:#000000;stroke-width:0.258458"><tspan
+           style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.20298px;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman,  Italic';fill:#000000;stroke-width:0.258458"
+           id="tspan274">d</tspan><tspan
+           id="tspan5415-7-7-6"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.03194px;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman, ';baseline-shift:sub;fill:#000000;stroke-width:0.258458">sp</tspan></tspan></text>
+    <path
+       style="fill:#000000;stroke:#000000;stroke-width:0.265;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#marker10219)"
+       d="m 88.357166,110.2491 v 6.28444"
+       id="path10209"
+       inkscape:connector-curvature="0"
+       clip-path="url(#clipPath18537)" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path10497"
+       d="m 88.357166,149.00214 v -5.66477"
+       style="fill:#000000;stroke:#000000;stroke-width:0.265;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#marker10501)"
+       clip-path="url(#clipPath18533)" />
+    <text
+       xml:space="preserve"
+       style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;line-height:1.25;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman,  Italic';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#999999;fill-opacity:1;stroke:none;stroke-width:0.264583"
+       x="88.353172"
+       y="109.69622"
+       id="text1480"
+       clip-path="url(#clipPath18529)"><tspan
+         sodipodi:role="line"
+         id="tspan1478"
+         x="88.353172"
+         y="109.69622"
+         style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman,  Italic';fill:#000000;stroke-width:0.264583">w<tspan
+   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:65%;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman, ';baseline-shift:sub;fill:#000000"
+   id="tspan1482">st</tspan></tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.23333px;line-height:1.25;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman, Italic';letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+       x="26.600523"
+       y="134.59412"
+       id="text2115"
+       clip-path="url(#clipPath18525)"><tspan
+         sodipodi:role="line"
+         id="tspan2113"
+         x="26.600523"
+         y="134.59412"
+         style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman, Italic';stroke-width:0.264583">x</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:10.5833px;line-height:1.25;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman,  Italic';letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+       x="5.7533555"
+       y="110.634"
+       id="text2145"
+       clip-path="url(#clipPath18521)"><tspan
+         sodipodi:role="line"
+         id="tspan2143"
+         x="5.7533555"
+         y="110.634"
+         style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman, Italic';stroke-width:0.264583">y</tspan></text>
+    <path
+       style="display:inline;fill:#000000;stroke:#000000;stroke-width:0.265;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#marker3967)"
+       d="m 8.62825,130.84382 34.844657,-0.25657 m 6.244067,-0.046 8.902873,-0.0655"
+       id="path3957"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccc"
+       inkscape:transform-center-x="-24.919284"
+       inkscape:transform-center-y="0.059888"
+       clip-path="url(#clipPath18517)" />
+    <text
+       xml:space="preserve"
+       style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;line-height:1.25;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman,  Italic';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#999999;fill-opacity:1;stroke:none;stroke-width:0.264583"
+       x="44.042995"
+       y="131.90187"
+       id="text4775"
+       clip-path="url(#clipPath18513)"><tspan
+         sodipodi:role="line"
+         id="tspan4773"
+         x="44.042995"
+         y="131.90187"
+         style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman,  Italic';fill:#000000;stroke-width:0.264583">r<tspan
+   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:65%;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman, ';baseline-shift:sub;fill:#000000"
+   id="tspan4777">si</tspan></tspan></text>
+    <g
+       style="display:inline;stroke:#ff0000"
+       id="g2173"
+       transform="rotate(90,87.38064,218.09617)"
+       clip-path="url(#clipPath18509)">
+      <path
+         inkscape:connector-curvature="0"
+         id="path1377"
+         d="M 0,297 V 279.41365"
+         style="fill:none;stroke:#ff0000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#marker1387)" />
+      <path
+         inkscape:transform-center-x="8.793175"
+         style="fill:none;stroke:#ff0000;stroke-width:0.5;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#marker1741-6)"
+         d="M 0,297 H -17.58635"
+         id="path1737"
+         inkscape:connector-curvature="0" />
+    </g>
+    <text
+       xml:space="preserve"
+       style="font-size:4.93889px;line-height:0.95;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math';display:inline;stroke-width:0.264583"
+       x="11.041293"
+       y="144.74521"
+       id="text1453"
+       clip-path="url(#clipPath18505)"><tspan
+         sodipodi:role="line"
+         id="tspan1451"
+         x="11.041293"
+         y="144.74521"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman, ';stroke-width:0.264583"><tspan
+   style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman, Italic'"
+   id="tspan1455">Q</tspan> = number of slots</tspan></text>
+  </g>
+</svg>

--- a/docs/source/EM_analyzers/SynR_jmag2d_analyzer.rst
+++ b/docs/source/EM_analyzers/SynR_jmag2d_analyzer.rst
@@ -252,7 +252,7 @@ in this case to find torque and power quantities, can be seen here:
 
     class SynR_EM_PostAnalyzer:
         def copper_loss(self):
-            return 3 * (self.I ** 2) * (self.R_wdg + self.R_wdg_coil_ends + self.R_wdg_coil_sides)
+            return 3 * (self.I ** 2) * (self.R_wdg)
 
         def get_next_state(results, in_state):
             state_out = copy.deepcopy(in_state)

--- a/docs/source/EM_analyzers/input_stator_wdg_res.csv
+++ b/docs/source/EM_analyzers/input_stator_wdg_res.csv
@@ -7,7 +7,7 @@ l_st,Stack length,m
 Q,Number of slots,
 y,Slot pitch (in number of slots),
 z_Q,Number of turns per coil,
-z_C,Number of coils per phase,
+z_C,Number of series coils per phase,
 Kcu,Slot fill factor,
 Kov,Winding overlength factor,
 sigma_cond,Conductor conductivity,S/m

--- a/docs/source/EM_analyzers/input_stator_wdg_res.csv
+++ b/docs/source/EM_analyzers/input_stator_wdg_res.csv
@@ -12,3 +12,4 @@ Kcu,Slot fill factor,
 Kov,Winding overlength factor,
 sigma_cond,Conductor conductivity,S/m
 slot_area,Stator slot area,m^2
+n_layers,Number of layers (single or double),

--- a/docs/source/EM_analyzers/output_stator_wdg_res.csv
+++ b/docs/source/EM_analyzers/output_stator_wdg_res.csv
@@ -1,4 +1,6 @@
 Arguments,Description,Units
-R_wdg,Resistance of a winding,Ohms
-R_wdg_coil_ends,Resistance of coil ends of a winding,Ohms
-R_wdg_coil_sides,Resistance of coil sides of a winding,Ohms
+l_coil,Length of a single loop of a coil,meters
+l_ew,Length of an end winding,meters
+R_coil,Resistance of a coil,Ohms
+R_ew,Resistance of an end winding,Ohms
+R_wdg,Resistance of a phase winding,Ohms

--- a/docs/source/EM_analyzers/results_stator_wdg_res.csv
+++ b/docs/source/EM_analyzers/results_stator_wdg_res.csv
@@ -1,0 +1,6 @@
+Arguments,Value,Units
+l_coil,0.496,meters
+l_ew,0.198,meters
+R_coil,0.035,Ohms
+R_ew,0.014,Ohms
+R_wdg,0.14,Ohms

--- a/docs/source/EM_analyzers/stator_wdg_res.rst
+++ b/docs/source/EM_analyzers/stator_wdg_res.rst
@@ -24,7 +24,7 @@ To calculate :math:`l_\text{coil}`, the following coil shape is assumed
 .. figure:: ./Images/coil_diagram.svg
    :alt: coil_diagram 
    :align: center
-   :width: 500 
+   :width: 250 
 
 This is the view when one side of the stator is cut along the axial direction and unrolled. Using this diagram, :math:`l_\text{coil}` is calculated as
 

--- a/docs/source/EM_analyzers/stator_wdg_res.rst
+++ b/docs/source/EM_analyzers/stator_wdg_res.rst
@@ -66,7 +66,7 @@ Here, :math:`\tau_u` is calculated as the length of an arc (when a stator is in 
     \tau_u &= \frac{2 \pi}{Q} (r_\text{si} + d_\text{sp} + \frac{d_\text{st}}{2})\\
 
 where :math:`Q` is the number of stator slots, :math:`r_\text{si}` is the stator inner radius, :math:`d_\text{sp}` is the stator pole thickness, and :math:`d_\text{st}` is the stator 
-tooth depth (see :doc:`here <../machines/bspm/bspm_machine>`).
+tooth depth (see :doc:`here <../machines/bspm/bspm_machine>` or the figure below).
 
 
 Input from User

--- a/docs/source/EM_analyzers/stator_wdg_res.rst
+++ b/docs/source/EM_analyzers/stator_wdg_res.rst
@@ -10,16 +10,25 @@ This analyzer implements the coil length and resistance calculation approach pro
 
 * N. Bianchi, S. Bolognani, and P. Frare, “Design Criteria for High-Efficiency SPM Synchronous Motors,” in `IEEE Transactions on Energy Conversion`, June 2006.
 
-The calculation approach is now summarized. The following equation is used to calculate stator winding resistance:
+The calculation approach is summarized below. The following equation is used to calculate stator winding resistance:
 
 .. math::
 
     R_\text{wdg} &= \frac{z_Q z_C l_\text{coil}}{\sigma_\text{cond} A_\text{cond}}\\
 
-where :math:`z_Q` is a number of turns per coil, :math:`z_C` is a number of coils per phase, :math:`l_\text{coil}` is an average length of a single loop of a coil, and :math:`\sigma_\text{cond}` and :math:`A_\text{cond}` are conductor conductivity and cross-section area. 
-Conductor area is found as :math:`A_\text{cond} = K_\text{Cu}A_\text{slot}/(n_\text{layers}z_Q)`, where :math:`A_\text{slot}` is a stator slot area, :math:`K_\text{Cu}` is a slot fill factor, and :math:`n_\text{layers}` is a number of layers (:math:`n_\text{layers}=1` for a single-layer winding and :math:`n_\text{layers} = 2` for a double-layer winding).
+where :math:`z_Q` is the number of turns per coil, :math:`z_C` is the number of series coils per phase, :math:`l_\text{coil}` is the average length of a single coil 
+loop, :math:`\sigma_\text{cond}` is the conductor conductivity, and :math:`A_\text{cond}` is the cross-section area. 
 
-To calculate :math:`l_\text{coil}`, the following coil shape is assumed
+Conductor area is found as:
+
+.. math::
+    
+    A_\text{cond} = \frac{K_\text{Cu}A_\text{slot}}{(n_\text{layers}z_Q)}
+    
+where :math:`A_\text{slot}` is the stator slot area, :math:`K_\text{Cu}` is the slot fill factor, and :math:`n_\text{layers}` is the number of layers (:math:`n_\text{layers}=1` 
+for a single-layer winding and :math:`n_\text{layers} = 2` for a double-layer winding). 
+
+To calculate :math:`l_\text{coil}`, the following coil shape is assumed:
 
 .. figure:: ./Images/coil_diagram.svg
    :alt: coil_diagram 
@@ -32,22 +41,7 @@ This is the view when one side of the stator is cut along the axial direction an
 
     l_\text{coil} &= 2(l_\text{st} + l_\text{end wdg})\\
 
-where :math:`l_\text{st}` is a length of a coil along the axial length of a motor; :math:`l_\text{end wdg} = l_1 + 2l_2` is an end winding length.
-
-The segments with length :math:`l_2` represent the bent parts of a coil and are calculated as 1/4th of the circle circumference. The diameter of this circle is estimated as the average of stator tooth width :math:`w_\text{st}` and the length between adjacent slots :math:`\tau_u`.
-
-.. math::
-
-    l_2 &= \frac{1}{4} \pi \frac{\tau_u + w_\text{st}}{2}\\
-
-Here, :math:`\tau_u` is calculated as the length of an arc (when a stator is in its normal cylindrical shape) at a median depth of a slot:
-
-.. math::
-
-    \tau_u &= \frac{2 \pi}{Q} (r_\text{si} + d_\text{sp} + \frac{d_\text{st}}{2})\\
-
-where :math:`Q` is a number of stator slots, :math:`r_\text{si}` is a stator inner radius, :math:`d_\text{sp}` is a stator pole thickness, and :math:`d_\text{st}` is a stator tooth depth (see :doc:`here <../machines/bspm/bspm_machine>`).
-
+where :math:`l_\text{st}` is the length of a coil along the axial length of a motor and :math:`l_\text{end wdg} = l_1 + 2l_2` is the end winding length.
 
 The segments with length :math:`l_1` represent the parts of the end winding that appear only in distributed windings, which are calculated as
 
@@ -55,26 +49,48 @@ The segments with length :math:`l_1` represent the parts of the end winding that
 
     l_1 &= \tau_u K_\text{ov} (y-1)\\
 
-where :math:`y` is a coil pitch represented in a number of slots and :math:`K_\text{ov}` is a coil overlength factor. For a concentrated winding, :math:`y = 1`, resulting in :math:`l_1 = 0`.
+where :math:`y` is a coil pitch represented in a number of slots and :math:`K_\text{ov}` is a coil overlength factor. For a concentrated winding, :math:`y = 1`, resulting in 
+:math:`l_1 = 0`.
+
+The segments with length :math:`l_2` represent the bent parts of a coil and are calculated as 1/4th of the circle circumference. The diameter of this circle is estimated as 
+the average of the stator tooth width :math:`w_\text{st}` and the length between adjacent slots :math:`\tau_u`.
+
+.. math::
+
+    l_2 &= \frac{1}{4} \pi \frac{\tau_u + w_\text{st}}{2}\\
+
+Here, :math:`\tau_u` is calculated as the length of an arc (when a stator is in its normal cylindrical shape) at the median depth of a slot:
+
+.. math::
+
+    \tau_u &= \frac{2 \pi}{Q} (r_\text{si} + d_\text{sp} + \frac{d_\text{st}}{2})\\
+
+where :math:`Q` is the number of stator slots, :math:`r_\text{si}` is the stator inner radius, :math:`d_\text{sp}` is the stator pole thickness, and :math:`d_\text{st}` is the stator 
+tooth depth (see :doc:`here <../machines/bspm/bspm_machine>`).
 
 
 Input from User
 *********************************
 
-User is required to provide the following parameters.
+The user is required to provide the following parameters:
 
 .. csv-table:: `Input to stator winding resistance problem`
    :file: input_stator_wdg_res.csv
    :widths: 50, 70, 50
    :header-rows: 1
 
-For the definition of dimensions, please refer :doc:`here <../machines/bspm/bspm_machine>`.
+For the definition of dimensions, please refer to the figure below:
+
+.. figure:: ./Images/stator_wdg_cross_sect.svg
+   :alt: coil_diagram 
+   :align: center
+   :width: 400 
 
 
 Output to User
 **********************************
 
-Stator winding resistance analyzer returns the dictionary that has the following parameters:
+The stator winding resistance analyzer returns a dictionary that has the following parameters:
 
 .. csv-table:: `Output of stator winding resistance analyzer`
    :file: output_stator_wdg_res.csv
@@ -85,7 +101,7 @@ Stator winding resistance analyzer returns the dictionary that has the following
 Here, the total phase winding resistance `R_wdg` is the product of `R_coil` and the number of coils per phase `z_C`.
 
 
-Example code using resistance analyzer is provided below.
+Example code using the stator winding resistance analyzer is provided below:
 
 .. code-block:: python
 
@@ -119,12 +135,7 @@ Example code using resistance analyzer is provided below.
 
 The output of the code is the dictionary with the following key-value pairs:
 
-.. code-block:: python
-
-    results = {
-        'l_coil': 0.496,
-        'l_ew': 0.198,
-        'R_coil': 0.035,
-        'R_ew': 0.014,
-        'R_wdg': 0.14
-        }
+.. csv-table:: `Results of stator winding resistance analyzer`
+   :file: results_stator_wdg_res.csv
+   :widths: 50, 70, 50
+   :header-rows: 1

--- a/docs/source/EM_analyzers/stator_wdg_res.rst
+++ b/docs/source/EM_analyzers/stator_wdg_res.rst
@@ -23,7 +23,7 @@ Conductor area is found as:
 
 .. math::
     
-    A_\text{cond} = \frac{K_\text{Cu}A_\text{slot}}{(n_\text{layers}z_Q)}
+    A_\text{cond} = \frac{K_\text{Cu}A_\text{slot}}{n_\text{layers}z_Q}
     
 where :math:`A_\text{slot}` is the stator slot area, :math:`K_\text{Cu}` is the slot fill factor, and :math:`n_\text{layers}` is the number of layers (:math:`n_\text{layers}=1` 
 for a single-layer winding and :math:`n_\text{layers} = 2` for a double-layer winding). 

--- a/examples/mach_eval_examples/SynR_eval/SynR_em_post_analyzer.py
+++ b/examples/mach_eval_examples/SynR_eval/SynR_em_post_analyzer.py
@@ -10,7 +10,7 @@ from mach_eval.analyzers.torque_data import (
 
 class SynR_EM_PostAnalyzer:
     def copper_loss(self):
-        return 3 * (self.I ** 2) * (self.R_wdg + self.R_wdg_coil_ends + self.R_wdg_coil_sides)
+        return 3 * (self.I ** 2) * (self.R_wdg)
 
     def get_next_state(results, in_state):
         state_out = copy.deepcopy(in_state)

--- a/mach_eval/analyzers/electromagnetic/SynR/SynR_em_analyzer.py
+++ b/mach_eval/analyzers/electromagnetic/SynR/SynR_em_analyzer.py
@@ -194,6 +194,7 @@ class SynR_EM_Analyzer:
             Kov=self.machine_variant.Kov,
             sigma_cond=self.machine_variant.coil_mat["copper_elec_conductivity"],
             slot_area=self.machine_variant.s_slot*1e-6,
+            n_layers=self.machine_variant.no_of_layers,
         )
         res_analyzer = StatorWindingResistanceAnalyzer()
         stator_resistance = res_analyzer.analyze(res_prob)
@@ -201,16 +202,15 @@ class SynR_EM_Analyzer:
 
     @property
     def R_wdg(self):
-        return self.stator_resistance[0]
+        return self.stator_resistance["R_wdg"]
 
     @property
     def R_wdg_coil_ends(self):
-        return self.stator_resistance[1]
+        return 2 * self.stator_resistance["R_ew"] * self.z_C
 
     @property
     def R_wdg_coil_sides(self):
-        return self.stator_resistance[2]
-
+        return self.R_wdg - self. R_wdg_coil_ends
 
     def draw_machine(self, tool):
         ####################################################

--- a/mach_eval/analyzers/electromagnetic/stator_wdg_res.py
+++ b/mach_eval/analyzers/electromagnetic/stator_wdg_res.py
@@ -70,7 +70,9 @@ class StatorWindingResistanceAnalyzer:
         # Length between adjacent slots evaluated at median depth of slot
         tau_u = 2 * np.pi / Q * (r_si + d_sp + d_st / 2)
         # Length of end winding
-        l_ew = 0.5 * np.pi * (tau_u + w_st) / 2 + tau_u * Kov * (y - 1)
+        l_1 = tau_u * Kov * (y - 1)
+        l_2 = 1 / 4 * np.pi * (tau_u + w_st) / 2
+        l_ew = l_1 + 2 * l_2
         # Mean length of one coil
         l_coil = 2 * (l_st + l_ew)
 

--- a/mach_eval/analyzers/electromagnetic/stator_wdg_res.py
+++ b/mach_eval/analyzers/electromagnetic/stator_wdg_res.py
@@ -17,6 +17,7 @@ class StatorWindingResistanceProblem:
         Kov: winding overlength factor
         sigma_cond: conductor conductivity [Siemens/m]
         slot_area: stator slot area [m^2]
+        n_layers: number of layers (1 for a single-layer and 2 for a double-layer winding)
 
     """
 
@@ -43,11 +44,14 @@ class StatorWindingResistanceAnalyzer:
 
         Args:
             problem: object of type StatorWindingResistanceProblem holding force data
-        Returns:
-            R_wdg: phase winding resistance [Ohm]
-            R_wdg_coil_ends: phase winding resistance due to coil ends [Ohm]
-            R_wdg_coil_sides: phase winding resistance due to coil sides [Ohm]
+        Returns results dictionary with the following parameters:
+            l_coil: length of a single loop of a coil [m]
+            l_ew: length of an end winding (one side) [m]
+            R_coil: resistance of a coil [m]
+            R_ew: resistance of an end winding [Ohms]
+            R_wdg: resistance of a phase winding [Ohms]
         """
+
         r_si = problem.r_si
         d_sp = problem.d_sp
         d_st = problem.d_st


### PR DESCRIPTION
This PR updates the stator winding resistance analyzer to include the following (solves issue #200):
* In addition to the resistance values, the analyzer also returns the length of a coil and end winding. The output is a dictionary `results` with the following keys: `l_coil`, `l_ew`,`R_coil`, `R_ew`, `R_wdg`.
* The [stator_wdg_res.rst](https://github.com/Severson-Group/eMach/compare/user/Anvar-Khamitov/update-stator-wdg-analyzer?expand=1#diff-5f4e3665be05286738500ef68cbac68eceb8da06add292bfd1955b6b146f74c9) file is updated - changes throughout the document are made and the coil diagram is added.
* The analyzer receives an additional input of the number of layers `n_layers`.
* Update `SynR_em_analyzer` analyzer code and .rst document to use the updated stator winding resistance analyzer.

Please review this PR. If helpful, I have attached the .pdf file for the analyzer documentation obtained from the generated .html file.

[5. Stator Winding Resistance Analyzer — eMach 0.0.1 documentation.pdf](https://github.com/Severson-Group/eMach/files/12563935/5.Stator.Winding.Resistance.Analyzer.eMach.0.0.1.documentation.pdf)
