### PR TITLE
Add option to enable or disable eddy current calculations in BSPM analyzer

### DIFF
--- a/mach_eval/analyzers/electromagnetic/bspm/jmag_2d.py
+++ b/mach_eval/analyzers/electromagnetic/bspm/jmag_2d.py
@@ -753,15 +753,21 @@ class BSPM_EM_Analyzer:
             "Shaft", self.machine_variant.shaft_mat["shaft_material"]
         )
         study.GetMaterial("Shaft").SetValue("Laminated", 0)
-        study.GetMaterial("Shaft").SetValue("EddyCurrentCalculation", 1)
-
+        if self.config.enable_eddy_current_calcs:
+            study.GetMaterial("Shaft").SetValue("EddyCurrentCalculation", 1)
+        else:
+            study.GetMaterial("Shaft").SetValue("EddyCurrentCalculation", 0)
+        
         study.SetMaterialByName("Coils", "Copper")
         study.GetMaterial("Coils").SetValue("UserConductivityType", 1)
 
         study.SetMaterialByName(
             "Magnet", "{}".format(self.machine_variant.magnet_mat["magnet_material"])
         )
-        study.GetMaterial("Magnet").SetValue("EddyCurrentCalculation", 1)
+        if self.config.enable_eddy_current_calcs:
+            study.GetMaterial("Magnet").SetValue("EddyCurrentCalculation", 1)
+        else:
+            study.GetMaterial("Magnet").SetValue("EddyCurrentCalculation", 0)
         study.GetMaterial("Magnet").SetValue(
             "Temperature", self.operating_point.ambient_temp + self.operating_point.rotor_temp_rise
         )  # TEMPERATURE (There is no 75 deg C option)

--- a/mach_eval/analyzers/electromagnetic/bspm/jmag_2d_config.py
+++ b/mach_eval/analyzers/electromagnetic/bspm/jmag_2d_config.py
@@ -28,3 +28,4 @@ class JMAG_2D_Config:
         self.jmag_scheduler = kwargs["jmag_scheduler"] # True if it is desired to schedule jobs instead of solving immediately
         self.jmag_visible = kwargs["jmag_visible"] # JMAG application visible if true
         self.jmag_version = kwargs["jmag_version"] # JMAG application version
+        self.enable_eddy_current_calcs = kwargs.get("enable_eddy_current_calcs", True)  # Enable eddy current calculations for the shaft and permanent magnets if True (default), disable if False


### PR DESCRIPTION
This PR adds option to enable or disable eddy current calculations in BSPM analyzer to close #346.

## Summary of changes
These changes are taking place in this PR:

- add a field `self.enable_eddy_current_calcs` in `jmag_2d_config.py` to take a value of either `True` or `False`, defaulting `True`, i.e., the eddy current calculations are enabled by default. By using `kwargs.get()`, the default value of `True` is returned unless this field is defined. Therefore, we do not need to add/edit the field in existing code (e.g., in [electromagnetic_step.py](https://github.com/Severson-Group/eMach/blob/v1.1.x/examples/mach_eval_examples/bspm_eval/electromagnetic_step.py)).
![image](https://github.com/user-attachments/assets/6bf2d511-8fcc-4ce9-bfca-ea9ffda9f409)

- edit `jmag_2d.py` so that 

1. when `enable_eddy_current_calcs` is `True`, it passes `1` to JMAG to enable the eddy current calculation or
2. when `enable_eddy_current_calcs` is `False`, it passes `0` to JMAG to disable the eddy current calculation

These are applied to both the shaft and PM.
![image](https://github.com/user-attachments/assets/55c55c79-4284-4bfa-90b5-477d1eb7f889)


## Some testing myself

1. Run [bspm_evaluator.py](https://github.com/Severson-Group/eMach/blob/feature/enable-eddy-currents/examples/mach_eval_examples/bspm_eval/bspm_evaluator.py) without any changes. When opening the JMAG file, eddy currents are enabled.
2. Add a new line `enable_eddy_current_calcs=True` within `JMAG_2D_Config()` in [electromagnetic_step.py](https://github.com/Severson-Group/eMach/blob/feature/enable-eddy-currents/examples/mach_eval_examples/bspm_eval/electromagnetic_step.py). Run [bspm_evaluator.py](https://github.com/Severson-Group/eMach/blob/feature/enable-eddy-currents/examples/mach_eval_examples/bspm_eval/bspm_evaluator.py) and when opening the JMAG file, eddy currents are enabled.
3. Add a new line `enable_eddy_current_calcs=False` within `JMAG_2D_Config()` in [electromagnetic_step.py](https://github.com/Severson-Group/eMach/blob/feature/enable-eddy-currents/examples/mach_eval_examples/bspm_eval/electromagnetic_step.py). Run [bspm_evaluator.py](https://github.com/Severson-Group/eMach/blob/feature/enable-eddy-currents/examples/mach_eval_examples/bspm_eval/bspm_evaluator.py) and when opening the JMAG file, eddy currents are disabled as expected.
