### PR TITLE
turn on numbers for tutorial section

### DIFF
--- a/docs/source/getting_started/tutorials/index.rst
+++ b/docs/source/getting_started/tutorials/index.rst
@@ -31,6 +31,7 @@ their own custom scripts for using its functionalities.
 
 .. toctree::
     :hidden:
+    :numbered:
 
     Rectangle Optimization <rectangle_tutorial/index>
     Analytical Machine Design <analytical_machine_des_tutorial/index>


### PR DESCRIPTION
This PR adds numbering for the tutorials similar to the analyzer section. See below:

![image](https://github.com/Severson-Group/eMach/assets/112111913/a02fb726-45b0-4525-be39-9c22e8a8b420)

closes #303 