### PR TITLE
Fix Sphinx Build Warnings

### DIFF
--- a/docs/source/getting_started/pre_reqs.rst
+++ b/docs/source/getting_started/pre_reqs.rst
@@ -118,7 +118,7 @@ examples provided within the ``examples`` folder to confirm everything is workin
 
 
 More Information on Using Virtual Environments with Python (Approach 1)
-----------------------------------------------------
+------------------------------------------------------------------------
 
 This section has been added to help approach 1 users be more "Python savvy". This section gives an overview of Python virtual
 environments and provides necessary links to enable users to work with virtual environments using VS code.

--- a/docs/source/user_guide/mach_eval_overview.rst
+++ b/docs/source/user_guide/mach_eval_overview.rst
@@ -11,7 +11,7 @@ explained. These classes act an extension of the ``mach_opt`` module's ``Designe
 purpose of this extension, is to provide a stronger framework for the flow of information between multiple evaluation steps (i.e. 
 an interdependent multiphysics machine design). These classes are constructed specifically for the design and evaluation of 
 electric machine, however they can be utilized in the optimization of any complex design problem. An example optimization 
-demonstrating the use of the ``mach_eval`` module is provided :doc:`in this document</getting_started/tutorials/analytical_machine_des_tutorial/index>`.
+demonstrating the use of the ``mach_eval`` module is provided :doc:`in this document<../getting_started/tutorials/analytical_machine_des_tutorial/index>`.
 
 MachineDesigner
 ****************

--- a/docs/source/user_guide/mach_opt_overview.rst
+++ b/docs/source/user_guide/mach_opt_overview.rst
@@ -27,7 +27,7 @@ DesignSpace
 DataHandler
 	Saves the design, evaluation results, and objective values so that optimization can be paused and resumed.
 
-Additional details of each of these objects can be found in the code documentation. An example optimization of a rectangle using the ``mach_opt`` module can be found :doc:`here </getting_started/tutorials/rectangle_tutorial/index>`.
+Additional details of each of these objects can be found in the code documentation. An example optimization of a rectangle using the ``mach_opt`` module can be found :doc:`here <../getting_started/tutorials/rectangle_tutorial/index>`.
 
 Designer
 ****************


### PR DESCRIPTION
Closes #342

This pull request updates a few files to resolve build warnings I encountered when working in eMachPrivate and building those docs.

One was a title underline being too short (easy fix).

The other two were links that broke when copying the public docs up into eMachPrivate's `docs/source/public` directory. The fix was switching to relative paths instead of absolute.