### PR TITLE
Fix ReadTheDocs

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -6,3 +6,8 @@ build:
   os: ubuntu-20.04
   tools:
     python: "3.8"
+    
+ python:
+   install:
+     - requirements: docs/requirements.txt
+     

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -7,7 +7,6 @@ build:
   tools:
     python: "3.8"
     
- python:
-   install:
-     - requirements: docs/requirements.txt
-     
+python:
+  install:
+    - requirements: docs/requirements.txt

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,1 @@
+sphinx-rtd-theme


### PR DESCRIPTION
# Abstract
This PR adds a requirements file to list Python packages that ReadTheDocs will use to build the eMach documentation.

# Context
This fixes #295, where ReadTheDocs was failing to build our documentation due to a [recent dependency update](https://blog.readthedocs.com/defaulting-latest-build-tools/) in their system that no long automatically installs the `sphinx_rtd_theme`.

# Validation
I have tested the patch by instructing ReadTheDocs to build our website based on the `fix_readthedocs` branch. The build succeeded (and is now deployed to [emach.readthedocs.io](https://emach.readthedocs.io/)):

![image](https://github.com/Severson-Group/eMach/assets/7421348/241d1232-ec94-40f6-8678-f7ca92e28cbb)


