### PR TITLE
Remove valid constraints from get_objectives() function.

### DIFF
--- a/examples/mach_opt_examples/713_mach_ex.py
+++ b/examples/mach_opt_examples/713_mach_ex.py
@@ -469,7 +469,7 @@ class DesignSpace:
     def n_obj(self) -> int:
         return self._n_obj
 
-    def get_objectives(self, valid_constraints, full_results) -> tuple:
+    def get_objectives(self, full_results) -> tuple:
         """ Calculates objectives from evaluation results
         
 

--- a/examples/mach_opt_examples/cuboid_ex.py
+++ b/examples/mach_opt_examples/cuboid_ex.py
@@ -84,7 +84,7 @@ class CuboidDesignSpace(mo.DesignSpace):
         self._n_obj = n_obj
         self._bounds = bounds
 
-    def get_objectives(self, valid_constraints, full_results) -> tuple:
+    def get_objectives(self, full_results) -> tuple:
         """ Calculates objectives from evaluation results
         
 

--- a/examples/mach_opt_examples/rectangle_ex.py
+++ b/examples/mach_opt_examples/rectangle_ex.py
@@ -76,7 +76,7 @@ class RectDesignSpace(mo.DesignSpace):
         self._n_obj = n_obj
         self._bounds = bounds
 
-    def get_objectives(self, valid_constraints, full_results) -> tuple:
+    def get_objectives(self, full_results) -> tuple:
         """ Calculates objectives from evaluation results
         
 


### PR DESCRIPTION
This PR addresses #305. Removed `valid_constraints` from the `get_objectives()` function in the `machine_opt_examples` folder.

closes #305