### PR TITLE
Restructure Index Files to Clean Up Table of Contents

### DIFF
--- a/docs/source/EM_analyzers/index.rst
+++ b/docs/source/EM_analyzers/index.rst
@@ -7,12 +7,12 @@ This section provides documentation for the electromagnetic analyzers supported 
     :maxdepth: 4
     :numbered:
 
-    bfield_outer_stator
-    bfield_spm_inner_rotor
-    torque_data
-    force_vector_data
-    stator_wdg_res
-    bspm_jmag2d_analyzer
-    winding_factors
-    SynR_jmag2d_analyzer
-    inductance_analyzer
+    B Field Outer Stator <bfield_outer_stator>
+    B Field SPM Inner Rotor <bfield_spm_inner_rotor>
+    Torque Data <torque_data>
+    Force Data <force_vector_data>
+    Stator Winding Resistance <stator_wdg_res>
+    BSPM JMAG 2D FEA <bspm_jmag2d_analyzer>
+    Winding Factors <winding_factors>
+    SynR JMAG 2D FEA <SynR_jmag2d_analyzer>
+    Inductance/Saliency <inductance_analyzer>

--- a/docs/source/getting_started/tutorials/index.rst
+++ b/docs/source/getting_started/tutorials/index.rst
@@ -32,10 +32,10 @@ their own custom scripts for using its functionalities.
 .. toctree::
     :hidden:
 
-    rectangle_tutorial/index
-    analytical_machine_des_tutorial/index
-    analytical_machine_opt_tutorial/index
-    make_electric_machine_tutorial/index
-    bspm_eval_tutorial/index
-    bspm_opti_tutorial/index
+    Rectangle Optimization <rectangle_tutorial/index>
+    Analytical Machine Design <analytical_machine_des_tutorial/index>
+    Analytical Machine Optimization <analytical_machine_opt_tutorial/index>
+    Making an Electric Machine using eMach <make_electric_machine_tutorial/index>
+    BSPM Evaluation <bspm_eval_tutorial/index>
+    BSPM Optimization <bspm_opti_tutorial/index>
 

--- a/docs/source/mechanical_analyzers/index.rst
+++ b/docs/source/mechanical_analyzers/index.rst
@@ -8,10 +8,10 @@ This page contains links to analyzers in eMach which aid in evaluating the mecha
     :maxdepth: 3
     :numbered:
     
-    thermal_res_net_analyzer	
-    SPM_rotor_thermal_analyzer
-    SPM_rotor_airflow_analyzer
-    windage_loss_analyzer
-    inner_rotor_stator_thermal_analyzer
-    SPM_structural_analyzer
-    SPM_sleeve_analyzer
+    Thermal Resistance Network <thermal_res_net_analyzer>	
+    SPM Rotor Thermal <SPM_rotor_thermal_analyzer>
+    SPM Airflow <SPM_rotor_airflow_analyzer>
+    Windage Loss <windage_loss_analyzer>
+    Inner Rotor Stator Thermal <inner_rotor_stator_thermal_analyzer>
+    SPM Rotor Structural <SPM_structural_analyzer>
+    SPM Sleeve <SPM_sleeve_analyzer>


### PR DESCRIPTION
This PR eliminates the repetitive wording in the tree on `eMach.readthedocs` for the `tutorials` and `analyzers` sections according to the issue raised in #291.

See the three different tree renderings:

![image](https://github.com/Severson-Group/eMach/assets/112111913/66d876ce-8b14-4be0-8ef5-2ad1c433e286)
![image](https://github.com/Severson-Group/eMach/assets/112111913/637e533a-ef70-4524-a915-44e9a7ab0259)
![image](https://github.com/Severson-Group/eMach/assets/112111913/9d9d0990-3744-4559-b4f4-9e03a5c26865)

closes #291