### PR TITLE
Set JMAG Versions to be Specified by User

### DIFF
--- a/docs/source/EM_analyzers/SynR_jmag2d_analyzer.rst
+++ b/docs/source/EM_analyzers/SynR_jmag2d_analyzer.rst
@@ -31,7 +31,8 @@ Input from User
 To use this analyzer, users must pass in a ``MachineDesign`` object. An instance of the ``MachineDesign`` class can be created by passing in 
 ``machine`` and ``operating_point`` objects. The machine must be a ``SynR_Machine`` and the ``operating_point`` must be of type 
 ``SynR_Machine_Oper_Pt``. More information on both these classes is available in the ``SynR Design`` section under ``MACHINE DESIGNS``. To 
-initialize the ``SynR_JMAG_2D_FEA_Analyzer``, users must also specify analyzer configuration parameters.
+initialize the ``SynR_JMAG_2D_FEA_Analyzer``, users must also specify analyzer configuration parameters. One can control the version of JMAG
+desired for use in this analyzer using ``jmag_version``. For example, the use of JMAG-Designer21.1 would require an input of ``21.1``.
 
 The tables below provide the input expected by the ``MachineDesign`` class and the configuration input required to initialize the 
 ``SynR_JMAG_2D_FEA_Analyzer``.
@@ -217,6 +218,7 @@ A copy of this file lies in the ``eMach\examples\mach_eval_examples\SynR_eval`` 
         jmag_scheduler=False,
         jmag_visible=True,
         scale_axial_length = True,
+        jmag_version=None,
     )
 
     SynR_em_analysis = SynR_em.SynR_EM_Analyzer(configuration)

--- a/docs/source/EM_analyzers/bspm_jmag2d_analyzer.rst
+++ b/docs/source/EM_analyzers/bspm_jmag2d_analyzer.rst
@@ -51,7 +51,8 @@ Other Configurations
 
 In addition to time step and mesh size, several other changes can be made to the BSPM JMAG analyzer. Most of these configurations are self
 explanatory and are described using comments within the ``JMAG_2D_Config`` class. For example, by setting the ``jmag_visible`` to ``True`` or 
-``False``, users can control whether the JMAG application will be visible while a FEA evaluation is running.
+``False``, users can control whether the JMAG application will be visible while a FEA evaluation is running. One can control the version of JMAG
+desired for use in this analyzer using ``jmag_version``. For example, the use of JMAG-Designer21.1 would require an input of ``21.1``.
 
 Input from User
 *********************************
@@ -197,6 +198,7 @@ is shown below:
         num_cpus=4,
         jmag_scheduler=False,
         jmag_visible=True,
+        jmag_visible=None,
     )
 
     em_analysis = BSPM_EM_Analyzer(jmag_config)

--- a/docs/source/EM_analyzers/inductance_analyzer.rst
+++ b/docs/source/EM_analyzers/inductance_analyzer.rst
@@ -146,6 +146,7 @@ initializes the analyzer class with an explanation of the required configuration
         jmag_scheduler=False,
         jmag_visible=True,
         scale_axial_length = True,
+        jmag_version=None,
     )
 
     SynR_inductance_analysis = SynR_inductance.SynR_Inductance_Analyzer(configuration)

--- a/docs/source/getting_started/tutorials/bspm_eval_tutorial/index.rst
+++ b/docs/source/getting_started/tutorials/bspm_eval_tutorial/index.rst
@@ -199,6 +199,7 @@ is stored in ``State`` for future reference. It is worth noting that the losses 
         num_cpus=4,
         jmag_scheduler=False,
         jmag_visible=False,
+        jmag_version=None,
     )
     em_analysis = em.BSPM_EM_Analyzer(jmag_config)
     # define AnalysysStep for EM evaluation

--- a/examples/mach_eval_examples/SynR_eval/electromagnetic_step.py
+++ b/examples/mach_eval_examples/SynR_eval/electromagnetic_step.py
@@ -45,6 +45,7 @@ configuration = SynR_EM_Config(
     jmag_visible=True,
     non_zero_end_ring_res = False,
     scale_axial_length = True,
+    jmag_version="21.1",
 )
 
 SynR_em_analysis = SynR_em.SynR_EM_Analyzer(configuration)

--- a/examples/mach_eval_examples/SynR_eval/electromagnetic_step.py
+++ b/examples/mach_eval_examples/SynR_eval/electromagnetic_step.py
@@ -45,7 +45,7 @@ configuration = SynR_EM_Config(
     jmag_visible=True,
     non_zero_end_ring_res = False,
     scale_axial_length = True,
-    jmag_version="21.1",
+    jmag_version="22.1",
 )
 
 SynR_em_analysis = SynR_em.SynR_EM_Analyzer(configuration)

--- a/examples/mach_eval_examples/SynR_eval/inductance_step.py
+++ b/examples/mach_eval_examples/SynR_eval/inductance_step.py
@@ -44,6 +44,7 @@ configuration = SynR_EM_Config(
     jmag_visible=True,
     non_zero_end_ring_res = False,
     scale_axial_length = True,
+    jmag_version="21.1",
 )
 
 SynR_inductance_analysis = SynR_inductance.SynR_Inductance_Analyzer(configuration)

--- a/examples/mach_eval_examples/bspm_eval/electromagnetic_step.py
+++ b/examples/mach_eval_examples/bspm_eval/electromagnetic_step.py
@@ -45,6 +45,7 @@ jmag_config = JMAG_2D_Config(
     num_cpus=4,
     jmag_scheduler=False,
     jmag_visible=False,
+    jmag_version="21.1",
 )
 em_analysis = em.BSPM_EM_Analyzer(jmag_config)
 # define AnalysysStep for EM evaluation

--- a/mach_cad/tools/jmag/jmag.py
+++ b/mach_cad/tools/jmag/jmag.py
@@ -1,5 +1,6 @@
 from win32com.client import DispatchEx
 import os
+import string
 
 from ..tool_abc import toolabc as abc
 from ..token_draw import TokenDraw
@@ -13,8 +14,12 @@ __all__ += ["JmagDesigner"]
 class JmagDesigner(
     abc.ToolBase, abc.DrawerBase, abc.MakerExtrudeBase, abc.MakerRevolveBase
 ):
-    def __init__(self):
-        self.jd_instance = DispatchEx("designerstarter.InstanceManager")
+    def __init__(self, jmag_version=None):
+        if jmag_version is None:
+            self.jd_instance = DispatchEx("designerstarter.InstanceManager")
+        else:
+            jmag_version = jmag_version.translate(str.maketrans('', '', string.punctuation))
+            self.jd_instance = DispatchEx("designerstarter.InstanceManager.%s" % jmag_version)
         self.jd = None  # JMAG-Designer Application object
         self.geometry_editor = None  # The Geometry Editor object
         self.doc = None  # The document object in Geometry Editor

--- a/mach_eval/analyzers/electromagnetic/SynR/SynR_em_analyzer.py
+++ b/mach_eval/analyzers/electromagnetic/SynR/SynR_em_analyzer.py
@@ -82,7 +82,12 @@ class SynR_EM_Analyzer:
         if attempts > 1:
             self.project_name = self.project_name + "_attempts_%d" % (attempts)
 
-        toolJmag = JMAG.JmagDesigner(self.config.jmag_version)
+        JMAG_exist = os.path.exists("C:/Program Files/JMAG-Designer%s" % self.config.jmag_version)
+        if JMAG_exist is True:
+            toolJmag = JMAG.JmagDesigner(self.config.jmag_version)
+        else:
+            print('WARNING: The JMAG version does not exist, defaulting to newest JMAG version available!')
+            toolJmag = JMAG.JmagDesigner()
 
         toolJmag.visible = self.config.jmag_visible
         toolJmag.open(comp_filepath=expected_project_file, length_unit="DimMillimeter", study_type="Transient2D")

--- a/mach_eval/analyzers/electromagnetic/SynR/SynR_em_analyzer.py
+++ b/mach_eval/analyzers/electromagnetic/SynR/SynR_em_analyzer.py
@@ -82,7 +82,7 @@ class SynR_EM_Analyzer:
         if attempts > 1:
             self.project_name = self.project_name + "_attempts_%d" % (attempts)
 
-        toolJmag = JMAG.JmagDesigner()
+        toolJmag = JMAG.JmagDesigner(self.config.jmag_version)
 
         toolJmag.visible = self.config.jmag_visible
         toolJmag.open(comp_filepath=expected_project_file, length_unit="DimMillimeter", study_type="Transient2D")

--- a/mach_eval/analyzers/electromagnetic/SynR/SynR_em_config.py
+++ b/mach_eval/analyzers/electromagnetic/SynR/SynR_em_config.py
@@ -25,3 +25,4 @@ class SynR_EM_Config:
         self.jmag_scheduler = kwargs["jmag_scheduler"] # True if it is desired to schedule jobs instead of solving immediately
         self.jmag_visible = kwargs["jmag_visible"] # JMAG application visible if true
         self.scale_axial_length = kwargs["scale_axial_length"] # True: scale axial length to get the required rated torque
+        self.jmag_version = kwargs["jmag_version"] # JMAG application version

--- a/mach_eval/analyzers/electromagnetic/SynR/SynR_inductance_analyzer.py
+++ b/mach_eval/analyzers/electromagnetic/SynR/SynR_inductance_analyzer.py
@@ -68,7 +68,12 @@ class SynR_Inductance_Analyzer:
         if attempts > 1:
             self.project_name = self.project_name + "_attempts_%d" % (attempts)
 
-        toolJmag = JMAG.JmagDesigner(self.config.jmag_version)
+        JMAG_exist = os.path.exists("C:/Program Files/JMAG-Designer%s" % self.config.jmag_version)
+        if JMAG_exist is True:
+            toolJmag = JMAG.JmagDesigner(self.config.jmag_version)
+        else:
+            print('WARNING: The JMAG version does not exist, defaulting to newest JMAG version available!')
+            toolJmag = JMAG.JmagDesigner()
 
         toolJmag.visible = self.config.jmag_visible
         toolJmag.open(comp_filepath=expected_project_file, length_unit="DimMillimeter", study_type="Transient2D")

--- a/mach_eval/analyzers/electromagnetic/SynR/SynR_inductance_analyzer.py
+++ b/mach_eval/analyzers/electromagnetic/SynR/SynR_inductance_analyzer.py
@@ -68,7 +68,7 @@ class SynR_Inductance_Analyzer:
         if attempts > 1:
             self.project_name = self.project_name + "_attempts_%d" % (attempts)
 
-        toolJmag = JMAG.JmagDesigner()
+        toolJmag = JMAG.JmagDesigner(self.config.jmag_version)
 
         toolJmag.visible = self.config.jmag_visible
         toolJmag.open(comp_filepath=expected_project_file, length_unit="DimMillimeter", study_type="Transient2D")

--- a/mach_eval/analyzers/electromagnetic/SynR/SynR_inductance_config.py
+++ b/mach_eval/analyzers/electromagnetic/SynR/SynR_inductance_config.py
@@ -25,3 +25,4 @@ class SynR_Inductance_Config:
         self.jmag_scheduler = kwargs["jmag_scheduler"] # True if it is desired to schedule jobs instead of solving immediately
         self.jmag_visible = kwargs["jmag_visible"] # JMAG application visible if true
         self.scale_axial_length = kwargs["scale_axial_length"] # True: scale axial length to get the required rated torque
+        self.jmag_version = kwargs["jmag_version"] # JMAG application version

--- a/mach_eval/analyzers/electromagnetic/bspm/electrical_analysis/JMAG.py
+++ b/mach_eval/analyzers/electromagnetic/bspm/electrical_analysis/JMAG.py
@@ -1,6 +1,7 @@
 import win32com.client
 import os
 import logging
+import string
 
 EPS = 0.01  # mm
 
@@ -28,9 +29,13 @@ class JMAG(object):  # < ToolBase & DrawerBase & MakerExtrudeBase & MakerRevolve
 
         self.config = configuration
 
-    def open(self, expected_project_file_path):
+    def open(self, expected_project_file_path, version):
         if self.app is None:
-            app = win32com.client.Dispatch("designer.Application")
+            if version is None:
+                app = win32com.client.Dispatch("designer.Application.211")
+            else:
+                version = version.translate(str.maketrans('', '', string.punctuation))
+                app = win32com.client.Dispatch("designer.Application.%s" % version)
             if self.config.jmag_visible == True:
                 app.Show()
             else:

--- a/mach_eval/analyzers/electromagnetic/bspm/electrical_analysis/JMAG.py
+++ b/mach_eval/analyzers/electromagnetic/bspm/electrical_analysis/JMAG.py
@@ -29,13 +29,13 @@ class JMAG(object):  # < ToolBase & DrawerBase & MakerExtrudeBase & MakerRevolve
 
         self.config = configuration
 
-    def open(self, expected_project_file_path, version):
+    def open(self, expected_project_file_path, jmag_version=None):
         if self.app is None:
-            if version is None:
-                app = win32com.client.Dispatch("designer.Application.211")
+            if jmag_version is None:
+                app = win32com.client.Dispatch("designer.Application")
             else:
-                version = version.translate(str.maketrans('', '', string.punctuation))
-                app = win32com.client.Dispatch("designer.Application.%s" % version)
+                jmag_version = jmag_version.translate(str.maketrans('', '', string.punctuation))
+                app = win32com.client.Dispatch("designer.Application.%s" % jmag_version)
             if self.config.jmag_visible == True:
                 app.Show()
             else:

--- a/mach_eval/analyzers/electromagnetic/bspm/jmag_2d.py
+++ b/mach_eval/analyzers/electromagnetic/bspm/jmag_2d.py
@@ -53,7 +53,14 @@ class BSPM_EM_Analyzer:
         from .electrical_analysis.JMAG import JMAG
 
         toolJd = JMAG(self.config)
-        app, attempts = toolJd.open(expected_project_file, self.config.jmag_version)
+
+        JMAG_exist = os.path.exists("C:/Program Files/JMAG-Designer%s" % self.config.jmag_version)
+        if JMAG_exist is True:
+            app, attempts = toolJd.open(expected_project_file, self.config.jmag_version)
+        else:
+            print('WARNING: The JMAG version does not exist, defaulting to newest JMAG version available!')
+            app, attempts = toolJd.open(expected_project_file)
+
         if attempts > 1:
             self.project_name = self.project_name + "attempts_%d" % (attempts)
 

--- a/mach_eval/analyzers/electromagnetic/bspm/jmag_2d.py
+++ b/mach_eval/analyzers/electromagnetic/bspm/jmag_2d.py
@@ -53,7 +53,7 @@ class BSPM_EM_Analyzer:
         from .electrical_analysis.JMAG import JMAG
 
         toolJd = JMAG(self.config)
-        app, attempts = toolJd.open(expected_project_file)
+        app, attempts = toolJd.open(expected_project_file, self.config.jmag_version)
         if attempts > 1:
             self.project_name = self.project_name + "attempts_%d" % (attempts)
 

--- a/mach_eval/analyzers/electromagnetic/bspm/jmag_2d_config.py
+++ b/mach_eval/analyzers/electromagnetic/bspm/jmag_2d_config.py
@@ -27,3 +27,4 @@ class JMAG_2D_Config:
         self.num_cpus = kwargs["num_cpus"] # number of cpus or cores used. Only value if multiple_cpus = True
         self.jmag_scheduler = kwargs["jmag_scheduler"] # True if it is desired to schedule jobs instead of solving immediately
         self.jmag_visible = kwargs["jmag_visible"] # JMAG application visible if true
+        self.jmag_version = kwargs["jmag_version"] # JMAG application version


### PR DESCRIPTION
This PR addresses #339. 

To fix the aforementioned issue, the following now takes place to specify the JMAG version:
1. User specifies JMAG version as `21.1`, `22.0`, `23.0` for example
2. JMAG version is imported to each analyzer as part of the `config` variable with other JMAG parameters (mesh size, steps, etc.)
3. When JMAG opens, it considers the specified version and opens that version
    - if that version does not exist, it defaults to the most recent version and produces a `warning`
    - if no version is specified, it also defaults to the most recent version
4. JMAG runs the version as it did previously 

The following parts of the `eMach` codebase have been changed:
- BSPM example, configuration, and analyzer files had to be changed to include new calls for version specification
- SynR example(s) and analyzer(s) had to be changed to include new calls for version specification
- JMAG configuration file in `mach_cad` had to be adjusted to look for version called by analyzer(s)
- Tutorial example(s) had to be changed to include new calls for version specification
- Documentation files had to be changed to include the proper code so that they will run properly

closes #339