### PR TITLE
Add Nathan to CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,3 +1,3 @@
 # This file implements GitHub's [codeowners](https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners) features
 
-* @Anvar-Khamitov @elsevers
+* @Anvar-Khamitov @npetersen2 @elsevers


### PR DESCRIPTION
This PR corrects a previously #326, which was mistakenly merged into `v1.0.x` instead of into `develop`