### PR TITLE
Update pyfemm to 0.1.3 in `environment.yml` 

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -16,7 +16,7 @@ dependencies:
   # to use pip packages, follow syntax below
   - pip
   - pip:
-    - pyfemm==0.1.1
+    - pyfemm==0.1.3
   #    - sphinx-rtd-theme
   
 


### PR DESCRIPTION
This PR updates pyfemm to 0.1.3 in `environment.yml` file to partially address [#358](https://github.com/Severson-Group/eMachPrivate/issues/30). This is required to make this package work in both Windows and wsl (see [this comment](https://github.com/Severson-Group/eMachPrivate/issues/30#issuecomment-2787359481)).

I modified the following lines in `environment.yml` so that pyfemm package can be updated to 0.1.3:

https://github.com/Severson-Group/eMach/blob/8687509e9460698e09f4a5fa391b74bf36780c39/environment.yml#L17-L19

## Testing

1. Remove the all eMach virtual environment.
2.  Execute this command `conda env create -f environment.yml` to re-install eMach environments. This reinstalled eMach environment is using the updated `environment.yml` file, which now includes `pyfemm==0.1.3`. 

<img width="320" alt="image" src="https://github.com/user-attachments/assets/bb1a8694-d8ce-4238-8291-0d3d5546ad50" />


3. After the environments were successfully created, I reran [example_induction_motor_femm.py](https://github.com/Severson-Group/eMach/blob/v1.2.x/examples/mach_cad_examples/example_induction_motor_femm.py) and there is no errors.
4. I implemented the above steps on both my laptop and the server `severson02` -- everything works as expected.

