### PR TITLE
Update environment.yml file to include pyfemm package

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -14,8 +14,9 @@ dependencies:
   - sphinx_rtd_theme
   
   # to use pip packages, follow syntax below
-  # - pip
-  # - pip:
+  - pip
+  - pip:
+    - pyfemm==0.1.1
   #    - sphinx-rtd-theme
   
 


### PR DESCRIPTION
This PR updates `environment.yml` file to include pyfemm to close #358.

I modified the following lines in `environment.yml` so that pyfemm package can be installed using [this approach](https://emach.readthedocs.io/en/latest/getting_started/pre_reqs.html#approach-1-create-a-new-emach-conda-environment) documented in eMach article:

https://github.com/Severson-Group/eMach/blob/da443335c4b844f1689f81fc5e036ac9c16718ec/environment.yml#L17-L19

## Testing

1. Before installing `pyfemm` package, if I run [example_induction_motor_femm.py](https://github.com/Severson-Group/eMach/blob/v1.2.x/examples/mach_cad_examples/example_induction_motor_femm.py) that requires FEMM module, I got the following errors (since FEMM module was not available):

![Screenshot 2025-04-07 213215](https://github.com/user-attachments/assets/e78c402a-14c3-4558-a3ea-a704b2a3d139)

2. Remove the all eMach virtual environment.
3.  Execute this command `conda env create -f environment.yml` to re-install eMach environments. This reinstalled eMach environment is using the updated `environment.yml` file, which now includes `pyfemm==0.1.1`. 

4. After the environments were successfully created, I reran [example_induction_motor_femm.py](https://github.com/Severson-Group/eMach/blob/v1.2.x/examples/mach_cad_examples/example_induction_motor_femm.py) and there is no errors.
5. I implemented the above steps on both my laptop and the server `severson02` -- everything works as expected.

