### PR TITLE
Fix broken link to git flow image

### DIFF
--- a/docs/source/maintainer.rst
+++ b/docs/source/maintainer.rst
@@ -10,8 +10,8 @@ This guide is intended to describe the protocol adopted for the *eMach* code dev
 Branches in git
 -------------------------------------------
 
-.. figure:: images/emach-git-branch-flow.SVG
-   :alt: Trial1 
+.. figure:: images/emach-git-branch-flow.svg
+   :alt: Git branch flow
    :align: center
    :scale: 80 %
 


### PR DESCRIPTION
This PR fixes the broken link in the maintainer doc for the Git Branch Flow image.

<img width="759" alt="image" src="https://github.com/Severson-Group/eMach/assets/7421348/7a4782be-dad3-4ecf-9c92-8434e70a03d2">
