### PR TITLE
Add `move` function to move JMAG Parts using `mach_cad`

### DIFF
--- a/examples/mach_cad_examples/example_jmag_make.py
+++ b/examples/mach_cad_examples/example_jmag_make.py
@@ -49,14 +49,14 @@ comp1 = mo.Component(
     name="comp1",
     cross_sections=[stator1],
     material=mo.MaterialGeneric(name="10JNEX900"),
-    make_solid=mo.MakeExtrude(location=mo.Location3D(), dim_depth=mo.DimMillimeter(15)),
+    make_solid=mo.MakeExtrude(location=mo.Location3D(anchor_xyz=[mo.DimMillimeter(0), mo.DimMillimeter(0), mo.DimMillimeter(10)]), dim_depth=mo.DimMillimeter(15)),
 )
 
 comp2 = mo.Component(
     name="comp2",
     cross_sections=[stator2],
     material=mo.MaterialGeneric(name="10JNEX900"),
-    make_solid=mo.MakeExtrude(location=mo.Location3D(), dim_depth=mo.DimMillimeter(15)),
+    make_solid=mo.MakeExtrude(location=mo.Location3D(anchor_xyz=[mo.DimMillimeter(0), mo.DimMillimeter(0), mo.DimMillimeter(-10)]), dim_depth=mo.DimMillimeter(15)),
 )
 
 file = r"trial100.jproj"

--- a/mach_cad/model_obj/make_solid/make_extrude.py
+++ b/mach_cad/model_obj/make_solid/make_extrude.py
@@ -37,9 +37,7 @@ class MakeExtrude(MakeSolidBase):
         for i in range(len(cs_token)):
             token1.append(maker.prepare_section(cs_token[i]))
 
-        token2 = maker.extrude(name, material, self._dim_depth, token1)
-
-        maker.move(name, self.location)
+        token2 = maker.extrude(name, material, self._dim_depth, self.location, token1)
 
         token_make = TokenMake(cs_token, token1, token2)
         return token_make

--- a/mach_cad/model_obj/make_solid/make_extrude.py
+++ b/mach_cad/model_obj/make_solid/make_extrude.py
@@ -39,5 +39,7 @@ class MakeExtrude(MakeSolidBase):
 
         token2 = maker.extrude(name, material, self._dim_depth, token1)
 
+        maker.move(name, self.location)
+
         token_make = TokenMake(cs_token, token1, token2)
         return token_make

--- a/mach_cad/model_obj/make_solid/make_revolve.py
+++ b/mach_cad/model_obj/make_solid/make_revolve.py
@@ -66,8 +66,6 @@ class MakeRevolve(MakeSolidBase):
             name, material, self._dim_center, self._dim_axis, self._dim_angle, token1
         )
 
-        maker.move(name, self.location)
-
         token_make = TokenMake(cs_token, token1, token2)
 
         token_make = TokenMake(cs_token, token1, token2)

--- a/mach_cad/model_obj/make_solid/make_revolve.py
+++ b/mach_cad/model_obj/make_solid/make_revolve.py
@@ -63,9 +63,9 @@ class MakeRevolve(MakeSolidBase):
             token1.append(maker.prepare_section(cs_token[i]))
 
         token2 = maker.revolve(
-            name, material, self._dim_center, self._dim_axis, self._dim_angle, token1
+            name, material, self._dim_center, self._dim_axis, self._dim_angle, self.location, token1
         )
-        
+
         token_make = TokenMake(cs_token, token1, token2)
 
         token_make = TokenMake(cs_token, token1, token2)

--- a/mach_cad/model_obj/make_solid/make_revolve.py
+++ b/mach_cad/model_obj/make_solid/make_revolve.py
@@ -65,6 +65,9 @@ class MakeRevolve(MakeSolidBase):
         token2 = maker.revolve(
             name, material, self._dim_center, self._dim_axis, self._dim_angle, token1
         )
+
+        maker.move(name, self.location)
+
         token_make = TokenMake(cs_token, token1, token2)
 
         token_make = TokenMake(cs_token, token1, token2)

--- a/mach_cad/model_obj/make_solid/make_revolve.py
+++ b/mach_cad/model_obj/make_solid/make_revolve.py
@@ -67,6 +67,4 @@ class MakeRevolve(MakeSolidBase):
         )
 
         token_make = TokenMake(cs_token, token1, token2)
-
-        token_make = TokenMake(cs_token, token1, token2)
         return token_make

--- a/mach_cad/model_obj/make_solid/make_revolve.py
+++ b/mach_cad/model_obj/make_solid/make_revolve.py
@@ -65,7 +65,7 @@ class MakeRevolve(MakeSolidBase):
         token2 = maker.revolve(
             name, material, self._dim_center, self._dim_axis, self._dim_angle, token1
         )
-
+        
         token_make = TokenMake(cs_token, token1, token2)
 
         token_make = TokenMake(cs_token, token1, token2)

--- a/mach_cad/tools/femm/FEMM.py
+++ b/mach_cad/tools/femm/FEMM.py
@@ -294,7 +294,7 @@ class FEMMDesigner(
         """
         return cs_token
 
-    def extrude(self, name, material: str, depth: float, token=None) -> any:
+    def extrude(self, name, material: str, depth: float, location: "Location3D", token=None) -> any:
         """ Assign material to a component. 
         Axial length has to be specified using "probdef" method.
         """
@@ -306,7 +306,7 @@ class FEMMDesigner(
 
         return 1
 
-    def revolve(self, name, material: str, center, axis, angle: float,) -> any:
+    def revolve(self, name, material: str, center, axis, angle: float, location: "Location3D") -> any:
         """ Not implemented in FEMM. 
         Axisymmetric problem has to be specified using "probdef" method.
         """

--- a/mach_cad/tools/jmag/jmag.py
+++ b/mach_cad/tools/jmag/jmag.py
@@ -361,6 +361,58 @@ class JmagDesigner(
         self.study.SetMaterialByName(name, material.name)
         return extrude_part
 
+    def move(self, name: str, location: 'Location3D') -> any:
+        """Function to move the newly solid part to the final location
+
+        Args:
+            name: name of the newly extruded component.
+            location: the displacement from the part's origin to the global origin.
+
+        Returns:
+            Function will return the handle to move part to new location
+        """
+
+        move_x = eval(self.default_length)(location.anchor_xyz[0])
+        move_y = eval(self.default_length)(location.anchor_xyz[1])
+        move_z = eval(self.default_length)(location.anchor_xyz[2])
+
+        self.assembly.GetItem(name).ClosePart()
+        self.doc.GetSelection().Clear()
+        ref1 = self.assembly().GetItem(name)
+        self.doc.GetSelection().Add(ref1)
+        move_part = self.doc.GetAssemblyManager().CreateMovePartParameter()
+        move_part.SetProperty("MoveX", move_x)
+        move_part.SetProperty("MoveY", move_y)
+        move_part.SetProperty("MoveZ", move_z)
+        self.doc.GetAssemblyManager().Execute(move_part)
+
+        # depth = eval(self.default_length)(depth)
+
+        # self.part = self.create_part()
+        # ref1 = self.sketch
+
+        # extrude_part = self.part.CreateExtrudeSolid(ref1, depth)
+        # self.part.SetProperty("Name", name)
+        # self.part.SetProperty("Color", material.color)
+
+        # sketch_name = name + "_sketch"
+        # self.sketch.SetProperty("Name", sketch_name)
+
+        # self.part = None
+        # self.sketch = None
+        # self.doc.SaveModel(True)
+        # model_name = name + "_model"
+        # self.model = self.create_model(model_name)
+
+        # study_name = name + "_study"
+        # self.study = self.create_study(study_name, self.study_type, self.model)
+
+        # self.set_default_length_unit(self.default_length)
+        # self.set_default_angle_unit(self.default_angle)
+
+        # self.study.SetMaterialByName(name, material.name)
+        return move_part
+
     def revolve(self, name, material: str, center, axis, angle: float,) -> any:
         """ Revolves cross-section along an arc
 

--- a/mach_cad/tools/jmag/jmag.py
+++ b/mach_cad/tools/jmag/jmag.py
@@ -329,7 +329,7 @@ class JmagDesigner(
             name: name of the newly extruded component.
             depth: Depth of extrusion. Should be defined with eMach Dimensions.
             material : Material applied to the extruded component.
-            location: the displacement from the part's origin to the global origin.
+            location: the displacement from the global origin the part's origin.
 
         Returns:
             Function will return the handle to the new extruded part

--- a/mach_cad/tools/jmag/jmag.py
+++ b/mach_cad/tools/jmag/jmag.py
@@ -322,13 +322,14 @@ class JmagDesigner(
 
         return study
 
-    def extrude(self, name, material: str, depth: float, token=None) -> any:
+    def extrude(self, name, material: str, depth: float, location: "Location3D", token=None) -> any:
         """ Extrudes a cross-section to a 3D component
 
         Args:
             name: name of the newly extruded component.
             depth: Depth of extrusion. Should be defined with eMach Dimensions.
             material : Material applied to the extruded component.
+            location: the displacement from the part's origin to the global origin.
 
         Returns:
             Function will return the handle to the new extruded part
@@ -342,6 +343,19 @@ class JmagDesigner(
         extrude_part = self.part.CreateExtrudeSolid(ref1, depth)
         self.part.SetProperty("Name", name)
         self.part.SetProperty("Color", material.color)
+
+        self.assembly.GetItem(name).ClosePart()
+        self.doc.GetSelection().Clear()
+        ref2 = self.assembly.GetItem(name)
+        self.doc.GetSelection().Add(ref2)
+        move_part = self.doc.GetAssemblyManager().CreateMovePartParameter()
+        move_x = eval(self.default_length)(location.anchor_xyz[0])
+        move_y = eval(self.default_length)(location.anchor_xyz[1])
+        move_z = eval(self.default_length)(location.anchor_xyz[2])
+        move_part.SetProperty(u"MoveX", move_x)
+        move_part.SetProperty(u"MoveY", move_y)
+        move_part.SetProperty(u"MoveZ", move_z)
+        self.doc.GetAssemblyManager().Execute(move_part)
 
         sketch_name = name + "_sketch"
         self.sketch.SetProperty("Name", sketch_name)

--- a/mach_cad/tools/jmag/jmag.py
+++ b/mach_cad/tools/jmag/jmag.py
@@ -375,58 +375,6 @@ class JmagDesigner(
         self.study.SetMaterialByName(name, material.name)
         return extrude_part
 
-    def move(self, name: str, location: 'Location3D') -> any:
-        """Function to move the newly solid part to the final location
-
-        Args:
-            name: name of the newly extruded component.
-            location: the displacement from the part's origin to the global origin.
-
-        Returns:
-            Function will return the handle to move part to new location
-        """
-
-        move_x = eval(self.default_length)(location.anchor_xyz[0])
-        move_y = eval(self.default_length)(location.anchor_xyz[1])
-        move_z = eval(self.default_length)(location.anchor_xyz[2])
-
-        self.assembly.GetItem(name).ClosePart()
-        self.doc.GetSelection().Clear()
-        ref1 = self.assembly().GetItem(name)
-        self.doc.GetSelection().Add(ref1)
-        move_part = self.doc.GetAssemblyManager().CreateMovePartParameter()
-        move_part.SetProperty("MoveX", move_x)
-        move_part.SetProperty("MoveY", move_y)
-        move_part.SetProperty("MoveZ", move_z)
-        self.doc.GetAssemblyManager().Execute(move_part)
-
-        # depth = eval(self.default_length)(depth)
-
-        # self.part = self.create_part()
-        # ref1 = self.sketch
-
-        # extrude_part = self.part.CreateExtrudeSolid(ref1, depth)
-        # self.part.SetProperty("Name", name)
-        # self.part.SetProperty("Color", material.color)
-
-        # sketch_name = name + "_sketch"
-        # self.sketch.SetProperty("Name", sketch_name)
-
-        # self.part = None
-        # self.sketch = None
-        # self.doc.SaveModel(True)
-        # model_name = name + "_model"
-        # self.model = self.create_model(model_name)
-
-        # study_name = name + "_study"
-        # self.study = self.create_study(study_name, self.study_type, self.model)
-
-        # self.set_default_length_unit(self.default_length)
-        # self.set_default_angle_unit(self.default_angle)
-
-        # self.study.SetMaterialByName(name, material.name)
-        return move_part
-
     def revolve(self, name, material: str, center, axis, angle: float,) -> any:
         """ Revolves cross-section along an arc
 

--- a/mach_cad/tools/jmag/jmag.py
+++ b/mach_cad/tools/jmag/jmag.py
@@ -405,6 +405,20 @@ class JmagDesigner(
         self.part.GetItem("Revolve").setProperty("AxisVecZ", 0)
         self.part.GetItem("Revolve").setProperty("Angle", angle)
         self.part.SetProperty("Name", name)
+
+        self.assembly.GetItem(name).ClosePart()
+        self.doc.GetSelection().Clear()
+        ref2 = self.assembly.GetItem(name)
+        self.doc.GetSelection().Add(ref2)
+        move_part = self.doc.GetAssemblyManager().CreateMovePartParameter()
+        move_x = eval(self.default_length)(location.anchor_xyz[0])
+        move_y = eval(self.default_length)(location.anchor_xyz[1])
+        move_z = eval(self.default_length)(location.anchor_xyz[2])
+        move_part.SetProperty(u"MoveX", move_x)
+        move_part.SetProperty(u"MoveY", move_y)
+        move_part.SetProperty(u"MoveZ", move_z)
+        self.doc.GetAssemblyManager().Execute(move_part)
+
         sketch_name = name + "_sketch"
         self.sketch.SetProperty("Name", sketch_name)
 

--- a/mach_cad/tools/jmag/jmag.py
+++ b/mach_cad/tools/jmag/jmag.py
@@ -375,7 +375,7 @@ class JmagDesigner(
         self.study.SetMaterialByName(name, material.name)
         return extrude_part
 
-    def revolve(self, name, material: str, center, axis, angle: float,) -> any:
+    def revolve(self, name, material: str, center, axis, angle: float, location: "Location3D") -> any:
         """ Revolves cross-section along an arc
 
         Args:
@@ -384,6 +384,7 @@ class JmagDesigner(
             center: center point of rotation. Should be of type Location2d defined with eMach Dimensions.
             axis: Axis of rotation. Should be of type Location2d defined with eMach Dimensions.
                   Specifying negative value reverses the axis of rotation.
+            location: the displacement from the part's origin to the global origin.
 
         Returns:
              This function will return the handle of the newly revolved part.

--- a/mach_cad/tools/magnet/magnet.py
+++ b/mach_cad/tools/magnet/magnet.py
@@ -136,13 +136,14 @@ class MagNet(abc.ToolBase, abc.DrawerBase, abc.MakerExtrudeBase, abc.MakerRevolv
         )
         return 1
 
-    def extrude(self, name, material, depth, token=None):
+    def extrude(self, name, material, depth, location, token=None):
         """Extrude, assign a material and name a selected section in MAGNET.
 
         Args:
             name: Name assigned to extruded component.
             material: Name of material from tool library whose properties are assigned to component.
             depth: Length of extrusion. Should be of type DimLinear.
+            location: Not used currently.
             token: Not used currently.
 
         Returns:
@@ -159,7 +160,7 @@ class MagNet(abc.ToolBase, abc.DrawerBase, abc.MakerExtrudeBase, abc.MakerRevolv
 
         return ret
 
-    def revolve(self, name, material, center, axis, angle, token=None):
+    def revolve(self, name, material, center, axis, angle, location, token=None):
         """Revolve, assign a material and name a selected section in MAGNET.
 
         Args:
@@ -170,6 +171,7 @@ class MagNet(abc.ToolBase, abc.DrawerBase, abc.MakerExtrudeBase, abc.MakerRevolv
             axis: Axis about which the cross-section is revolved. Should be of type Location2D defined with eMach
                 Dimensions.
             angle: Angle of revolution. Should be of type DimAngular.
+            location: Not used currently.
             token: Not used currently.
 
         Returns:

--- a/mach_cad/tools/tool_abc/toolabc.py
+++ b/mach_cad/tools/tool_abc/toolabc.py
@@ -66,11 +66,6 @@ class MakerBase(ABC):
         """Function to select a cross-section"""
         pass
 
-    @abstractmethod
-    def move(self, name: str, location: 'Location3D') -> any:
-        """Function to move the newly solid part to the final location"""
-        pass
-
 
 class MakerExtrudeBase(MakerBase):
     """Abstract base class defining method(s) to extrude cross-sections in eMach tools"""

--- a/mach_cad/tools/tool_abc/toolabc.py
+++ b/mach_cad/tools/tool_abc/toolabc.py
@@ -70,11 +70,11 @@ class MakerBase(ABC):
 class MakerExtrudeBase(MakerBase):
     """Abstract base class defining method(s) to extrude cross-sections in eMach tools"""
     @abstractmethod
-    def extrude(self, name: str, material: str, depth: 'DimLinear') -> any:
+    def extrude(self, name: str, material: str, depth: 'DimLinear', location: 'Location3D') -> any:
         pass
 
 
 class MakerRevolveBase(MakerBase):
     """Abstract base class defining method(s) to revolve cross-sections in eMach tools"""
     @abstractmethod
-    def revolve(self, name: str, material: str, center: 'Location2D', axis: 'Location2D', angle: float) -> any: pass
+    def revolve(self, name: str, material: str, center: 'Location2D', axis: 'Location2D', angle: float, location: 'Location3D') -> any: pass

--- a/mach_cad/tools/tool_abc/toolabc.py
+++ b/mach_cad/tools/tool_abc/toolabc.py
@@ -66,6 +66,11 @@ class MakerBase(ABC):
         """Function to select a cross-section"""
         pass
 
+    @abstractmethod
+    def move(self, name: str, location: 'Location3D') -> any:
+        """Function to move the newly solid part to the final location"""
+        pass
+
 
 class MakerExtrudeBase(MakerBase):
     """Abstract base class defining method(s) to extrude cross-sections in eMach tools"""


### PR DESCRIPTION
This PR adds `move` function to `mach_cad` to close #354 and to close #355.


These changes are taking place in this PR:
- Add `location` argument for both `extrude` and `revolve` method to move Part
    - [FEMM](https://github.com/Severson-Group/eMach/pull/356/files#diff-b8dbaa77b5ad17e018fa294a96d8d88b9ca3239b203ecb05f78a50887cb43055)
    - [JMAG](https://github.com/Severson-Group/eMach/pull/356/files#diff-24f021aef52f7a2ba06011cb3471cf1cad833bf2b51ccbf5a3560413d8f8d09a)
    - [MagNet](https://github.com/Severson-Group/eMach/pull/356/files#diff-0de3c4cac75a3683ed0098095dd4769ac2d33d7664d4286c7f323fa7c8677a42)
- Add `location` argument to extrude function in [`MakeExtrude`](https://github.com/Severson-Group/eMach/pull/356/files#diff-53feb66edb84a5f240a3485275d77f790d5860d5f508c0e2e4432a4dbc388086) Class and [`MakeRevolve`](https://github.com/Severson-Group/eMach/pull/356/files#diff-4df980966c2a0d5d930b0c515a7f2da85d89627cef0a790bf427d8b4a2b38ee1) Class
- Remove duplicated code in [`make_revolve.py`](https://github.com/Severson-Group/eMach/pull/356/files#diff-4df980966c2a0d5d930b0c515a7f2da85d89627cef0a790bf427d8b4a2b38ee1)
