### PR TITLE
Fix error when calculating coil resistance and copper loss in BSPM_EM_Analyzer

### DIFF
--- a/examples/mach_eval_examples/bspm_eval/bspm_evaluator.py
+++ b/examples/mach_eval_examples/bspm_eval/bspm_evaluator.py
@@ -1,8 +1,12 @@
 import os
 import sys
 
+
+os.chdir(os.path.dirname(__file__))
+
 # add the directory 3 levels above this file's directory to path for module import
 sys.path.append(os.path.dirname(__file__)+"/../../..")
+sys.path.append(os.path.dirname(__file__)+"/../../../..")
 sys.path.append(os.path.dirname(__file__))
 
 from mach_eval import MachineEvaluator

--- a/mach_eval/analyzers/electromagnetic/bspm/jmag_2d.py
+++ b/mach_eval/analyzers/electromagnetic/bspm/jmag_2d.py
@@ -166,7 +166,7 @@ class BSPM_EM_Analyzer:
     @property
     def copper_loss(self):
         copper_loss_per_phase = (
-            ((self.current_trms / 2) ** 2 + self.current_srms ** 2) * self.R_coil * self.z_C
+            ((self.current_trms / 2) ** 2 + self.current_srms ** 2) * self.R_wdg
         )
 
         copper_loss = self.m * copper_loss_per_phase

--- a/mach_eval/analyzers/electromagnetic/bspm/jmag_2d.py
+++ b/mach_eval/analyzers/electromagnetic/bspm/jmag_2d.py
@@ -139,19 +139,37 @@ class BSPM_EM_Analyzer:
     @property
     def R_coil(self):
         a_wire = (self.machine_variant.s_slot * self.machine_variant.Kcu) / (
-            2 * self.machine_variant.Z_q
+            self.machine_variant.no_of_layers * self.machine_variant.Z_q
         )
-        return (self.l_coil * self.machine_variant.Z_q * self.machine_variant.Q / 6) / (
+        return (self.l_coil * self.machine_variant.Z_q) / (
             self.machine_variant.coil_mat["copper_elec_conductivity"] * a_wire
         )
 
     @property
+    def R_wdg(self):
+        return (self.R_coil * self.z_C)
+
+    @property
+    def m(self):
+        m = len(self.machine_variant.coil_groups)
+        return m
+
+    @property
+    def z_C(self):
+        if len(self.machine_variant.layer_phases) == 1:
+            z_C = self.machine_variant.Q / (2 * self.m)
+        elif len(self.machine_variant.layer_phases) == 2:
+            z_C = self.machine_variant.Q / (self.m)
+
+        return z_C
+
+    @property
     def copper_loss(self):
-        return (
-            self.machine_variant.Q
-            * ((self.current_trms / 2) ** 2 + self.current_srms**2)
-            * self.R_coil
+        copper_loss_per_phase = (
+            ((self.current_trms / 2) ** 2 + self.current_srms**2) * self.R_coil * self.z_C
         )
+        copper_loss = self.m * copper_loss_per_phase,
+        return copper_loss
 
     def draw_machine(self, toolJd):
         ####################################################
@@ -896,7 +914,7 @@ class BSPM_EM_Analyzer:
         circuit(
             self.machine_variant.p,
             self.machine_variant.Z_q,
-            Rs=self.R_coil,
+            Rs=self.R_wdg,
             ampT=current_tpeak,
             ampS=current_speak,
             freq=self.excitation_freq,

--- a/mach_eval/analyzers/electromagnetic/bspm/jmag_2d.py
+++ b/mach_eval/analyzers/electromagnetic/bspm/jmag_2d.py
@@ -166,9 +166,10 @@ class BSPM_EM_Analyzer:
     @property
     def copper_loss(self):
         copper_loss_per_phase = (
-            ((self.current_trms / 2) ** 2 + self.current_srms**2) * self.R_coil * self.z_C
+            ((self.current_trms / 2) ** 2 + self.current_srms ** 2) * self.R_coil * self.z_C
         )
-        copper_loss = self.m * copper_loss_per_phase,
+
+        copper_loss = self.m * copper_loss_per_phase
         return copper_loss
 
     def draw_machine(self, toolJd):

--- a/mach_eval/analyzers/electromagnetic/bspm/jmag_2d.py
+++ b/mach_eval/analyzers/electromagnetic/bspm/jmag_2d.py
@@ -156,11 +156,13 @@ class BSPM_EM_Analyzer:
 
     @property
     def z_C(self):
-        if len(self.machine_variant.layer_phases) == 1:
+        if self.machine_variant.no_of_layers == 1:
             z_C = self.machine_variant.Q / (2 * self.m)
-        elif len(self.machine_variant.layer_phases) == 2:
+        elif self.machine_variant.no_of_layers == 2:
             z_C = self.machine_variant.Q / (self.m)
-
+        else:
+            raise InvalidDesign(message="The number of winding layers must be 1 or 2")
+            
         return z_C
 
     @property


### PR DESCRIPTION
This PR fixes issue in #277. Specifically, the following changes have been made:
* `R_coil` method in [jmag_2d.py](https://github.com/Severson-Group/eMach/blob/develop/mach_eval/analyzers/electromagnetic/bspm/jmag_2d.py) file now returns the resistance of one coil (not phase winding).
* `R_coil` and `copper_loss` methods in [jmag_2d.py](https://github.com/Severson-Group/eMach/blob/develop/mach_eval/analyzers/electromagnetic/bspm/jmag_2d.py) takes into account both single- and double-layer windings.
* [jmag_2d.py](https://github.com/Severson-Group/eMach/blob/develop/mach_eval/analyzers/electromagnetic/bspm/jmag_2d.py) uses the proper resistance value when setting circuit resistance values in JMAG.
* Import statements have been updated to find all modules.

@wchan29 could you take a look when you have a chance? This PR is based on our discussion in eMach group on slack, summarized in #277. Thanks!